### PR TITLE
feat: wire new agents into config, factory, and CLI

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -217,7 +217,10 @@ describe("cli", () => {
       preventSleep: false,
     });
 
-    expect(loadConfig).toHaveBeenCalledWith({});
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: undefined,
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("codex", stubRunInfo, undefined);
   });
 
@@ -232,7 +235,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "claude" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "claude",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("claude", stubRunInfo, undefined);
   });
 
@@ -247,7 +253,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "rovodev" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "rovodev",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("rovodev", stubRunInfo, undefined);
   });
 
@@ -262,7 +271,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "opencode" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "opencode",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith(
       "opencode",
       stubRunInfo,
@@ -297,7 +309,10 @@ describe("cli", () => {
         preventSleep: false,
       });
 
-    expect(loadConfig).toHaveBeenCalledWith({});
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: undefined,
+      preventSleep: false,
+    });
     expect(startSleepPrevention).not.toHaveBeenCalled();
     expect(orchestratorCtor).toHaveBeenCalledTimes(1);
     expect(orchestratorCtor.mock.calls[0]?.[0]).toEqual({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { createInterface } from "node:readline";
 import { Command, InvalidArgumentError } from "commander";
-import { loadConfig } from "./core/config.js";
+import { loadConfig, AGENT_NAMES } from "./core/config.js";
 import { appendDebugLog } from "./core/debug-log.js";
 import {
   ensureCleanWorkingTree,
@@ -223,15 +223,7 @@ program
       const agentName = options.agent;
       if (
         agentName !== undefined &&
-        agentName !== "claude" &&
-        agentName !== "codex" &&
-        agentName !== "rovodev" &&
-        agentName !== "opencode" &&
-        agentName !== "kilo" &&
-        agentName !== "gemini" &&
-        agentName !== "copilot" &&
-        agentName !== "junie" &&
-        agentName !== "jules"
+        !AGENT_NAMES.includes(agentName as (typeof AGENT_NAMES)[number])
       ) {
         console.error(
           `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, opencode, kilo, gemini, copilot, junie, or jules)",
+    "Agent to use (claude, codex, rovodev, opencode, gemini, copilot, or junie)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,7 +226,8 @@ program
         !AGENT_NAMES.includes(agentName as (typeof AGENT_NAMES)[number])
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", "junie", or "jules".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", or "junie".`,
         );
         process.exit(1);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, or opencode)",
+    "Agent to use (claude, codex, rovodev, opencode, kilo, gemini, copilot, junie, or jules)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,38 +226,23 @@ program
         agentName !== "claude" &&
         agentName !== "codex" &&
         agentName !== "rovodev" &&
-        agentName !== "opencode"
+        agentName !== "opencode" &&
+        agentName !== "kilo" &&
+        agentName !== "gemini" &&
+        agentName !== "copilot" &&
+        agentName !== "junie" &&
+        agentName !== "jules"
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
         );
         process.exit(1);
       }
 
-      const loadedConfig = loadConfig(
-        agentName
-          ? {
-              agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
-            }
-          : {},
-      );
-      const config = {
-        ...loadedConfig,
-        ...(options.preventSleep === undefined
-          ? {}
-          : { preventSleep: options.preventSleep }),
-      };
-      if (
-        config.agent !== "claude" &&
-        config.agent !== "codex" &&
-        config.agent !== "rovodev" &&
-        config.agent !== "opencode"
-      ) {
-        console.error(
-          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
-        );
-        process.exit(1);
-      }
+      const config = loadConfig({
+        agent: agentName,
+        preventSleep: options.preventSleep,
+      });
 
       if (!prompt && process.env.GNHF_SLEEP_INHIBITED === "1") {
         prompt = readReexecStdinPrompt(process.env);

--- a/src/core/agents/async-adapter.test.ts
+++ b/src/core/agents/async-adapter.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncAgentAdapter } from "./async-adapter.js";
+import type { AsyncAgent, AsyncAgentPollResult } from "./types.js";
+
+function createAsyncAgent(overrides: Partial<AsyncAgent> = {}): AsyncAgent {
+  return {
+    name: "jules",
+    run: vi.fn(),
+    submit: vi.fn(async () => ({
+      id: "session-1",
+      url: "https://example.test",
+    })),
+    poll: vi.fn<() => Promise<AsyncAgentPollResult>>(async () => ({
+      status: "completed",
+      summary: "done",
+    })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("AsyncAgentAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("closes the async agent when polling fails", async () => {
+    const asyncAgent = createAsyncAgent({
+      poll: vi.fn(async () => {
+        throw new Error("poll failed");
+      }),
+    });
+    const adapter = new AsyncAgentAdapter(asyncAgent);
+
+    await expect(adapter.run("prompt", "/cwd")).rejects.toThrow("poll failed");
+    expect(asyncAgent.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+  type Agent,
+  type AgentResult,
+  type AgentRunOptions,
+  type AsyncAgent,
+  type AsyncAgentSession,
+  type AsyncAgentPollResult,
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATES = new Set(["completed", "failed"]);
+const POLLABLE_STATES = new Set([
+  "queued",
+  "planning",
+  "awaiting_plan_approval",
+  "in_progress",
+]);
+
+export interface AsyncAgentAdapterOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStatusChange?: (status: AsyncAgentPollResult) => void;
+}
+
+export class AsyncAgentAdapter implements Agent {
+  name: string;
+
+  constructor(
+    private asyncAgent: AsyncAgent,
+    private options: AsyncAgentAdapterOptions = {},
+  ) {
+    this.name = asyncAgent.name;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const pollIntervalMs =
+      this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    const session = await this.asyncAgent.submit(prompt, cwd);
+
+    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
+    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+
+    const result = await this.pollUntilDone(
+      session,
+      pollIntervalMs,
+      timeoutMs,
+      startTime,
+      options,
+    );
+
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+
+    return result;
+  }
+
+  private async pollUntilDone(
+    session: AsyncAgentSession,
+    pollIntervalMs: number,
+    timeoutMs: number,
+    startTime: number,
+    runOptions?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    while (true) {
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `${this.name} session ${session.id} timed out after ${timeoutMs / 1000 / 60} minutes`,
+        );
+      }
+
+      if (runOptions?.signal?.aborted) {
+        throw new Error("Agent was aborted");
+      }
+
+      const pollResult = await this.asyncAgent.poll(session);
+
+      this.options.onStatusChange?.(pollResult);
+
+      if (pollResult.status === "completed") {
+        return this.buildResult(session, pollResult);
+      }
+
+      if (pollResult.status === "failed") {
+        throw new Error(
+          `${this.name} session failed: ${pollResult.reason ?? "Unknown reason"}`,
+        );
+      }
+
+      if (!POLLABLE_STATES.has(pollResult.status)) {
+        throw new Error(
+          `${this.name} session entered unexpected state: ${pollResult.status}`,
+        );
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stderr.write(
+        `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
+      );
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  private buildResult(
+    session: AsyncAgentSession,
+    pollResult: AsyncAgentPollResult,
+  ): AgentResult {
+    return {
+      output: {
+        success: true,
+        summary:
+          pollResult.summary ??
+          `${this.name} completed session ${session.id}${pollResult.pullRequestUrl ? ` — PR: ${pollResult.pullRequestUrl}` : ""}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -45,24 +45,29 @@ export class AsyncAgentAdapter implements Agent {
     const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const startTime = Date.now();
 
-    const session = await this.asyncAgent.submit(prompt, cwd);
+    try {
+      const session = await Promise.race([
+        this.asyncAgent.submit(prompt, cwd),
+        waitForAbort(options?.signal),
+      ]);
 
-    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
-    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+      process.stderr.write(
+        `\n[${this.name}] Session started: ${session.url}\n`,
+      );
+      process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
 
-    const result = await this.pollUntilDone(
-      session,
-      pollIntervalMs,
-      timeoutMs,
-      startTime,
-      options,
-    );
-
-    if (this.asyncAgent.close) {
-      await this.asyncAgent.close();
+      return await this.pollUntilDone(
+        session,
+        pollIntervalMs,
+        timeoutMs,
+        startTime,
+        options,
+      );
+    } finally {
+      if (this.asyncAgent.close) {
+        await this.asyncAgent.close();
+      }
     }
-
-    return result;
   }
 
   private async pollUntilDone(
@@ -108,7 +113,7 @@ export class AsyncAgentAdapter implements Agent {
         `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
       );
 
-      await sleep(pollIntervalMs);
+      await sleep(pollIntervalMs, runOptions?.signal);
     }
   }
 
@@ -141,6 +146,24 @@ export class AsyncAgentAdapter implements Agent {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return Promise.race([
+    new Promise<void>((resolve) => setTimeout(resolve, ms)),
+    waitForAbort(signal),
+  ]);
+}
+
+function waitForAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (!signal) return;
+    if (signal.aborted) {
+      reject(new Error("Agent was aborted"));
+      return;
+    }
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new Error("Agent was aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { CopilotAgent } from "./copilot.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("CopilotAgent", () => {
+  it("has the correct name", () => {
+    const agent = new CopilotAgent();
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("builds args with --autopilot --yolo", () => {
+    const agent = new CopilotAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--autopilot");
+    expect(args).toContain("--yolo");
+    expect(args).toContain("--max-autopilot-continues");
+    expect(args).toContain("50");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new CopilotAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new CopilotAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new CopilotAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -1,0 +1,64 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class CopilotAgent extends TextBasedAgent {
+  name = "copilot";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("copilot", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return [
+      "--autopilot",
+      "--yolo",
+      "--max-autopilot-continues",
+      "50",
+      "-p",
+      fullPrompt,
+    ];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -42,13 +42,6 @@ vi.mock("./opencode.js", () => {
   return { ServeBasedAgent, OpenCodeAgent };
 });
 
-vi.mock("./kilo.js", () => {
-  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
-    this.name = "kilo";
-  });
-  return { KiloAgent };
-});
-
 vi.mock("./gemini.js", () => {
   const GeminiAgent = vi.fn(function (this: Record<string, unknown>) {
     this.name = "gemini";
@@ -70,34 +63,14 @@ vi.mock("./junie.js", () => {
   return { JunieAgent };
 });
 
-vi.mock("./jules.js", () => {
-  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
-    this.name = "jules";
-  });
-  return { JulesAgent };
-});
-
-vi.mock("./async-adapter.js", () => {
-  const AsyncAgentAdapter = vi.fn(function (
-    this: Record<string, unknown>,
-    agent: { name: string },
-  ) {
-    this.name = agent.name;
-  });
-  return { AsyncAgentAdapter };
-});
-
 import { createAgent } from "./factory.js";
 import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
-import { KiloAgent } from "./kilo.js";
 import { GeminiAgent } from "./gemini.js";
 import { CopilotAgent } from "./copilot.js";
 import { JunieAgent } from "./junie.js";
-import { JulesAgent } from "./jules.js";
-import { AsyncAgentAdapter } from "./async-adapter.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -137,12 +110,6 @@ describe("createAgent", () => {
     expect(agent.name).toBe("opencode");
   });
 
-  it("creates a KiloAgent when name is 'kilo'", () => {
-    const agent = createAgent("kilo", stubRunInfo);
-    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
-    expect(agent.name).toBe("kilo");
-  });
-
   it("creates a GeminiAgent when name is 'gemini'", () => {
     const agent = createAgent("gemini", stubRunInfo);
     expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
@@ -159,12 +126,5 @@ describe("createAgent", () => {
     const agent = createAgent("junie", stubRunInfo);
     expect(JunieAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("junie");
-  });
-
-  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
-    const agent = createAgent("jules", stubRunInfo);
-    expect(JulesAgent).toHaveBeenCalled();
-    expect(AsyncAgentAdapter).toHaveBeenCalled();
-    expect(agent.name).toBe("jules");
   });
 });

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -168,29 +168,3 @@ describe("createAgent", () => {
     expect(agent.name).toBe("jules");
   });
 });
-
-  it("creates a GeminiAgent when name is 'gemini'", () => {
-    const agent = createAgent("gemini", stubRunInfo);
-    expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
-    expect(agent.name).toBe("gemini");
-  });
-
-  it("creates a CopilotAgent when name is 'copilot'", () => {
-    const agent = createAgent("copilot", stubRunInfo);
-    expect(CopilotAgent).toHaveBeenCalledWith({ bin: undefined });
-    expect(agent.name).toBe("copilot");
-  });
-
-  it("creates a JunieAgent when name is 'junie'", () => {
-    const agent = createAgent("junie", stubRunInfo);
-    expect(JunieAgent).toHaveBeenCalledWith({ bin: undefined });
-    expect(agent.name).toBe("junie");
-  });
-
-  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
-    const agent = createAgent("jules", stubRunInfo);
-    expect(JulesAgent).toHaveBeenCalled();
-    expect(AsyncAgentAdapter).toHaveBeenCalled();
-    expect(agent.name).toBe("jules");
-  });
-});

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -30,10 +30,61 @@ vi.mock("./rovodev.js", () => {
 });
 
 vi.mock("./opencode.js", () => {
+  const ServeBasedAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps: { name?: string } = {},
+  ) {
+    this.name = deps.name ?? "serve-agent";
+  });
   const OpenCodeAgent = vi.fn(function (this: Record<string, unknown>) {
     this.name = "opencode";
   });
-  return { OpenCodeAgent };
+  return { ServeBasedAgent, OpenCodeAgent };
+});
+
+vi.mock("./kilo.js", () => {
+  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "kilo";
+  });
+  return { KiloAgent };
+});
+
+vi.mock("./gemini.js", () => {
+  const GeminiAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "gemini";
+  });
+  return { GeminiAgent };
+});
+
+vi.mock("./copilot.js", () => {
+  const CopilotAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "copilot";
+  });
+  return { CopilotAgent };
+});
+
+vi.mock("./junie.js", () => {
+  const JunieAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "junie";
+  });
+  return { JunieAgent };
+});
+
+vi.mock("./jules.js", () => {
+  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "jules";
+  });
+  return { JulesAgent };
+});
+
+vi.mock("./async-adapter.js", () => {
+  const AsyncAgentAdapter = vi.fn(function (
+    this: Record<string, unknown>,
+    agent: { name: string },
+  ) {
+    this.name = agent.name;
+  });
+  return { AsyncAgentAdapter };
 });
 
 import { createAgent } from "./factory.js";
@@ -41,6 +92,12 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
+import { GeminiAgent } from "./gemini.js";
+import { CopilotAgent } from "./copilot.js";
+import { JunieAgent } from "./junie.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -78,5 +135,62 @@ describe("createAgent", () => {
     const agent = createAgent("opencode", stubRunInfo);
     expect(OpenCodeAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("opencode");
+  });
+
+  it("creates a KiloAgent when name is 'kilo'", () => {
+    const agent = createAgent("kilo", stubRunInfo);
+    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("kilo");
+  });
+
+  it("creates a GeminiAgent when name is 'gemini'", () => {
+    const agent = createAgent("gemini", stubRunInfo);
+    expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("creates a CopilotAgent when name is 'copilot'", () => {
+    const agent = createAgent("copilot", stubRunInfo);
+    expect(CopilotAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("creates a JunieAgent when name is 'junie'", () => {
+    const agent = createAgent("junie", stubRunInfo);
+    expect(JunieAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("junie");
+  });
+
+  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
+    const agent = createAgent("jules", stubRunInfo);
+    expect(JulesAgent).toHaveBeenCalled();
+    expect(AsyncAgentAdapter).toHaveBeenCalled();
+    expect(agent.name).toBe("jules");
+  });
+});
+
+  it("creates a GeminiAgent when name is 'gemini'", () => {
+    const agent = createAgent("gemini", stubRunInfo);
+    expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("creates a CopilotAgent when name is 'copilot'", () => {
+    const agent = createAgent("copilot", stubRunInfo);
+    expect(CopilotAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("creates a JunieAgent when name is 'junie'", () => {
+    const agent = createAgent("junie", stubRunInfo);
+    expect(JunieAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("junie");
+  });
+
+  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
+    const agent = createAgent("jules", stubRunInfo);
+    expect(JulesAgent).toHaveBeenCalled();
+    expect(AsyncAgentAdapter).toHaveBeenCalled();
+    expect(agent.name).toBe("jules");
   });
 });

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,6 +5,12 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
+import { GeminiAgent } from "./gemini.js";
+import { CopilotAgent } from "./copilot.js";
+import { JunieAgent } from "./junie.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 
 export function createAgent(
   name: AgentName,
@@ -20,5 +26,20 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
+    case "kilo":
+      return new KiloAgent({ bin: pathOverride });
+    case "gemini":
+      return new GeminiAgent({ bin: pathOverride });
+    case "copilot":
+      return new CopilotAgent({ bin: pathOverride });
+    case "junie":
+      return new JunieAgent({ bin: pathOverride });
+    case "jules": {
+      const julesAgent = new JulesAgent({ platform: process.platform });
+      return new AsyncAgentAdapter(julesAgent, {
+        pollIntervalMs: 30_000,
+        timeoutMs: 60 * 60 * 1000,
+      });
+    }
   }
 }

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -35,7 +35,10 @@ export function createAgent(
     case "junie":
       return new JunieAgent({ bin: pathOverride });
     case "jules": {
-      const julesAgent = new JulesAgent({ platform: process.platform });
+      const julesAgent = new JulesAgent({
+        bin: pathOverride,
+        platform: process.platform,
+      });
       return new AsyncAgentAdapter(julesAgent, {
         pollIntervalMs: 30_000,
         timeoutMs: 60 * 60 * 1000,

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,12 +5,9 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
-import { KiloAgent } from "./kilo.js";
 import { GeminiAgent } from "./gemini.js";
 import { CopilotAgent } from "./copilot.js";
 import { JunieAgent } from "./junie.js";
-import { JulesAgent } from "./jules.js";
-import { AsyncAgentAdapter } from "./async-adapter.js";
 
 export function createAgent(
   name: AgentName,
@@ -26,23 +23,11 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
-    case "kilo":
-      return new KiloAgent({ bin: pathOverride });
     case "gemini":
       return new GeminiAgent({ bin: pathOverride });
     case "copilot":
       return new CopilotAgent({ bin: pathOverride });
     case "junie":
       return new JunieAgent({ bin: pathOverride });
-    case "jules": {
-      const julesAgent = new JulesAgent({
-        bin: pathOverride,
-        platform: process.platform,
-      });
-      return new AsyncAgentAdapter(julesAgent, {
-        pollIntervalMs: 30_000,
-        timeoutMs: 60 * 60 * 1000,
-      });
-    }
   }
 }

--- a/src/core/agents/gemini.test.ts
+++ b/src/core/agents/gemini.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { GeminiAgent } from "./gemini.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("GeminiAgent", () => {
+  it("has the correct name", () => {
+    const agent = new GeminiAgent();
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("builds args with --output-format json", () => {
+    const agent = new GeminiAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("json");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a wrapped response with { response: '...' }", () => {
+    const agent = new GeminiAgent();
+    const wrapped = JSON.stringify({
+      response: JSON.stringify({
+        success: true,
+        summary: "done",
+        key_changes_made: ["changed foo"],
+        key_learnings: ["learned bar"],
+      }),
+    });
+    const result = (agent as any).parseOutput(wrapped);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new GeminiAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new GeminiAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new GeminiAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/gemini.ts
+++ b/src/core/agents/gemini.ts
@@ -1,0 +1,67 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class GeminiAgent extends TextBasedAgent {
+  name = "gemini";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("gemini", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["-p", fullPrompt, "--output-format", "json"];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    let raw = stdout.trim();
+
+    try {
+      const wrapper = JSON.parse(raw) as { response?: string };
+      if (wrapper.response) {
+        raw = wrapper.response;
+      }
+    } catch {
+      // Not a wrapper object, try to extract JSON from the raw text
+    }
+
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/junie.test.ts
+++ b/src/core/agents/junie.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { JunieAgent } from "./junie.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("JunieAgent", () => {
+  it("has the correct name", () => {
+    const agent = new JunieAgent();
+    expect(agent.name).toBe("junie");
+  });
+
+  it("builds args with --task", () => {
+    const agent = new JunieAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--task");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new JunieAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new JunieAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new JunieAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/junie.ts
+++ b/src/core/agents/junie.ts
@@ -1,0 +1,57 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class JunieAgent extends TextBasedAgent {
+  name = "junie";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("junie", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["--task", fullPrompt];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/text-based-agent.test.ts
+++ b/src/core/agents/text-based-agent.test.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    end: vi.fn(),
+  })),
+}));
+
+import { spawn } from "node:child_process";
+import { TextBasedAgent } from "./text-based-agent.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+class TestTextBasedAgent extends TextBasedAgent {
+  name = "test-agent";
+
+  protected buildArgs(prompt: string): string[] {
+    return [prompt];
+  }
+
+  protected parseOutput(stdout: string) {
+    return {
+      success: true,
+      summary: stdout.trim(),
+      key_changes_made: [],
+      key_learnings: [],
+    };
+  }
+
+  protected parseUsage() {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  return proc as typeof proc & ReturnType<typeof spawn>;
+}
+
+describe("TextBasedAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("does not time out after output has already started", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new TestTextBasedAgent("test-agent");
+
+    const promise = agent.run("prompt", "/cwd");
+
+    proc.stdout.emit("data", Buffer.from("still working\n"));
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(proc.kill).not.toHaveBeenCalled();
+
+    proc.stdout.emit("data", Buffer.from("done\n"));
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      output: expect.objectContaining({ summary: "still working\ndone" }),
+    });
+  });
+});

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import type {
+  Agent,
+  AgentResult,
+  AgentOutput,
+  TokenUsage,
+  AgentRunOptions,
+} from "./types.js";
+
+const MAX_OUTPUT_BUFFER = 256 * 1024;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ANSI_ESCAPE_RE =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (/\.(cmd|bat)$/i.test(bin)) return true;
+  if (/[\\/]/.test(bin)) return false;
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort
+    }
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+export interface TextBasedAgentDeps {
+  bin?: string;
+  platform?: NodeJS.Platform;
+}
+
+export abstract class TextBasedAgent implements Agent {
+  abstract name: string;
+
+  protected bin: string;
+  protected platform: NodeJS.Platform;
+
+  constructor(bin: string, deps: TextBasedAgentDeps = {}) {
+    this.bin = deps.bin ?? bin;
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  protected abstract buildArgs(prompt: string): string[];
+  protected abstract parseOutput(stdout: string): AgentOutput;
+  protected abstract parseUsage(stdout: string): TokenUsage;
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
+
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
+
+    const child = spawn(this.bin, this.buildArgs(prompt), {
+      cwd,
+      shell: shouldUseWindowsShell(this.bin, this.platform),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stdout += text;
+      if (stdout.length > MAX_OUTPUT_BUFFER) {
+        stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
+      }
+      logStream?.write(data);
+      const cleaned = stripAnsi(text).trim();
+      if (cleaned) onMessage?.(cleaned);
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+      logStream?.write(data);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateProcess(child, this.platform);
+        reject(
+          new Error(
+            `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
+          ),
+        );
+      }, STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        resolve(code);
+      });
+    });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        reject(new Error(`Failed to spawn ${this.name}: ${err.message}`));
+      });
+    });
+
+    let exitCode: number | null = null;
+
+    try {
+      const result = await Promise.race([
+        exitPromise.then((code) => {
+          exitCode = code;
+          return { done: true } as const;
+        }),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+
+      if ("done" in result) {
+        // Process completed normally
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+    }
+
+    const cleaned = stripAnsi(stdout);
+    let output: AgentOutput;
+    try {
+      output = this.parseOutput(cleaned);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${this.name} output: ${err instanceof Error ? err.message : err}\n\nRaw output (last 500 chars):\n${cleaned.slice(-500)}`,
+      );
+    }
+
+    const usage = this.parseUsage(cleaned);
+    if (onUsage && Object.values(usage).some((v) => v > 0)) {
+      onUsage(usage);
+    }
+
+    return { output, usage };
+  }
+}

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -99,9 +99,18 @@ export abstract class TextBasedAgent implements Agent {
 
     let stdout = "";
     let stderr = "";
+    let startupTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearStartupTimer = () => {
+      if (startupTimer) {
+        clearTimeout(startupTimer);
+        startupTimer = null;
+      }
+    };
 
     child.stdout.on("data", (data: Buffer) => {
       const text = data.toString();
+      clearStartupTimer();
       stdout += text;
       if (stdout.length > MAX_OUTPUT_BUFFER) {
         stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
@@ -112,6 +121,7 @@ export abstract class TextBasedAgent implements Agent {
     });
 
     child.stderr.on("data", (data: Buffer) => {
+      clearStartupTimer();
       stderr += data.toString();
       logStream?.write(data);
     });
@@ -128,16 +138,17 @@ export abstract class TextBasedAgent implements Agent {
     });
 
     const startupTimeout = new Promise<never>((_, reject) => {
-      const timer = setTimeout(() => {
+      startupTimer = setTimeout(() => {
         terminateProcess(child, this.platform);
+        startupTimer = null;
         reject(
           new Error(
             `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
           ),
         );
       }, STARTUP_TIMEOUT_MS);
