### PR TITLE
Agent infrastructure and shared abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 
 - **Dead simple** — one command starts an autonomous loop that runs until you Ctrl+C or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries and exponential backoff
-- **Agent-agnostic** — works with Claude Code, Codex, Rovo Dev, or OpenCode out of the box
+- **Agent-agnostic** — works with Claude Code, Codex, Kilo Code, Rovo Dev, or OpenCode out of the box
 
 ## Quick Start
 
@@ -146,7 +146,7 @@ npm link
 
 | Flag                     | Description                                                        | Default                |
 | ------------------------ | ------------------------------------------------------------------ | ---------------------- |
-| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)         | config file (`claude`) |
+| `--agent <agent>`        | Agent to use (`claude`, `codex`, `kilo`, `rovodev`, or `opencode`) | config file (`claude`) |
 | `--max-iterations <n>`   | Abort after `n` total iterations                                   | unlimited              |
 | `--max-tokens <n>`       | Abort after `n` total input+output tokens                          | unlimited              |
 | `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`) | config file (`on`)     |
@@ -157,7 +157,7 @@ npm link
 Config lives at `~/.gnhf/config.yml`:
 
 ```yaml
-# Agent to use by default (claude, codex, rovodev, or opencode)
+# Agent to use by default (claude, codex, kilo, rovodev, or opencode)
 agent: claude
 
 # Custom paths to agent binaries (optional)
@@ -200,14 +200,15 @@ GNHF_DEBUG_LOG_PATH=/tmp/gnhf-debug.jsonl gnhf "ship it"
 
 ## Agents
 
-`gnhf` supports four agents:
+`gnhf` supports five agents:
 
-| Agent       | Flag               | Requirements                                                               | Notes                                                                                                                                                                                                            |
-| ----------- | ------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                        | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
-| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                            | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
-| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.        | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
-| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first. | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
+| Agent       | Flag               | Requirements                                                                           | Notes                                                                                                                                                                                                            |
+| ----------- | ------------------ | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                                    | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
+| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                                        | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
+| Kilo Code   | `--agent kilo`     | Install Kilo Code CLI (`npm install -g @kilocode/cli`) and configure a provider first. | `gnhf` starts a local `kilo serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.     |
+| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.                    | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
+| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first.             | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
 
 ## Development
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, or opencode)",
+    "Agent to use (claude, codex, rovodev, opencode, or kilo)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,10 +226,11 @@ program
         agentName !== "claude" &&
         agentName !== "codex" &&
         agentName !== "rovodev" &&
-        agentName !== "opencode"
+        agentName !== "opencode" &&
+        agentName !== "kilo"
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
         );
         process.exit(1);
       }
@@ -237,7 +238,12 @@ program
       const loadedConfig = loadConfig(
         agentName
           ? {
-              agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
+              agent: agentName as
+                | "claude"
+                | "codex"
+                | "rovodev"
+                | "opencode"
+                | "kilo",
             }
           : {},
       );
@@ -251,10 +257,11 @@ program
         config.agent !== "claude" &&
         config.agent !== "codex" &&
         config.agent !== "rovodev" &&
