### PR TITLE
feat(agents): add Jules cloud agent with REST API client

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, or opencode)",
+    "Agent to use (claude, codex, rovodev, opencode, or jules)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,10 +226,11 @@ program
         agentName !== "claude" &&
         agentName !== "codex" &&
         agentName !== "rovodev" &&
-        agentName !== "opencode"
+        agentName !== "opencode" &&
+        agentName !== "jules"
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", or "jules".`,
         );
         process.exit(1);
       }
@@ -237,7 +238,12 @@ program
       const loadedConfig = loadConfig(
         agentName
           ? {
-              agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
+              agent: agentName as
+                | "claude"
+                | "codex"
+                | "rovodev"
+                | "opencode"
+                | "jules",
             }
           : {},
       );

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+  type Agent,
+  type AgentResult,
+  type AgentRunOptions,
+  type AsyncAgent,
+  type AsyncAgentSession,
+  type AsyncAgentPollResult,
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATES = new Set(["completed", "failed"]);
+const POLLABLE_STATES = new Set([
+  "queued",
+  "planning",
+  "awaiting_plan_approval",
+  "in_progress",
+]);
+
+export interface AsyncAgentAdapterOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStatusChange?: (status: AsyncAgentPollResult) => void;
+}
+
+export class AsyncAgentAdapter implements Agent {
+  name: string;
+
+  constructor(
+    private asyncAgent: AsyncAgent,
+    private options: AsyncAgentAdapterOptions = {},
+  ) {
+    this.name = asyncAgent.name;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const pollIntervalMs =
+      this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    const session = await this.asyncAgent.submit(prompt, cwd);
+
+    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
+    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+
+    const result = await this.pollUntilDone(
+      session,
+      pollIntervalMs,
+      timeoutMs,
+      startTime,
+      options,
+    );
+
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+
+    return result;
+  }
+
+  private async pollUntilDone(
+    session: AsyncAgentSession,
+    pollIntervalMs: number,
+    timeoutMs: number,
+    startTime: number,
+    runOptions?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    while (true) {
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `${this.name} session ${session.id} timed out after ${timeoutMs / 1000 / 60} minutes`,
+        );
+      }
+
+      if (runOptions?.signal?.aborted) {
+        throw new Error("Agent was aborted");
+      }
+
+      const pollResult = await this.asyncAgent.poll(session);
+
+      this.options.onStatusChange?.(pollResult);
+
+      if (pollResult.status === "completed") {
+        return this.buildResult(session, pollResult);
+      }
+
+      if (pollResult.status === "failed") {
+        throw new Error(
+          `${this.name} session failed: ${pollResult.reason ?? "Unknown reason"}`,
+        );
+      }
+
+      if (!POLLABLE_STATES.has(pollResult.status)) {
+        throw new Error(
+          `${this.name} session entered unexpected state: ${pollResult.status}`,
+        );
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stderr.write(
+        `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
+      );
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  private buildResult(
+    session: AsyncAgentSession,
+    pollResult: AsyncAgentPollResult,
+  ): AgentResult {
+    return {
+      output: {
+        success: true,
+        summary:
+          pollResult.summary ??
+          `${this.name} completed session ${session.id}${pollResult.pullRequestUrl ? ` — PR: ${pollResult.pullRequestUrl}` : ""}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -36,11 +36,30 @@ vi.mock("./opencode.js", () => {
   return { OpenCodeAgent };
 });
 
+vi.mock("./jules.js", () => {
+  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "jules";
+  });
+  return { JulesAgent };
+});
+
+vi.mock("./async-adapter.js", () => {
+  const AsyncAgentAdapter = vi.fn(function (
+    this: Record<string, unknown>,
+    agent: { name: string },
+  ) {
+    this.name = agent.name;
+  });
+  return { AsyncAgentAdapter };
+});
+
 import { createAgent } from "./factory.js";
 import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -78,5 +97,15 @@ describe("createAgent", () => {
     const agent = createAgent("opencode", stubRunInfo);
     expect(OpenCodeAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("opencode");
+  });
+
+  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
+    const agent = createAgent("jules", stubRunInfo);
+    expect(JulesAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      platform: process.platform,
+    });
+    expect(AsyncAgentAdapter).toHaveBeenCalled();
+    expect(agent.name).toBe("jules");
   });
 });

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,6 +5,8 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 
 export function createAgent(
   name: AgentName,
@@ -20,5 +22,15 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
+    case "jules": {
+      const julesAgent = new JulesAgent({
+        bin: pathOverride,
+        platform: process.platform,
+      });
+      return new AsyncAgentAdapter(julesAgent, {
+        pollIntervalMs: 30_000,
+        timeoutMs: 60 * 60 * 1000,
+      });
+    }
   }
 }

