### PR TITLE
feat(agents): add Gemini, Copilot, and Junie CLI agents

### DIFF
--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+  type Agent,
+  type AgentResult,
+  type AgentRunOptions,
+  type AsyncAgent,
+  type AsyncAgentSession,
+  type AsyncAgentPollResult,
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATES = new Set(["completed", "failed"]);
+const POLLABLE_STATES = new Set([
+  "queued",
+  "planning",
+  "awaiting_plan_approval",
+  "in_progress",
+]);
+
+export interface AsyncAgentAdapterOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStatusChange?: (status: AsyncAgentPollResult) => void;
+}
+
+export class AsyncAgentAdapter implements Agent {
+  name: string;
+
+  constructor(
+    private asyncAgent: AsyncAgent,
+    private options: AsyncAgentAdapterOptions = {},
+  ) {
+    this.name = asyncAgent.name;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const pollIntervalMs =
+      this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    const session = await this.asyncAgent.submit(prompt, cwd);
+
+    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
+    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+
+    const result = await this.pollUntilDone(
+      session,
+      pollIntervalMs,
+      timeoutMs,
+      startTime,
+      options,
+    );
+
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+
+    return result;
+  }
+
+  private async pollUntilDone(
+    session: AsyncAgentSession,
+    pollIntervalMs: number,
+    timeoutMs: number,
+    startTime: number,
+    runOptions?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    while (true) {
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `${this.name} session ${session.id} timed out after ${timeoutMs / 1000 / 60} minutes`,
+        );
+      }
+
+      if (runOptions?.signal?.aborted) {
+        throw new Error("Agent was aborted");
+      }
+
+      const pollResult = await this.asyncAgent.poll(session);
+
+      this.options.onStatusChange?.(pollResult);
+
+      if (pollResult.status === "completed") {
+        return this.buildResult(session, pollResult);
+      }
+
+      if (pollResult.status === "failed") {
+        throw new Error(
+          `${this.name} session failed: ${pollResult.reason ?? "Unknown reason"}`,
+        );
+      }
+
+      if (!POLLABLE_STATES.has(pollResult.status)) {
+        throw new Error(
+          `${this.name} session entered unexpected state: ${pollResult.status}`,
+        );
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stderr.write(
+        `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
+      );
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  private buildResult(
+    session: AsyncAgentSession,
+    pollResult: AsyncAgentPollResult,
+  ): AgentResult {
+    return {
+      output: {
+        success: true,
+        summary:
+          pollResult.summary ??
+          `${this.name} completed session ${session.id}${pollResult.pullRequestUrl ? ` — PR: ${pollResult.pullRequestUrl}` : ""}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { CopilotAgent } from "./copilot.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("CopilotAgent", () => {
+  it("has the correct name", () => {
+    const agent = new CopilotAgent();
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("builds args with --autopilot --yolo", () => {
+    const agent = new CopilotAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--autopilot");
+    expect(args).toContain("--yolo");
+    expect(args).toContain("--max-autopilot-continues");
+    expect(args).toContain("50");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new CopilotAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new CopilotAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new CopilotAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -1,0 +1,64 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class CopilotAgent extends TextBasedAgent {
+  name = "copilot";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("copilot", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return [
+      "--autopilot",
+      "--yolo",
+      "--max-autopilot-continues",
+      "50",
+      "-p",
+      fullPrompt,
+    ];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -4,17 +4,7 @@ import {
   type TokenUsage,
 } from "./types.js";
 import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
-
-const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
-const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
-
-function extractJson(text: string): string {
-  const fenceMatch = text.match(JSON_FENCE_RE);
-  if (fenceMatch) return fenceMatch[1];
-  const trailingMatch = text.match(TRAILING_JSON_RE);
-  if (trailingMatch) return trailingMatch[0];
-  return text;
-}
+import { extractJson } from "./json-utils.js";
 
 export class CopilotAgent extends TextBasedAgent {
   name = "copilot";
@@ -54,6 +44,7 @@ export class CopilotAgent extends TextBasedAgent {
   }
 
   protected parseUsage(_stdout: string): TokenUsage {
+    // TODO: Extract token usage from Copilot CLI output if available
     return {
       inputTokens: 0,
       outputTokens: 0,

--- a/src/core/agents/gemini.test.ts
+++ b/src/core/agents/gemini.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { GeminiAgent } from "./gemini.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("GeminiAgent", () => {
+  it("has the correct name", () => {
+    const agent = new GeminiAgent();
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("builds args with --output-format json", () => {
+    const agent = new GeminiAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("json");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a wrapped response with { response: '...' }", () => {
+    const agent = new GeminiAgent();
+    const wrapped = JSON.stringify({
+      response: JSON.stringify({
+        success: true,
+        summary: "done",
+        key_changes_made: ["changed foo"],
+        key_learnings: ["learned bar"],
+      }),
+    });
+    const result = (agent as any).parseOutput(wrapped);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new GeminiAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new GeminiAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new GeminiAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/gemini.ts
+++ b/src/core/agents/gemini.ts
@@ -4,17 +4,7 @@ import {
   type TokenUsage,
 } from "./types.js";
 import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
-
-const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
-const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
-
-function extractJson(text: string): string {
-  const fenceMatch = text.match(JSON_FENCE_RE);
-  if (fenceMatch) return fenceMatch[1];
-  const trailingMatch = text.match(TRAILING_JSON_RE);
-  if (trailingMatch) return trailingMatch[0];
-  return text;
-}
+import { extractJson } from "./json-utils.js";
 
 export class GeminiAgent extends TextBasedAgent {
   name = "gemini";
@@ -57,6 +47,7 @@ export class GeminiAgent extends TextBasedAgent {
   }
 
   protected parseUsage(_stdout: string): TokenUsage {
+    // TODO: Extract token usage from Gemini CLI output if available
     return {
       inputTokens: 0,
       outputTokens: 0,

--- a/src/core/agents/gemini.ts
+++ b/src/core/agents/gemini.ts
@@ -1,0 +1,67 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class GeminiAgent extends TextBasedAgent {
+  name = "gemini";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("gemini", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["-p", fullPrompt, "--output-format", "json"];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    let raw = stdout.trim();
+
+    try {
+      const wrapper = JSON.parse(raw) as { response?: string };
+      if (wrapper.response) {
+        raw = wrapper.response;
+      }
+    } catch {
+      // Not a wrapper object, try to extract JSON from the raw text
+    }
+
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/json-utils.ts
+++ b/src/core/agents/json-utils.ts
@@ -1,0 +1,10 @@
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+export function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}

--- a/src/core/agents/junie.test.ts
+++ b/src/core/agents/junie.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { JunieAgent } from "./junie.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("JunieAgent", () => {
+  it("has the correct name", () => {
+    const agent = new JunieAgent();
+    expect(agent.name).toBe("junie");
+  });
+
+  it("builds args with --task", () => {
+    const agent = new JunieAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--task");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new JunieAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new JunieAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new JunieAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/junie.ts
+++ b/src/core/agents/junie.ts
@@ -1,0 +1,57 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class JunieAgent extends TextBasedAgent {
+  name = "junie";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("junie", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["--task", fullPrompt];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/junie.ts
+++ b/src/core/agents/junie.ts
@@ -4,17 +4,7 @@ import {
   type TokenUsage,
 } from "./types.js";
 import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
-
-const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
-const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
-
-function extractJson(text: string): string {
-  const fenceMatch = text.match(JSON_FENCE_RE);
-  if (fenceMatch) return fenceMatch[1];
-  const trailingMatch = text.match(TRAILING_JSON_RE);
-  if (trailingMatch) return trailingMatch[0];
-  return text;
-}
+import { extractJson } from "./json-utils.js";
 
 export class JunieAgent extends TextBasedAgent {
   name = "junie";
@@ -47,6 +37,7 @@ export class JunieAgent extends TextBasedAgent {
   }
 
   protected parseUsage(_stdout: string): TokenUsage {
+    // TODO: Extract token usage from Junie CLI output if available
     return {
       inputTokens: 0,
       outputTokens: 0,

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import type {
+  Agent,
+  AgentResult,
+  AgentOutput,
+  TokenUsage,
+  AgentRunOptions,
+} from "./types.js";
+
+const MAX_OUTPUT_BUFFER = 256 * 1024;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ANSI_ESCAPE_RE =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (/\.(cmd|bat)$/i.test(bin)) return true;
+  if (/[\\/]/.test(bin)) return false;
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort
+    }
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+export interface TextBasedAgentDeps {
+  bin?: string;
+  platform?: NodeJS.Platform;
+}
+
+export abstract class TextBasedAgent implements Agent {
+  abstract name: string;
+
+  protected bin: string;
+  protected platform: NodeJS.Platform;
+
+  constructor(bin: string, deps: TextBasedAgentDeps = {}) {
+    this.bin = deps.bin ?? bin;
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  protected abstract buildArgs(prompt: string): string[];
+  protected abstract parseOutput(stdout: string): AgentOutput;
+  protected abstract parseUsage(stdout: string): TokenUsage;
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
+
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
+
+    const child = spawn(this.bin, this.buildArgs(prompt), {
+      cwd,
+      shell: shouldUseWindowsShell(this.bin, this.platform),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stdout += text;
+      if (stdout.length > MAX_OUTPUT_BUFFER) {
+        stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
+      }
+      logStream?.write(data);
+      const cleaned = stripAnsi(text).trim();
+      if (cleaned) onMessage?.(cleaned);
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+      logStream?.write(data);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateProcess(child, this.platform);
+        reject(
+          new Error(
+            `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
+          ),
+        );
+      }, STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        resolve(code);
+      });
+    });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        reject(new Error(`Failed to spawn ${this.name}: ${err.message}`));
+      });
+    });
+
+    let exitCode: number | null = null;
+
+    try {
+      const result = await Promise.race([
+        exitPromise.then((code) => {
+          exitCode = code;
+          return { done: true } as const;
+        }),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+
+      if ("done" in result) {
+        // Process completed normally
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+    }
+
+    const cleaned = stripAnsi(stdout);
+    let output: AgentOutput;
+    try {
+      output = this.parseOutput(cleaned);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${this.name} output: ${err instanceof Error ? err.message : err}\n\nRaw output (last 500 chars):\n${cleaned.slice(-500)}`,
+      );
+    }
+
+    const usage = this.parseUsage(cleaned);
+    if (onUsage && Object.values(usage).some((v) => v > 0)) {
+      onUsage(usage);
+    }
+
+    return { output, usage };
+  }
+}

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -49,3 +49,59 @@ export interface Agent {
     options?: AgentRunOptions,
   ): Promise<AgentResult>;
 }
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}


### PR DESCRIPTION
## Summary

Add three new text-based agent implementations extending TextBasedAgent:

### Changes
- **gemini.ts**: Uses `gemini -p --output-format json` for headless mode, handles wrapped `{ response: '...' }` and fenced JSON output formats
- **copilot.ts**: Uses `copilot --autopilot --yolo --max-autopilot-continues 50 -p` for unattended autonomous operation with JSON parsing from text output
- **junie.ts**: Uses `junie --task` for headless task execution with JSON output extraction from terminal text

All agents return zero token usage since their CLIs don't expose token counts in stdout.

### Dependencies
- Depends on #41 (TextBasedAgent base class)