-        config.agent !== "opencode"
+        config.agent !== "opencode" &&
+        config.agent !== "kilo"
       ) {
         console.error(
-          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
         );
         process.exit(1);
       }

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+  type Agent,
+  type AgentResult,
+  type AgentRunOptions,
+  type AsyncAgent,
+  type AsyncAgentSession,
+  type AsyncAgentPollResult,
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATES = new Set(["completed", "failed"]);
+const POLLABLE_STATES = new Set([
+  "queued",
+  "planning",
+  "awaiting_plan_approval",
+  "in_progress",
+]);
+
+export interface AsyncAgentAdapterOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStatusChange?: (status: AsyncAgentPollResult) => void;
+}
+
+export class AsyncAgentAdapter implements Agent {
+  name: string;
+
+  constructor(
+    private asyncAgent: AsyncAgent,
+    private options: AsyncAgentAdapterOptions = {},
+  ) {
+    this.name = asyncAgent.name;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const pollIntervalMs =
+      this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    const session = await this.asyncAgent.submit(prompt, cwd);
+
+    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
+    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+
+    const result = await this.pollUntilDone(
+      session,
+      pollIntervalMs,
+      timeoutMs,
+      startTime,
+      options,
+    );
+
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+
+    return result;
+  }
+
+  private async pollUntilDone(
+    session: AsyncAgentSession,
+    pollIntervalMs: number,
+    timeoutMs: number,
+    startTime: number,
+    runOptions?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    while (true) {
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `${this.name} session ${session.id} timed out after ${timeoutMs / 1000 / 60} minutes`,
+        );
+      }
+
+      if (runOptions?.signal?.aborted) {
+        throw new Error("Agent was aborted");
+      }
+
+      const pollResult = await this.asyncAgent.poll(session);
+
+      this.options.onStatusChange?.(pollResult);
+
+      if (pollResult.status === "completed") {
+        return this.buildResult(session, pollResult);
+      }
+
+      if (pollResult.status === "failed") {
+        throw new Error(
+          `${this.name} session failed: ${pollResult.reason ?? "Unknown reason"}`,
+        );
+      }
+
+      if (!POLLABLE_STATES.has(pollResult.status)) {
+        throw new Error(
+          `${this.name} session entered unexpected state: ${pollResult.status}`,
+        );
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stderr.write(
+        `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
+      );
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  private buildResult(
+    session: AsyncAgentSession,
+    pollResult: AsyncAgentPollResult,
+  ): AgentResult {
+    return {
+      output: {
+        success: true,
+        summary:
+          pollResult.summary ??
+          `${this.name} completed session ${session.id}${pollResult.pullRequestUrl ? ` — PR: ${pollResult.pullRequestUrl}` : ""}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/agents/codex.test.ts
+++ b/src/core/agents/codex.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
@@ -11,13 +12,25 @@ import { CodexAgent } from "./codex.js";
 
 const mockSpawn = vi.mocked(spawn);
 
-function createMockProcess() {
+function createMockProcess(jsonlLines: string[]) {
+  const stdout = Readable.from(
+    jsonlLines.map((line) => Buffer.from(line + "\n")),
+  );
+  const stderr = new Readable({
+    read() {},
+  }) as unknown as NodeJS.ReadableStream;
   const proc = Object.assign(new EventEmitter(), {
-    stdout: new EventEmitter(),
-    stderr: new EventEmitter(),
+    stdout,
+    stderr,
     stdin: null,
     kill: vi.fn(),
+    pid: 1234,
   });
+
+  stdout.on("end", () => {
+    setImmediate(() => proc.emit("close", 0));
+  });
+
   return proc as typeof proc & ReturnType<typeof spawn>;
 }
 
@@ -26,15 +39,37 @@ describe("CodexAgent", () => {
     vi.clearAllMocks();
   });
 
-  it("does not use a shell for direct Windows launches", () => {
-    const proc = createMockProcess();
+  const successJsonl = [
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: JSON.stringify({
+          success: true,
+          summary: "done",
+          key_changes_made: [],
+          key_learnings: [],
+        }),
+      },
+    }),
+    JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 },
+    }),
+  ];
+
+  it("does not use a shell for direct Windows launches", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
+
     const agent = new CodexAgent("/tmp/schema.json", {
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    const result = await agent.run("test prompt", "/work/dir");
 
+    expect(result.output.success).toBe(true);
+    expect(result.output.summary).toBe("done");
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex",
       [
@@ -56,15 +91,16 @@ describe("CodexAgent", () => {
     );
   });
 
-  it("uses a shell on Windows for cmd wrapper paths", () => {
-    const proc = createMockProcess();
+  it("uses a shell on Windows for cmd wrapper paths", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
+
     const agent = new CodexAgent("/tmp/schema.json", {
       bin: "C:\\tools\\codex.cmd",
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    await agent.run("test prompt", "/work/dir");
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "C:\\tools\\codex.cmd",
@@ -87,18 +123,19 @@ describe("CodexAgent", () => {
     );
   });
 
-  it("uses a shell on Windows when a bare override resolves to a cmd wrapper", () => {
-    const proc = createMockProcess();
+  it("uses a shell on Windows when a bare override resolves to a cmd wrapper", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
     vi.mocked(execFileSync).mockReturnValue(
       "C:\\tools\\codex-switch.cmd\r\n" as never,
     );
+
     const agent = new CodexAgent("/tmp/schema.json", {
       bin: "codex-switch",
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    await agent.run("test prompt", "/work/dir");
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex-switch",
@@ -122,7 +159,7 @@ describe("CodexAgent", () => {
   });
 
   it("kills the full process tree on Windows when aborted", async () => {
-    const proc = createMockProcess();
+    const proc = createMockProcess([]);
     Object.defineProperty(proc, "pid", { value: 6789 });
     mockSpawn.mockReturnValue(proc);
     const controller = new AbortController();
@@ -142,5 +179,33 @@ describe("CodexAgent", () => {
       { stdio: "ignore" },
     );
     expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it("rejects when codex exits with non-zero code", async () => {
+    const stderr = new Readable({
+      read() {},
+    }) as unknown as NodeJS.ReadableStream;
+    const stdout = Readable.from([]);
+    const proc = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      kill: vi.fn(),
+    }) as ReturnType<typeof spawn>;
+
+    mockSpawn.mockReturnValue(proc);
+
+    const agent = new CodexAgent("/tmp/schema.json", {
+      platform: "linux",
+    });
+
+    setImmediate(() => {
+      (stderr as EventEmitter).emit("data", Buffer.from("something went wrong"));
+      proc.emit("close", 1);
+    });
+
+    await expect(agent.run("test prompt", "/work/dir")).rejects.toThrow(
+      "codex exited with code 1: something went wrong",
+    );
   });
 });

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -7,11 +7,7 @@ import type {
   TokenUsage,
   AgentRunOptions,
 } from "./types.js";
-import {
-  parseJSONLStream,
-  setupAbortHandler,
-  setupChildProcessHandlers,
-} from "./stream-utils.js";
+import { consumeJSONLStream } from "./stream-utils.js";
 
 interface CodexItemCompleted {
   type: "item.completed";
@@ -33,6 +29,9 @@ interface CodexAgentDeps {
   bin?: string;
   platform?: NodeJS.Platform;
 }
+
+const CODEX_STARTUP_TIMEOUT_MS = 60_000;
+const MAX_STDERR_BUFFER = 64 * 1024;
 
 function shouldUseWindowsShell(
   bin: string,
@@ -97,53 +96,60 @@ export class CodexAgent implements Agent {
     this.schemaPath = schemaPath;
   }
 
-  run(
+  async run(
     prompt: string,
     cwd: string,
     options?: AgentRunOptions,
   ): Promise<AgentResult> {
     const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
 
-    return new Promise((resolve, reject) => {
-      const logStream = logPath ? createWriteStream(logPath) : null;
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
 
-      const child = spawn(
-        this.bin,
-        [
-          "exec",
-          prompt,
-          "--json",
-          "--output-schema",
-          this.schemaPath,
-          "--dangerously-bypass-approvals-and-sandbox",
-          "--color",
-          "never",
-        ],
-        {
-          cwd,
-          shell: shouldUseWindowsShell(this.bin, this.platform),
-          stdio: ["ignore", "pipe", "pipe"],
-          env: process.env,
-        },
-      );
+    const child = spawn(
+      this.bin,
+      [
+        "exec",
+        prompt,
+        "--json",
+        "--output-schema",
+        this.schemaPath,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--color",
+        "never",
+      ],
+      {
+        cwd,
+        shell: shouldUseWindowsShell(this.bin, this.platform),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      },
+    );
 
-      if (
-        setupAbortHandler(signal, child, reject, () =>
-          terminateCodexProcess(child, this.platform),
-        )
-      ) {
-        return;
+    let stderr = "";
+    const stderrHandler = (data: Buffer) => {
+      stderr += data.toString();
+      if (stderr.length > MAX_STDERR_BUFFER) {
+        stderr = stderr.slice(-MAX_STDERR_BUFFER);
       }
+    };
+    child.stderr?.on("data", stderrHandler);
 
-      let lastAgentMessage: string | null = null;
-      const cumulative: TokenUsage = {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-      };
+    let lastAgentMessage: string | null = null;
+    const cumulative: TokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
 
-      parseJSONLStream<CodexEvent>(child.stdout!, logStream, (event) => {
+    const streamPromise = consumeJSONLStream<CodexEvent>(
+      child,
+      logStream,
+      (event) => {
         if (
           event.type === "item.completed" &&
           "item" in event &&
@@ -160,25 +166,83 @@ export class CodexAgent implements Agent {
           cumulative.cacheReadTokens += u.cached_input_tokens ?? 0;
           onUsage?.({ ...cumulative });
         }
-      });
+      },
+    );
 
-      setupChildProcessHandlers(child, "codex", logStream, reject, () => {
-        if (!lastAgentMessage) {
-          reject(new Error("codex returned no agent message"));
-          return;
-        }
-
-        try {
-          const output = JSON.parse(lastAgentMessage) as AgentOutput;
-          resolve({ output, usage: cumulative });
-        } catch (err) {
-          reject(
-            new Error(
-              `Failed to parse codex output: ${err instanceof Error ? err.message : err}`,
-            ),
-          );
-        }
+    let exitCode: number | null = null;
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        child.stderr?.off("data", stderrHandler);
+        exitCode = code;
+        resolve(code);
       });
     });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        child.stderr?.off("data", stderrHandler);
+        reject(new Error(`Failed to spawn codex: ${err.message}`));
+      });
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateCodexProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateCodexProcess(child, this.platform);
+        reject(
+          new Error(
+            `codex did not produce output within ${CODEX_STARTUP_TIMEOUT_MS / 1000}s — it may be hanging on MCP startup or backpressure`,
+          ),
+        );
+      }, CODEX_STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    try {
+      await Promise.race([
+        Promise.all([streamPromise, exitPromise]),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`codex exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`codex exited with code ${exitCode}: ${stderr}`);
+    }
+
+    if (!lastAgentMessage) {
+      throw new Error("codex returned no agent message");
+    }
+
+    try {
+      const output = JSON.parse(lastAgentMessage) as AgentOutput;
+      return { output, usage: cumulative };
+    } catch (err) {
+      throw new Error(
+        `Failed to parse codex output: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 }

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -30,10 +30,23 @@ vi.mock("./rovodev.js", () => {
 });
 
 vi.mock("./opencode.js", () => {
+  const ServeBasedAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps: { name?: string } = {},
+  ) {
+    this.name = deps.name ?? "serve-agent";
+  });
   const OpenCodeAgent = vi.fn(function (this: Record<string, unknown>) {
     this.name = "opencode";
   });
-  return { OpenCodeAgent };
+  return { ServeBasedAgent, OpenCodeAgent };
+});
+
+vi.mock("./kilo.js", () => {
+  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "kilo";
+  });
+  return { KiloAgent };
 });
 
 import { createAgent } from "./factory.js";
@@ -41,6 +54,7 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -78,5 +92,11 @@ describe("createAgent", () => {
     const agent = createAgent("opencode", stubRunInfo);
     expect(OpenCodeAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("opencode");
+  });
+
+  it("creates a KiloAgent when name is 'kilo'", () => {
+    const agent = createAgent("kilo", stubRunInfo);
+    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("kilo");
   });
 });

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,6 +5,7 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
 
 export function createAgent(
   name: AgentName,
@@ -20,5 +21,7 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
+    case "kilo":
+      return new KiloAgent({ bin: pathOverride });
   }
 }

--- a/src/core/agents/kilo.test.ts
+++ b/src/core/agents/kilo.test.ts
@@ -1,0 +1,297 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { KiloAgent } from "./kilo.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  return proc as unknown as ChildProcessWithoutNullStreams;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sseResponse(chunks: string | string[]): Response {
+  const values = Array.isArray(chunks) ? chunks : [chunks];
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of values) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+function finalMessageResponse(
+  summary: string,
+  usage: { input: number; output: number; read: number; write: number },
+  messageId = "msg-123",
+) {
+  return jsonResponse({
+    info: {
+      id: messageId,
+      sessionID: "session-123",
+      role: "assistant",
+      structured: {
+        success: true,
+        summary,
+        key_changes_made: [],
+        key_learnings: [],
+      },
+      tokens: {
+        input: usage.input,
+        output: usage.output,
+        cache: {
+          read: usage.read,
+          write: usage.write,
+        },
+      },
+    },
+    parts: [
+      {
+        id: "part-final",
+        type: "text",
+        text: JSON.stringify({
+          success: true,
+          summary,
+          key_changes_made: [],
+          key_learnings: [],
+        }),
+        metadata: {
+          openai: {
+            phase: "final_answer",
+          },
+        },
+      },
+    ],
+  });
+}
+
+const SSE_SESSION_IDLE = `data: {"payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n`;
+
+describe("KiloAgent", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    tempDir = mkdtempSync(join(tmpdir(), "gnhf-kilo-test-"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses 'kilo' as the default binary name", () => {
+    const agent = new KiloAgent();
+    expect(agent.name).toBe("kilo");
+  });
+
+  it("accepts a custom binary path", () => {
+    const agent = new KiloAgent({ bin: "/custom/kilo" });
+    expect(agent.name).toBe("kilo");
+  });
+
+  it("spawns kilo serve with correct arguments", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      platform: "linux",
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    setTimeout(() => proc.emit("close", 0), 10);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await promise;
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "kilo",
+      expect.any(Array),
+      expect.objectContaining({ shell: false, detached: true }),
+    );
+  });
+
+  it("uses shell on Windows", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      platform: "win32",
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    setTimeout(() => proc.emit("close", 0), 10);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await promise;
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "kilo",
+      expect.any(Array),
+      expect.objectContaining({ shell: true, detached: false }),
+    );
+  });
+
+  it("reports token usage correctly", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 100,
+          output: 50,
+          read: 20,
+          write: 10,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+    });
+
+    const usageCalls: { inputTokens: number; outputTokens: number }[] = [];
+    const result = await agent.run("test prompt", "/work/dir", {
+      onUsage: (u) =>
+        usageCalls.push({
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+        }),
+    });
+
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.outputTokens).toBe(50);
+    expect(result.usage.cacheReadTokens).toBe(20);
+    expect(result.usage.cacheCreationTokens).toBe(10);
+  });
+
+  it("rejects when kilo exits before becoming ready", async () => {
+    vi.useRealTimers();
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    (proc.stderr as EventEmitter).emit("data", Buffer.from("binary not found"));
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow("kilo exited before becoming ready");
+  });
+
+  it("closes the server on close()", async () => {
+    const proc = createMockProcess();
+    let closeHandler: ((code: number | null) => void) | null = null;
+    proc.on = vi.fn((event: string, handler: unknown) => {
+      if (event === "close") {
+        closeHandler = handler as (code: number | null) => void;
+      }
+      return proc;
+    });
+
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      killProcess: () => {},
+    });
+
+    await agent.run("test prompt", "/work/dir");
+
+    closeHandler?.(0);
+
+    await agent.close();
+  });
+});