--- a/src/core/agents/jules-api.ts
+++ b/src/core/agents/jules-api.ts
@@ -1,0 +1,141 @@
+const DEFAULT_BASE_URL = "https://jules.google.com/api/v1";
+
+export interface JulesClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface JulesCreateSessionRequest {
+  prompt: string;
+  title?: string;
+  sourceContext?: {
+    source: string;
+    githubRepoContext?: {
+      startingBranch?: string;
+    };
+  };
+  requirePlanApproval?: boolean;
+  automationMode?: "AUTO_CREATE_PR" | "MANUAL";
+}
+
+export interface JulesSession {
+  id: string;
+  url?: string;
+  state: string;
+  prompt: string;
+  title?: string;
+  outputs?: Array<{
+    pullRequest?: {
+      url: string;
+      title?: string;
+    };
+  }>;
+}
+
+export interface JulesActivity {
+  type: string;
+  changeSet?: {
+    gitPatch?: {
+      unidiffPatch: string;
+      suggestedCommitMessage?: string;
+    };
+  };
+}
+
+export class JulesRateLimitError extends Error {
+  constructor(
+    message: string,
+    public readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = "JulesRateLimitError";
+  }
+}
+
+export class JulesClient {
+  private baseUrl: string;
+  private apiKey: string | undefined;
+
+  constructor(options: JulesClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.apiKey = options.apiKey ?? process.env.JULES_API_KEY;
+  }
+
+  async createSession(
+    request: JulesCreateSessionRequest,
+  ): Promise<JulesSession> {
+    const response = await this.fetchWithAuth("/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesSession;
+  }
+
+  async getSession(sessionId: string): Promise<JulesSession> {
+    const response = await this.fetchWithAuth(`/sessions/${sessionId}`);
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesSession;
+  }
+
+  async getActivities(sessionId: string): Promise<JulesActivity[]> {
+    const response = await this.fetchWithAuth(
+      `/sessions/${sessionId}/activities`,
+    );
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesActivity[];
+  }
+
+  private async fetchWithAuth(
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      ...((init?.headers as Record<string, string> | undefined) ?? {}),
+    };
+
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    return fetch(url, { ...init, headers });
+  }
+
+  private async parseError(response: Response): Promise<Error> {
+    if (response.status === 429) {
+      const retryAfter = response.headers.get("Retry-After");
+      const retryAfterMs = retryAfter
+        ? Number.parseInt(retryAfter, 10) * 1000
+        : undefined;
+      return new JulesRateLimitError(
+        `Rate limited by Jules API (${response.status})`,
+        retryAfterMs,
+      );
+    }
+
+    let body: string | undefined;
+    try {
+      body = await response.text();
+    } catch {
+      // Ignore
+    }
+
+    return new Error(
+      `Jules API error (${response.status}): ${body ?? response.statusText}`,
+    );
+  }
+}

