### PR TITLE
fix(schema): refresh strict output schema

### DIFF
--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -7,6 +7,7 @@ export interface AgentOutput {
 
 export const AGENT_OUTPUT_SCHEMA = {
   type: "object",
+  additionalProperties: false,
   properties: {
     success: { type: "boolean" },
     summary: { type: "string" },

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -95,6 +95,7 @@ describe("setupRun", () => {
     expect(schemaCall).toBeDefined();
     const schema = JSON.parse(schemaCall![1] as string);
     expect(schema.type).toBe("object");
+    expect(schema.additionalProperties).toBe(false);
     expect(schema.required).toContain("success");
     expect(schema.required).toContain("summary");
     expect(schema.required).toContain("key_changes_made");
@@ -145,6 +146,26 @@ describe("setupRun", () => {
 describe("resumeRun", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("refreshes output-schema.json to the current JSON schema", () => {
+    mockExistsSync.mockImplementation(
+      (path) => path === "/project/.gnhf/runs/run-abc",
+    );
+
+    resumeRun("run-abc", "/project");
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/project/.gnhf/runs/run-abc/output-schema.json",
+      expect.any(String),
+      "utf-8",
+    );
+    const schemaCall = mockWriteFileSync.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
+    );
+    const schema = JSON.parse(schemaCall![1] as string);
+    expect(schema.additionalProperties).toBe(false);
   });
 
   it("reads the stored base commit when present", () => {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -21,6 +21,14 @@ export interface RunInfo {
   baseCommitPath: string;
 }
 
+function writeSchemaFile(schemaPath: string): void {
+  writeFileSync(
+    schemaPath,
+    JSON.stringify(AGENT_OUTPUT_SCHEMA, null, 2),
+    "utf-8",
+  );
+}
+
 function ensureRunMetadataIgnored(cwd: string): void {
   const excludePath = execFileSync(
     "git",
@@ -67,11 +75,7 @@ export function setupRun(
   );
 
   const schemaPath = join(runDir, "output-schema.json");
-  writeFileSync(
-    schemaPath,
-    JSON.stringify(AGENT_OUTPUT_SCHEMA, null, 2),
-    "utf-8",
-  );
+  writeSchemaFile(schemaPath);
 
   const baseCommitPath = join(runDir, "base-commit");
   const hasStoredBaseCommit = existsSync(baseCommitPath);
@@ -102,6 +106,7 @@ export function resumeRun(runId: string, cwd: string): RunInfo {
   const promptPath = join(runDir, "prompt.md");
   const notesPath = join(runDir, "notes.md");
   const schemaPath = join(runDir, "output-schema.json");
+  writeSchemaFile(schemaPath);
   const baseCommitPath = join(runDir, "base-commit");
   const baseCommit = existsSync(baseCommitPath)
     ? readFileSync(baseCommitPath, "utf-8").trim()


### PR DESCRIPTION
## Summary
This change tightens the agent output contract and keeps persisted run schemas up to date. It makes the shared JSON schema reject unexpected fields and rewrites the per-run `output-schema.json` whenever a run is resumed, so file-based agents do not keep using an older schema.

**Risk Assessment:** 🟢 Low — Small, well-covered schema enforcement change with no negative test or review signals.

## Architecture
```mermaid
flowchart TD
  subgraph schema_def["Schema Definition"]
    direction TB
    agent_schema["AGENT_OUTPUT_SCHEMA (updated)"]
    run_setup["setupRun (updated)"]
    run_resume["resumeRun (updated)"]
    schema_file["Run Schema File (updated)"]

    agent_schema -->|"serialized by"| run_setup
    agent_schema -->|"serialized by"| run_resume
    run_setup -->|"writes for new runs"| schema_file
    run_resume -->|"refreshes on resume"| schema_file
  end

  subgraph agent_integration["Agent Integration"]
    direction TB
    claude_agent["ClaudeAgent (unchanged)"]
    opencode_agent["OpenCodeAgent (unchanged)"]
    codex_agent["CodexAgent (unchanged)"]
    rovodev_agent["RovoDevAgent (unchanged)"]

    agent_schema -->|"passed as inline schema"| claude_agent
    agent_schema -->|"embedded in prompt format"| opencode_agent
    schema_file -->|"used via --output-schema"| codex_agent
    schema_file -->|"read for inline system prompt"| rovodev_agent
  end
```

## Key changes made
- Added `additionalProperties: false` to `AGENT_OUTPUT_SCHEMA`, requiring agent output to match only the expected fields.
- Extracted schema writing into `writeSchemaFile()` and reused it from both `setupRun()` and `resumeRun()`.
- Expanded `run` tests to verify strict schema generation during setup and schema refresh during resume.

## How was this tested
- Validated the schema-update change by reviewing the affected files and running the full Vitest suite; all tests passed.
- `npm test` (`vitest run`): 21 test files, 191 tests passed.
- Prettier and ESLint checks passed with no fixes required.