--- a/src/core/agents/kilo.ts
+++ b/src/core/agents/kilo.ts
@@ -1,0 +1,10 @@
+import type { ServeAgentDeps } from "./opencode.js";
+import { ServeBasedAgent } from "./opencode.js";
+
+export class KiloAgent extends ServeBasedAgent {
+  name = "kilo";
+
+  constructor(deps: ServeAgentDeps = {}) {
+    super({ ...deps, name: "kilo" });
+  }
+}

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -16,7 +16,7 @@ import {
 import { appendDebugLog } from "../debug-log.js";
 import { shutdownChildProcess } from "./managed-process.js";
 
-interface OpenCodeMessagePart {
+interface ServeMessagePart {
   type?: string;
   text?: string;
   metadata?: {
@@ -26,7 +26,7 @@ interface OpenCodeMessagePart {
   };
 }
 
-interface OpenCodeTokens {
+interface ServeTokens {
   input?: number;
   output?: number;
   cache?: {
@@ -35,21 +35,21 @@ interface OpenCodeTokens {
   };
 }
 
-interface OpenCodeMessageResponse {
+interface ServeMessageResponse {
   info?: {
     id?: string;
     role?: string;
     structured?: AgentOutput;
-    tokens?: OpenCodeTokens;
+    tokens?: ServeTokens;
   };
-  parts?: OpenCodeMessagePart[];
+  parts?: ServeMessagePart[];
 }
 
-interface OpenCodeSessionResponse {
+interface ServeSessionResponse {
   id: string;
 }
 
-interface OpenCodeStreamEvent {
+interface ServeStreamEvent {
   directory?: string;
   payload?: {
     type?: string;
@@ -63,7 +63,7 @@ interface OpenCodeStreamEvent {
         messageID?: string;
         type?: string;
         text?: string;
-        tokens?: OpenCodeTokens;
+        tokens?: ServeTokens;
         metadata?: {
           openai?: {
             phase?: string;
@@ -73,13 +73,13 @@ interface OpenCodeStreamEvent {
       info?: {
         id?: string;
         role?: string;
-        tokens?: OpenCodeTokens;
+        tokens?: ServeTokens;
       };
     };
   };
 }
 
-interface OpenCodeDeps {
+export interface ServeAgentDeps {
   bin?: string;
   fetch?: typeof fetch;
   getPort?: () => Promise<number>;
@@ -88,7 +88,7 @@ interface OpenCodeDeps {
   spawn?: typeof spawn;
 }
 
-interface OpenCodeServer {
+export interface ServeAgentServer {
   baseUrl: string;
   child: ChildProcessWithoutNullStreams;
   closed: boolean;
@@ -108,7 +108,7 @@ interface RequestOptions {
   timeoutMs?: number;
 }
 
-interface OpenCodeTextPartState {
+interface ServeTextPartState {
   phase?: string;
   text: string;
 }
@@ -127,7 +127,7 @@ const STRUCTURED_OUTPUT_FORMAT = {
   retryCount: 1,
 } as const;
 
-function buildOpencodeChildEnv(): NodeJS.ProcessEnv {
+function buildServeChildEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   delete env.OPENCODE_SERVER_USERNAME;
   delete env.OPENCODE_SERVER_PASSWORD;
@@ -145,11 +145,6 @@ function buildPrompt(prompt: string): string {
   ].join("\n");
 }
 
-/**
- * On Windows with `shell: true`, `child.pid` is the `cmd.exe` wrapper, not
- * the actual server process.  `taskkill /T` terminates the entire process
- * tree rooted at that PID so the real server doesn't survive shutdown.
- */
 async function killWindowsProcessTree(pid: number): Promise<void> {
   try {
     execFileSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
@@ -172,7 +167,7 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
-function getAvailablePort(): Promise<number> {
+function getAvailablePort(label: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.unref();
@@ -181,7 +176,7 @@ function getAvailablePort(): Promise<number> {
       const address = server.address();
       if (!address || typeof address === "string") {
         server.close();
-        reject(new Error("Failed to allocate a port for opencode"));
+        reject(new Error(`Failed to allocate a port for ${label}`));
         return;
       }
 
@@ -223,7 +218,7 @@ async function delay(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-function toUsage(tokens?: OpenCodeTokens): TokenUsage {
+function toUsage(tokens?: ServeTokens): TokenUsage {
   return {
     inputTokens: tokens?.input ?? 0,
     outputTokens: tokens?.output ?? 0,
@@ -242,22 +237,59 @@ function withTimeoutSignal(
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
-export class OpenCodeAgent implements Agent {
-  name = "opencode";
+export class ServeBasedAgent implements Agent {
+  name: string;
 
-  private bin: string;
-  private fetchFn: typeof fetch;
-  private getPortFn: () => Promise<number>;
-  private killProcessFn: typeof process.kill;
-  private platform: NodeJS.Platform;
-  private spawnFn: typeof spawn;
-  private server: OpenCodeServer | null = null;
-  private closingPromise: Promise<void> | null = null;
+  protected bin: string;
+  protected fetchFn: typeof fetch;
+  protected getPortFn: () => Promise<number>;
+  protected killProcessFn: typeof process.kill;
+  protected platform: NodeJS.Platform;
+  protected spawnFn: typeof spawn;
+  protected server: ServeAgentServer | null = null;
+  protected closingPromise: Promise<void> | null = null;
 
-  constructor(deps: OpenCodeDeps = {}) {
-    this.bin = deps.bin ?? "opencode";
+  protected get debugLogPrefix(): string {
+    return this.name;
+  }
+
+  protected get portLabel(): string {
+    return this.name;
+  }
+
+  protected get spawnErrorMessage(): string {
+    return `Failed to spawn ${this.name}`;
+  }
+
+  protected get exitedErrorMessage(): string {
+    return `${this.name} exited before becoming ready`;
+  }
+
+  protected get noStreamBodyError(): string {
+    return `${this.name} returned no event stream body`;
+  }
+
+  protected get noTextOutputError(): string {
+    return `${this.name} returned no text output`;
+  }
+
+  protected get parseResponseError(): string {
+    return `Failed to parse ${this.name} response`;
+  }
+
+  protected get parseOutputError(): string {
+    return `Failed to parse ${this.name} output`;
+  }
+
+  protected get requestErrorPrefix(): string {
+    return this.name;
+  }
+
+  constructor(deps: ServeAgentDeps & { name?: string } = {}) {
+    this.name = deps.name ?? "serve-agent";
+    this.bin = deps.bin ?? this.name;
     this.fetchFn = deps.fetch ?? fetch;
-    this.getPortFn = deps.getPort ?? getAvailablePort;
+    this.getPortFn = deps.getPort ?? (() => getAvailablePort(this.portLabel));
     this.killProcessFn = deps.killProcess ?? process.kill.bind(process);
     this.platform = deps.platform ?? process.platform;
     this.spawnFn = deps.spawn ?? spawn;
@@ -317,10 +349,10 @@ export class OpenCodeAgent implements Agent {
     await this.shutdownServer();
   }
 
-  private async ensureServer(
+  protected async ensureServer(
     cwd: string,
     signal?: AbortSignal,
-  ): Promise<OpenCodeServer> {
+  ): Promise<ServeAgentServer> {
     if (this.server && !this.server.closed) {
       if (this.server.cwd !== cwd) {
         await this.shutdownServer();
@@ -328,11 +360,6 @@ export class OpenCodeAgent implements Agent {
         await this.server.readyPromise;
         return this.server;
       }
-    }
-
-    if (this.server && !this.server.closed) {
-      await this.server.readyPromise;
-      return this.server;
     }
 
     const port = await this.getPortFn();
@@ -353,11 +380,11 @@ export class OpenCodeAgent implements Agent {
         detached,
         shell: isWindows,
         stdio: ["ignore", "pipe", "pipe"],
-        env: buildOpencodeChildEnv(),
+        env: buildServeChildEnv(),
       },
     ) as unknown as ChildProcessWithoutNullStreams;
 
-    const server: OpenCodeServer = {
+    const server: ServeAgentServer = {
       baseUrl: `http://127.0.0.1:${port}`,
       child,
       closed: false,
@@ -392,7 +419,7 @@ export class OpenCodeAgent implements Agent {
     });
 
     this.server = server;
-    appendDebugLog("opencode:spawn", { cwd, port, detached });
+    appendDebugLog(`${this.debugLogPrefix}:spawn`, { cwd, port, detached });
     server.readyPromise = this.waitForHealthy(server, signal).catch(
       async (error) => {
         await this.shutdownServer();
@@ -404,61 +431,72 @@ export class OpenCodeAgent implements Agent {
     return server;
   }
 
-  private async waitForHealthy(
-    server: OpenCodeServer,
+  protected async waitForHealthy(
+    server: ServeAgentServer,
     signal?: AbortSignal,
   ): Promise<void> {
-    const deadline = Date.now() + 30_000;
-    let spawnErrorMessage: string | null = null;
+    const timeoutController = new AbortController();
+    const timeoutTimer = setTimeout(() => {
+      timeoutController.abort();
+    }, 30_000);
+    const combined = signal
+      ? AbortSignal.any([signal, timeoutController.signal])
+      : timeoutController.signal.signal;
+    let spawnErr: string | null = null;
 
     server.child.once("error", (error) => {
-      spawnErrorMessage = error.message;
+      spawnErr = error.message;
     });
 
-    while (Date.now() < deadline) {
-      if (signal?.aborted) {
-        throw createAbortError();
-      }
-
-      if (spawnErrorMessage) {
-        throw new Error(`Failed to spawn opencode: ${spawnErrorMessage}`);
-      }
-
-      if (server.closed) {
-        const output = server.stderr.trim() || server.stdout.trim();
-        throw new Error(
-          output
-            ? `opencode exited before becoming ready: ${output}`
-            : "opencode exited before becoming ready",
-        );
-      }
-
-      try {
-        const response = await this.fetchFn(`${server.baseUrl}/global/health`, {
-          method: "GET",
-          signal,
-        });
-        if (response.ok) return;
-      } catch (error) {
-        if (isAbortError(error)) {
-          throw createAbortError();
+    const poll = async (): Promise<void> => {
+      while (!combined.aborted) {
+        if (spawnErr) {
+          throw new Error(`${this.spawnErrorMessage}: ${spawnErr}`);
         }
+
+        if (server.closed) {
+          const output = server.stderr.trim() || server.stdout.trim();
+          throw new Error(
+            output
+              ? `${this.exitedErrorMessage}: ${output}`
+              : this.exitedErrorMessage,
+          );
+        }
+
+        try {
+          const response = await this.fetchFn(
+            `${server.baseUrl}/global/health`,
+            {
+              method: "GET",
+              signal: combined,
+            },
+          );
+          if (response.ok) {
+            clearTimeout(timeoutTimer);
+            return;
+          }
+        } catch (error) {
+          if (isAbortError(error)) {
+            throw createAbortError();
+          }
+        }
+
+        await delay(250, combined);
       }
 
-      await delay(250, signal);
-    }
+      clearTimeout(timeoutTimer);
+      throw createAbortError();
+    };
 
-    throw new Error(
-      `Timed out waiting for opencode serve to become ready on port ${server.port}`,
-    );
+    await poll();
   }
 
-  private async createSession(
-    server: OpenCodeServer,
+  protected async createSession(
+    server: ServeAgentServer,
     cwd: string,
     signal?: AbortSignal,
   ): Promise<string> {
-    const response = await this.requestJSON<OpenCodeSessionResponse>(
+    const response = await this.requestJSON<ServeSessionResponse>(
       server,
       "/session",
       {
@@ -474,8 +512,8 @@ export class OpenCodeAgent implements Agent {
     return response.id;
   }
 
-  private async streamMessage(
-    server: OpenCodeServer,
+  protected async streamMessage(
+    server: ServeAgentServer,
     sessionId: string,
     prompt: string,
     signal: AbortSignal,
@@ -495,7 +533,7 @@ export class OpenCodeAgent implements Agent {
     });
 
     if (!eventResponse.body) {
-      throw new Error("opencode returned no event stream body");
+      throw new Error(this.noStreamBodyError);
     }
 
     let messageRequestError: unknown = null;
@@ -528,44 +566,42 @@ export class OpenCodeAgent implements Agent {
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
     };
-    const usageByMessageId = new Map<string, TokenUsage>();
-    const textParts = new Map<string, OpenCodeTextPartState>();
+    const prevUsageByMessageId = new Map<string, TokenUsage>();
+    const textParts = new Map<string, ServeTextPartState>();
     let lastText: string | null = null;
     let lastFinalAnswerText: string | null = null;
-    let lastUsageSignature = "0:0:0:0";
 
     const updateUsage = (
       messageId: string | undefined,
-      tokens?: OpenCodeTokens,
+      tokens?: ServeTokens,
     ) => {
       if (!messageId || !tokens) return;
-      usageByMessageId.set(messageId, toUsage(tokens));
-
-      let nextInputTokens = 0;
-      let nextOutputTokens = 0;
-      let nextCacheReadTokens = 0;
-      let nextCacheCreationTokens = 0;
-      for (const messageUsage of usageByMessageId.values()) {
-        nextInputTokens += messageUsage.inputTokens;
-        nextOutputTokens += messageUsage.outputTokens;
-        nextCacheReadTokens += messageUsage.cacheReadTokens;
-        nextCacheCreationTokens += messageUsage.cacheCreationTokens;
+      const prev = prevUsageByMessageId.get(messageId) ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      };
+      const next = toUsage(tokens);
+      const dInput = next.inputTokens - prev.inputTokens;
+      const dOutput = next.outputTokens - prev.outputTokens;
+      const dCacheRead = next.cacheReadTokens - prev.cacheReadTokens;
+      const dCacheWrite = next.cacheCreationTokens - prev.cacheCreationTokens;
+      if (
+        dInput === 0 &&
+        dOutput === 0 &&
+        dCacheRead === 0 &&
+        dCacheWrite === 0
+      ) {
+        prevUsageByMessageId.set(messageId, next);
+        return;
       }
-
-      const signature = [
-        nextInputTokens,
-        nextOutputTokens,
-        nextCacheReadTokens,
-        nextCacheCreationTokens,
-      ].join(":");
-      usage.inputTokens = nextInputTokens;
-      usage.outputTokens = nextOutputTokens;
-      usage.cacheReadTokens = nextCacheReadTokens;
-      usage.cacheCreationTokens = nextCacheCreationTokens;
-      if (signature !== lastUsageSignature) {
-        lastUsageSignature = signature;
-        onUsage?.({ ...usage });
-      }
+      usage.inputTokens += dInput;
+      usage.outputTokens += dOutput;
+      usage.cacheReadTokens += dCacheRead;
+      usage.cacheCreationTokens += dCacheWrite;
+      prevUsageByMessageId.set(messageId, next);
+      onUsage?.({ ...usage });
     };
 
     const emitText = (partId: string, nextText: string, phase?: string) => {
@@ -579,7 +615,7 @@ export class OpenCodeAgent implements Agent {
       onMessage?.(trimmed);
     };
 
-    const handleEvent = (event: OpenCodeStreamEvent) => {
+    const handleEvent = (event: ServeStreamEvent) => {
       const payload = event.payload;
       const properties = payload?.properties;
       if (!properties || properties.sessionID !== sessionId) return false;
@@ -634,14 +670,18 @@ export class OpenCodeAgent implements Agent {
     const processRawEvent = (rawEvent: string) => {
       if (!rawEvent.trim()) return;
 
-      const dataLines = rawEvent
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice("data:".length).trimStart());
-      if (dataLines.length === 0) return;
+      let dataContent = "";
+      for (const line of rawEvent.split(/\r?\n/)) {
+        if (line.startsWith("data:")) {
+          const content = line.slice(5).trimStart();
+          if (dataContent) dataContent += "\n";
+          dataContent += content;
+        }
+      }
+      if (!dataContent) return;
 
       try {
-        const event = JSON.parse(dataLines.join("\n")) as OpenCodeStreamEvent;
+        const event = JSON.parse(dataContent) as ServeStreamEvent;
         if (handleEvent(event)) {
           sawSessionIdle = true;
         }
@@ -719,6 +759,7 @@ export class OpenCodeAgent implements Agent {
     } finally {
       streamAbortController.abort();
       await reader.cancel().catch(() => undefined);
+      textParts.clear();
     }
 
     const messageResult = await messageRequest;
@@ -733,12 +774,12 @@ export class OpenCodeAgent implements Agent {
     }
 
     const body = messageResult.body;
-    let response: OpenCodeMessageResponse;
+    let response: ServeMessageResponse;
     try {
-      response = JSON.parse(body) as OpenCodeMessageResponse;
+      response = JSON.parse(body) as ServeMessageResponse;
     } catch (error) {
       throw new Error(
-        `Failed to parse opencode response: ${error instanceof Error ? error.message : String(error)}`,
+        `${this.parseResponseError}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
@@ -755,6 +796,8 @@ export class OpenCodeAgent implements Agent {
       }
     }
 
+    prevUsageByMessageId.clear();
+
     if (response.info?.structured) {
       return {
         output: response.info.structured,
@@ -764,7 +807,7 @@ export class OpenCodeAgent implements Agent {
 
     const outputText = lastFinalAnswerText ?? lastText;
     if (!outputText) {
-      throw new Error("opencode returned no text output");
+      throw new Error(this.noTextOutputError);
     }
 
     try {
@@ -774,13 +817,13 @@ export class OpenCodeAgent implements Agent {
       };
     } catch (error) {
       throw new Error(
-        `Failed to parse opencode output: ${error instanceof Error ? error.message : String(error)}`,
+        `${this.parseOutputError}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
 
-  private async deleteSession(
-    server: OpenCodeServer,
+  protected async deleteSession(
+    server: ServeAgentServer,
     sessionId: string,
   ): Promise<void> {
     try {
@@ -793,8 +836,8 @@ export class OpenCodeAgent implements Agent {
     }
   }
 
-  private async abortSession(
-    server: OpenCodeServer,
+  protected async abortSession(
+    server: ServeAgentServer,
     sessionId: string,
   ): Promise<void> {
     try {
@@ -807,7 +850,7 @@ export class OpenCodeAgent implements Agent {
     }
   }
 
-  private async shutdownServer(): Promise<void> {
+  protected async shutdownServer(): Promise<void> {
     if (!this.server || this.server.closed) {
       this.server = null;
       return;
@@ -819,7 +862,10 @@ export class OpenCodeAgent implements Agent {
     }
 
     const server = this.server;
-    appendDebugLog("opencode:shutdown", { cwd: server.cwd, port: server.port });
+    appendDebugLog(`${this.debugLogPrefix}:shutdown`, {
+      cwd: server.cwd,
+      port: server.port,
+    });
 
     this.closingPromise = (
       this.platform === "win32" && server.child.pid
@@ -839,8 +885,8 @@ export class OpenCodeAgent implements Agent {
     await this.closingPromise;
   }
 
-  private async requestJSON<T>(
-    server: OpenCodeServer,
+  protected async requestJSON<T>(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<T> {
@@ -848,8 +894,8 @@ export class OpenCodeAgent implements Agent {
     return JSON.parse(body) as T;
   }
 
-  private async requestText(
-    server: OpenCodeServer,
+  protected async requestText(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<string> {
@@ -857,14 +903,20 @@ export class OpenCodeAgent implements Agent {
     return await response.text();
   }
 
-  private async request(
-    server: OpenCodeServer,
+  protected async request(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<Response> {
-    const headers = new Headers(options.headers);
+    const headers: Record<string, string> = {};
     if (options.body !== undefined) {
-      headers.set("content-type", "application/json");
+      headers["content-type"] = "application/json";
+    }
+    if (options.headers) {
+      const h = options.headers as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        headers[k] = v;
+      }
     }
 
     const signal = withTimeoutSignal(options.signal, options.timeoutMs);
@@ -877,12 +929,25 @@ export class OpenCodeAgent implements Agent {
     });
 
     if (!response.ok) {
-      const body = await response.text();
+      let body = "";
+      try {
+        body = await response.text();
+      } catch {
+        body = "[could not read body]";
+      }
       throw new Error(
-        `opencode ${options.method} ${path} failed with ${response.status}: ${body}`,
+        `${this.requestErrorPrefix} ${options.method} ${path} failed with ${response.status}: ${body}`,
       );
     }
 
     return response;
+  }
+}
+
+export class OpenCodeAgent extends ServeBasedAgent {
+  name = "opencode";
+
+  constructor(deps: ServeAgentDeps = {}) {
+    super({ ...deps, name: "opencode" });
   }
 }

--- a/src/core/agents/stream-utils.ts
+++ b/src/core/agents/stream-utils.ts
@@ -2,6 +2,8 @@ import type { ChildProcess } from "node:child_process";
 import type { Readable } from "node:stream";
 import type { WriteStream } from "node:fs";
 
+const MAX_STDERR_BUFFER = 64 * 1024;
+
 /**
  * Wire stderr collection, spawn-error handling, and the common close-handler
  * prefix (logStream.end + non-zero exit code rejection) for a child process.
@@ -16,15 +18,21 @@ export function setupChildProcessHandlers(
 ): void {
   let stderr = "";
 
-  child.stderr!.on("data", (data: Buffer) => {
+  const stderrHandler = (data: Buffer) => {
     stderr += data.toString();
-  });
+    if (stderr.length > MAX_STDERR_BUFFER) {
+      stderr = stderr.slice(-MAX_STDERR_BUFFER);
+    }
+  };
+  child.stderr!.on("data", stderrHandler);
 
   child.on("error", (err) => {
+    child.stderr?.off("data", stderrHandler);
     reject(new Error(`Failed to spawn ${agentName}: ${err.message}`));
   });
 
   child.on("close", (code) => {
+    child.stderr?.off("data", stderrHandler);
     logStream?.end();
     if (code !== 0) {
       reject(new Error(`${agentName} exited with code ${code}: ${stderr}`));
@@ -37,14 +45,15 @@ export function setupChildProcessHandlers(
 /**
  * Parse a JSONL stream, calling the callback for each parsed event.
  * Handles buffering of incomplete lines and skips unparseable lines.
+ * Returns a cleanup function to remove the data listener.
  */
 export function parseJSONLStream<T>(
   stream: Readable,
   logStream: WriteStream | null,
   callback: (event: T) => void,
-): void {
+): () => void {
   let buffer = "";
-  stream.on("data", (data: Buffer) => {
+  const handler = (data: Buffer) => {
     logStream?.write(data);
     buffer += data.toString();
     const lines = buffer.split("\n");
@@ -58,7 +67,77 @@ export function parseJSONLStream<T>(
         // Skip unparseable lines
       }
     }
+  };
+  stream.on("data", handler);
+  return () => stream.off("data", handler);
+}
+
+/**
+ * Async JSONL stream parser that properly handles backpressure.
+ * Uses `for await...of` on the stream to ensure the consumer
+ * controls the flow and prevents pipe-buffer deadlock.
+ *
+ * Drains stderr concurrently to prevent the child from blocking
+ * on stderr writes.
+ */
+export async function consumeJSONLStream<T>(
+  child: ChildProcess,
+  logStream: WriteStream | null,
+  onEvent: (event: T) => void,
+): Promise<void> {
+  const stdout = child.stdout;
+  const stderr = child.stderr;
+
+  if (!stdout) {
+    throw new Error("Child process has no stdout");
+  }
+
+  // Drain stderr by putting it into flowing mode without a listener.
+  // This prevents backpressure on stderr from blocking the child process.
+  if (stderr) {
+    stderr.resume();
+  }
+
+  // Propagate child process errors (e.g., spawn failures) through the stream.
+  const errorPromise = new Promise<never>((_, reject) => {
+    child.once("error", (err) => {
+      stdout.destroy();
+      reject(new Error(`Child process error: ${err.message}`));
+    });
   });
+
+  let buffer = "";
+
+  const consume = async () => {
+    for await (const chunk of stdout) {
+      const text = chunk.toString();
+      logStream?.write(text);
+      buffer += text;
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          onEvent(JSON.parse(line) as T);
+        } catch {
+          // Skip unparseable lines
+        }
+      }
+    }
+
+    // Process any remaining buffer after stream ends.
+    if (buffer.trim()) {
+      try {
+        onEvent(JSON.parse(buffer) as T);
+      } catch {
+        // Skip unparseable trailing data
+      }
+    }
+  };
+
+  await Promise.race([consume(), errorPromise]);
 }
 
 /**
@@ -75,7 +154,10 @@ export function setupAbortHandler(
 ): boolean {
   if (!signal) return false;
 
+  let settled = false;
   const onAbort = () => {
+    if (settled) return;
+    settled = true;
     abortChild();
     reject(new Error("Agent was aborted"));
   };
@@ -84,6 +166,9 @@ export function setupAbortHandler(
     return true;
   }
   signal.addEventListener("abort", onAbort, { once: true });
-  child.on("close", () => signal.removeEventListener("abort", onAbort));
+  child.on("close", () => {
+    settled = true;
+    signal.removeEventListener("abort", onAbort);
+  });
   return false;
 }

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import type {
+  Agent,
+  AgentResult,
+  AgentOutput,
+  TokenUsage,
+  AgentRunOptions,
+} from "./types.js";
+
+const MAX_OUTPUT_BUFFER = 256 * 1024;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ANSI_ESCAPE_RE =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (/\.(cmd|bat)$/i.test(bin)) return true;
+  if (/[\\/]/.test(bin)) return false;
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort
+    }
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+export interface TextBasedAgentDeps {
+  bin?: string;
+  platform?: NodeJS.Platform;
+}
+
+export abstract class TextBasedAgent implements Agent {
+  abstract name: string;
+
+  protected bin: string;
+  protected platform: NodeJS.Platform;
+
+  constructor(bin: string, deps: TextBasedAgentDeps = {}) {
+    this.bin = deps.bin ?? bin;
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  protected abstract buildArgs(prompt: string): string[];
+  protected abstract parseOutput(stdout: string): AgentOutput;
+  protected abstract parseUsage(stdout: string): TokenUsage;
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
+
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
+
+    const child = spawn(this.bin, this.buildArgs(prompt), {
+      cwd,
+      shell: shouldUseWindowsShell(this.bin, this.platform),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stdout += text;
+      if (stdout.length > MAX_OUTPUT_BUFFER) {
+        stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
+      }
+      logStream?.write(data);
+      const cleaned = stripAnsi(text).trim();
+      if (cleaned) onMessage?.(cleaned);
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+      logStream?.write(data);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateProcess(child, this.platform);
+        reject(
+          new Error(
+            `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
+          ),
+        );
+      }, STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        resolve(code);
+      });
+    });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        reject(new Error(`Failed to spawn ${this.name}: ${err.message}`));
+      });
+    });
+
+    let exitCode: number | null = null;
+
+    try {
+      const result = await Promise.race([
+        exitPromise.then((code) => {
+          exitCode = code;
+          return { done: true } as const;
+        }),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+
+      if ("done" in result) {
+        // Process completed normally
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+    }
+
+    const cleaned = stripAnsi(stdout);
+    let output: AgentOutput;
+    try {
+      output = this.parseOutput(cleaned);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${this.name} output: ${err instanceof Error ? err.message : err}\n\nRaw output (last 500 chars):\n${cleaned.slice(-500)}`,
+      );
+    }
+
+    const usage = this.parseUsage(cleaned);
+    if (onUsage && Object.values(usage).some((v) => v > 0)) {
+      onUsage(usage);
+    }
+
+    return { output, usage };
+  }
+}

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -49,3 +49,59 @@ export interface Agent {
     options?: AgentRunOptions,
   ): Promise<AgentResult>;
 }
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,9 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
+export type AgentName = "claude" | "codex" | "rovodev" | "opencode" | "kilo";
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
+const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode", "kilo"] as const;
 
 export interface Config {
   agent: AgentName;
@@ -79,7 +79,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
       );
     }
     if (typeof val !== "string") {


### PR DESCRIPTION
## Summary
This is the foundation PR for the split stack. It extracts and hardens the shared agent infrastructure that later PRs build on, so reviewers can evaluate the plumbing once instead of re-reviewing it mixed into every agent addition.

Concretely, this PR:
- extracts reusable serve-mode logic from `OpenCodeAgent` into `ServeBasedAgent`
- keeps the Codex stream and backpressure hardening work
- adds the shared `TextBasedAgent` base for headless CLI agents
- adds the shared `AsyncAgentAdapter` for polling-style remote agents
- adds Kilo support as a thin serve-based subclass

## Why This Is Separate
The original unified branch mixed shared abstractions, multiple new agents, Jules product behavior, docs, and a Windows cleanup fix into one review. This PR isolates the low-level infrastructure so later reviews can focus on agent behavior and user-facing Jules changes instead of reading through shared runtime code repeatedly.

## In Scope
- `ServeBasedAgent` extraction from `OpenCodeAgent`
- Codex stream handling hardening and related utilities
- `TextBasedAgent`, `AsyncAgentAdapter`, and shared agent type updates
- Kilo support and tests

## Out Of Scope
- Gemini, Copilot, and Junie agent implementations
- Jules API/client behavior and Jules product wiring
- Jules visibility/setup gating
- Windows serve-agent shutdown fallback and E2E restoration

## Reviewer Notes
Review this PR for:
- abstraction boundaries and reuse quality
- process lifecycle and stream handling correctness
- whether the new shared agent primitives are minimal and sensible
- whether Kilo is an appropriate thin subclass on top of the serve-mode base

## Follow-up PRs
- Fork stack PR 2: https://github.com/w0wl0lxd/gnhf/pull/2
- Fork stack PR 3: https://github.com/w0wl0lxd/gnhf/pull/1

## Testing
- `npx vitest run src/core/agents/opencode.test.ts src/core/agents/codex.test.ts src/core/agents/text-based-agent.test.ts src/core/agents/async-adapter.test.ts src/core/agents/kilo.test.ts`