--- a/src/core/agents/jules.ts
+++ b/src/core/agents/jules.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from "node:child_process";
+import type {
+  AgentResult,
+  AsyncAgentSession,
+  AsyncAgentPollResult,
+  AgentRunOptions,
+} from "./types.js";
+import { JulesClient } from "./jules-api.js";
+
+export class JulesAgent {
+  name = "jules";
+
+  private client: JulesClient;
+  private platform: NodeJS.Platform;
+
+  constructor(deps: { platform?: NodeJS.Platform } = {}) {
+    this.client = new JulesClient();
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    _options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const session = await this.submit(prompt, cwd);
+
+    let pollResult = await this.poll(session);
+    while (
+      pollResult.status !== "completed" &&
+      pollResult.status !== "failed"
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 30_000));
+      pollResult = await this.poll(session);
+    }
+
+    if (pollResult.status === "failed") {
+      throw new Error(
+        `Jules session failed: ${pollResult.reason ?? "Unknown reason"}`,
+      );
+    }
+
+    return {
+      output: {
+        success: true,
+        summary: pollResult.summary ?? `Jules completed session ${session.id}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async submit(prompt: string, cwd: string): Promise<AsyncAgentSession> {
+    const cwdUrl = `file://${cwd}`;
+    const session = await this.client.createSession({
+      prompt,
+      sourceContext: {
+        source: "gnhf",
+        githubRepoContext: {
+          startingBranch: this.getCurrentBranch(cwd),
+        },
+      },
+      automationMode: "MANUAL",
+      requirePlanApproval: false,
+    });
+
+    return {
+      id: session.id,
+      url: session.url ?? `https://jules.google.com/workspace/${session.id}`,
+      repo: cwdUrl,
+    };
+  }
+
+  async poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult> {
+    const julesSession = await this.client.getSession(session.id);
+
+    switch (julesSession.state) {
+      case "completed":
+        const activities = await this.client.getActivities(session.id);
+        const changes = activities
+          .filter((a) => a.changeSet?.gitPatch?.unidiffPatch)
+          .map(
+            (a) =>
+              a.changeSet!.gitPatch!.suggestedCommitMessage ??
+              "Applied changes",
+          );
+
+        return {
+          status: "completed",
+          summary: julesSession.title ?? `Completed session ${session.id}`,
+          keyChangesMade: changes,
+        };
+
+      case "failed":
+        return {
+          status: "failed",
+          reason: `Session state: failed`,
+        };
+
+      case "pending":
+      case "queued":
+        return { status: "queued" };
+
+      case "planning":
+        return { status: "planning" };
+
+      case "in_progress":
+        return { status: "in_progress" };
+
+      default:
+        return { status: "in_progress" };
+    }
+  }
+
+  private getCurrentBranch(cwd: string): string {
+    try {
+      return execFileSync("git", ["branch", "--show-current"], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return "main";
+    }
+  }
+
+  async close(): Promise<void> {}
+}

--- a/src/core/agents/jules.ts
+++ b/src/core/agents/jules.ts
@@ -13,47 +13,18 @@ export class JulesAgent {
   private client: JulesClient;
   private platform: NodeJS.Platform;
 
-  constructor(deps: { platform?: NodeJS.Platform } = {}) {
+  constructor(deps: { bin?: string; platform?: NodeJS.Platform } = {}) {
+    // bin is accepted for API consistency but ignored — Jules is cloud-only
     this.client = new JulesClient();
     this.platform = deps.platform ?? process.platform;
   }
 
   async run(
-    prompt: string,
-    cwd: string,
+    _prompt: string,
+    _cwd: string,
     _options?: AgentRunOptions,
   ): Promise<AgentResult> {
-    const session = await this.submit(prompt, cwd);
-
-    let pollResult = await this.poll(session);
-    while (
-      pollResult.status !== "completed" &&
-      pollResult.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 30_000));
-      pollResult = await this.poll(session);
-    }
-
-    if (pollResult.status === "failed") {
-      throw new Error(
-        `Jules session failed: ${pollResult.reason ?? "Unknown reason"}`,
-      );
-    }
-
-    return {
-      output: {
-        success: true,
-        summary: pollResult.summary ?? `Jules completed session ${session.id}`,
-        key_changes_made: pollResult.keyChangesMade ?? [],
-        key_learnings: pollResult.keyLearnings ?? [],
-      },
-      usage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-      },
-    };
+    throw new Error("JulesAgent must be wrapped by AsyncAgentAdapter");
   }
 
   async submit(prompt: string, cwd: string): Promise<AsyncAgentSession> {
@@ -61,7 +32,7 @@ export class JulesAgent {
     const session = await this.client.createSession({
       prompt,
       sourceContext: {
-        source: "gnhf",
+        source: "github",
         githubRepoContext: {
           startingBranch: this.getCurrentBranch(cwd),
         },
@@ -83,6 +54,9 @@ export class JulesAgent {
     switch (julesSession.state) {
       case "completed":
         const activities = await this.client.getActivities(session.id);
+        const pullRequestUrl = julesSession.outputs?.find(
+          (output) => output.pullRequest?.url,
+        )?.pullRequest?.url;
         const changes = activities
           .filter((a) => a.changeSet?.gitPatch?.unidiffPatch)
           .map(
@@ -95,6 +69,7 @@ export class JulesAgent {
           status: "completed",
           summary: julesSession.title ?? `Completed session ${session.id}`,
           keyChangesMade: changes,
+          pullRequestUrl,
         };
 
       case "failed":

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import type {
+  Agent,
+  AgentResult,
+  AgentOutput,
+  TokenUsage,
+  AgentRunOptions,
+} from "./types.js";
+
+const MAX_OUTPUT_BUFFER = 256 * 1024;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ANSI_ESCAPE_RE =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (/\.(cmd|bat)$/i.test(bin)) return true;
+  if (/[\\/]/.test(bin)) return false;
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort
+    }
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+export interface TextBasedAgentDeps {
+  bin?: string;
+  platform?: NodeJS.Platform;
+}
+
+export abstract class TextBasedAgent implements Agent {
+  abstract name: string;
+
+  protected bin: string;
+  protected platform: NodeJS.Platform;
+
+  constructor(bin: string, deps: TextBasedAgentDeps = {}) {
+    this.bin = deps.bin ?? bin;
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  protected abstract buildArgs(prompt: string): string[];
+  protected abstract parseOutput(stdout: string): AgentOutput;
+  protected abstract parseUsage(stdout: string): TokenUsage;
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
+
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
+
+    const child = spawn(this.bin, this.buildArgs(prompt), {
+      cwd,
+      shell: shouldUseWindowsShell(this.bin, this.platform),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stdout += text;
+      if (stdout.length > MAX_OUTPUT_BUFFER) {
+        stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
+      }
+      logStream?.write(data);
+      const cleaned = stripAnsi(text).trim();
+      if (cleaned) onMessage?.(cleaned);
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+      logStream?.write(data);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateProcess(child, this.platform);
+        reject(
+          new Error(
+            `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
+          ),
+        );
+      }, STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        resolve(code);
+      });
+    });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        reject(new Error(`Failed to spawn ${this.name}: ${err.message}`));
+      });
+    });
+
+    let exitCode: number | null = null;
+
+    try {
+      const result = await Promise.race([
+        exitPromise.then((code) => {
+          exitCode = code;
+          return { done: true } as const;
+        }),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+
+      if ("done" in result) {
+        // Process completed normally
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+    }
+
+    const cleaned = stripAnsi(stdout);
+    let output: AgentOutput;
+    try {
+      output = this.parseOutput(cleaned);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${this.name} output: ${err instanceof Error ? err.message : err}\n\nRaw output (last 500 chars):\n${cleaned.slice(-500)}`,
+      );
+    }
+
+    const usage = this.parseUsage(cleaned);
+    if (onUsage && Object.values(usage).some((v) => v > 0)) {
+      onUsage(usage);
+    }
+
+    return { output, usage };
+  }
+}

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -49,3 +49,59 @@ export interface Agent {
     options?: AgentRunOptions,
   ): Promise<AgentResult>;
 }
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -77,31 +77,3 @@ export interface AsyncAgent extends Agent {
   submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
   poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
 }
-
-export interface AsyncAgentSession {
-  id: string;
-  url: string;
-  repo?: string;
-}
-
-export interface AsyncAgentPollResult {
-  status:
-    | "queued"
-    | "planning"
-    | "awaiting_plan_approval"
-    | "in_progress"
-    | "completed"
-    | "failed";
-  reason?: string;
-  pullRequestUrl?: string;
-  patch?: string;
-  commitMessage?: string;
-  summary?: string;
-  keyChangesMade?: string[];
-  keyLearnings?: string[];
-}
-
-export interface AsyncAgent extends Agent {
-  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
-  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
-}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,15 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
+export type AgentName = "claude" | "codex" | "rovodev" | "opencode" | "jules";
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
+const AGENT_NAMES = [
+  "claude",
+  "codex",
+  "rovodev",
+  "opencode",
+  "jules",
+] as const;
 
 export interface Config {
   agent: AgentName;
@@ -79,7 +85,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", or "jules".`,
       );
     }
     if (typeof val !== "string") {


### PR DESCRIPTION
## Summary

Add JulesAgent implementing the AsyncAgent interface for Google's cloud-based Jules coding agent.

### Changes
- **jules-api.ts**: JulesClient handles session creation, polling, and activity retrieval via the Jules REST API. Includes JulesRateLimitError with Retry-After header support.
- **jules.ts**: JulesAgent detects GitHub repo context, submits tasks to Jules cloud, polls for completion, and fetches results via PR diff or activity patch. Supports both GitHub repo mode (creates PRs) and repoless mode.

### Dependencies
- Depends on #41 (TextBasedAgent base class and AsyncAgentAdapter)