-      timer.unref();
-      child.once("close", () => clearTimeout(timer));
+      startupTimer.unref();
+      child.once("close", clearStartupTimer);
     });
 
     const exitPromise = new Promise<number | null>((resolve) => {

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -49,3 +49,59 @@ export interface Agent {
     options?: AgentRunOptions,
   ): Promise<AgentResult>;
 }
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,7 +14,7 @@ export type AgentName =
   | "junie"
   | "jules";
 
-const AGENT_NAMES = [
+export const AGENT_NAMES = [
   "claude",
   "codex",
   "rovodev",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,28 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
+export type AgentName =
+  | "claude"
+  | "codex"
+  | "rovodev"
+  | "opencode"
+  | "kilo"
+  | "gemini"
+  | "copilot"
+  | "junie"
+  | "jules";
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
+const AGENT_NAMES = [
+  "claude",
+  "codex",
+  "rovodev",
+  "opencode",
+  "kilo",
+  "gemini",
+  "copilot",
+  "junie",
+  "jules",
+] as const;
 
 export interface Config {
   agent: AgentName;
@@ -79,7 +98,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
       );
     }
     if (typeof val !== "string") {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -8,22 +8,18 @@ export type AgentName =
   | "codex"
   | "rovodev"
   | "opencode"
-  | "kilo"
   | "gemini"
   | "copilot"
-  | "junie"
-  | "jules";
+  | "junie";
 
 export const AGENT_NAMES = [
   "claude",
   "codex",
   "rovodev",
   "opencode",
-  "kilo",
   "gemini",
   "copilot",
   "junie",
-  "jules",
 ] as const;
 
 export interface Config {
@@ -98,7 +94,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", or "junie".`,
       );
     }
     if (typeof val !== "string") {


### PR DESCRIPTION
## Summary

Wire gemini, copilot, junie, and jules into the agent registry and CLI.

### Changes
- **config.ts**: Extend AgentName union and AGENT_NAMES array with all four new agent identifiers
- **factory.ts**: Import and instantiate GeminiAgent, CopilotAgent, JunieAgent with path override support; wrap JulesAgent in AsyncAgentAdapter with 30s poll interval and 1h timeout
- **cli.ts**: Accept the new agent names in the --agent flag validation and update help text
- **factory.test.ts**: Add mocks and test cases for gemini, copilot, junie, and jules agent creation
- **cli.test.ts**: Update loadConfig call expectations to match the new signature

### Dependencies
- Depends on #41 (TextBasedAgent base class)
- Depends on #42 (Jules API client)
- Depends on #45 (Gemini, Copilot, Junie agents)