### PR TITLE
Gate Jules tooling and fix Windows cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 
 - **Dead simple** — one command starts an autonomous loop that runs until you Ctrl+C or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries and exponential backoff
-- **Agent-agnostic** — works with Claude Code, Codex, Rovo Dev, or OpenCode out of the box
+- **Agent-agnostic** — works with Claude Code, Codex, Kilo Code, Rovo Dev, or OpenCode out of the box
 
 ## Quick Start
 
@@ -146,7 +146,7 @@ npm link
 
 | Flag                     | Description                                                        | Default                |
 | ------------------------ | ------------------------------------------------------------------ | ---------------------- |
-| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)         | config file (`claude`) |
+| `--agent <agent>`        | Agent to use (`claude`, `codex`, `kilo`, `rovodev`, or `opencode`) | config file (`claude`) |
 | `--max-iterations <n>`   | Abort after `n` total iterations                                   | unlimited              |
 | `--max-tokens <n>`       | Abort after `n` total input+output tokens                          | unlimited              |
 | `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`) | config file (`on`)     |
@@ -157,7 +157,7 @@ npm link
 Config lives at `~/.gnhf/config.yml`:
 
 ```yaml
-# Agent to use by default (claude, codex, rovodev, or opencode)
+# Agent to use by default (claude, codex, kilo, rovodev, or opencode)
 agent: claude
 
 # Custom paths to agent binaries (optional)
@@ -200,14 +200,15 @@ GNHF_DEBUG_LOG_PATH=/tmp/gnhf-debug.jsonl gnhf "ship it"
 
 ## Agents
 
-`gnhf` supports four agents:
+`gnhf` supports five agents:
 
-| Agent       | Flag               | Requirements                                                               | Notes                                                                                                                                                                                                            |
-| ----------- | ------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                        | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
-| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                            | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
-| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.        | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
-| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first. | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
+| Agent       | Flag               | Requirements                                                                           | Notes                                                                                                                                                                                                            |
+| ----------- | ------------------ | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                                    | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
+| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                                        | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
+| Kilo Code   | `--agent kilo`     | Install Kilo Code CLI (`npm install -g @kilocode/cli`) and configure a provider first. | `gnhf` starts a local `kilo serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.     |
+| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.                    | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
+| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first.             | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 
 - **Dead simple** — one command starts an autonomous loop that runs until you Ctrl+C or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries and exponential backoff
-- **Agent-agnostic** — works with Claude Code, Codex, Kilo Code, Rovo Dev, or OpenCode out of the box
+- **Agent-agnostic** — works with Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, JetBrains Junie, Jules, Kilo Code, Rovo Dev, or OpenCode out of the box
 
 ## Quick Start
 
@@ -146,7 +146,7 @@ npm link
 
 | Flag                     | Description                                                        | Default                |
 | ------------------------ | ------------------------------------------------------------------ | ---------------------- |
-| `--agent <agent>`        | Agent to use (`claude`, `codex`, `kilo`, `rovodev`, or `opencode`) | config file (`claude`) |
+| `--agent <agent>`        | Agent to use (`claude`, `codex`, `gemini`, `copilot`, `junie`, `jules`, `kilo`, `rovodev`, or `opencode`) | config file (`claude`) |
 | `--max-iterations <n>`   | Abort after `n` total iterations                                   | unlimited              |
 | `--max-tokens <n>`       | Abort after `n` total input+output tokens                          | unlimited              |
 | `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`) | config file (`on`)     |
@@ -157,7 +157,7 @@ npm link
 Config lives at `~/.gnhf/config.yml`:
 
 ```yaml
-# Agent to use by default (claude, codex, kilo, rovodev, or opencode)
+# Agent to use by default (claude, codex, gemini, copilot, junie, jules, kilo, rovodev, or opencode)
 agent: claude
 
 # Custom paths to agent binaries (optional)
@@ -200,15 +200,21 @@ GNHF_DEBUG_LOG_PATH=/tmp/gnhf-debug.jsonl gnhf "ship it"
 
 ## Agents
 
-`gnhf` supports five agents:
+`gnhf` supports nine agents:
 
-| Agent       | Flag               | Requirements                                                                           | Notes                                                                                                                                                                                                            |
-| ----------- | ------------------ | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                                    | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
-| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                                        | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
-| Kilo Code   | `--agent kilo`     | Install Kilo Code CLI (`npm install -g @kilocode/cli`) and configure a provider first. | `gnhf` starts a local `kilo serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.     |
-| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.                    | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
-| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first.             | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
+| Agent                | Flag                 | Requirements                                                                                      | Notes                                                                                                                                                                                                            |
+| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code          | `--agent claude`     | Install Anthropic's `claude` CLI and sign in first.                                               | `gnhf` invokes `claude` directly in non-interactive mode.                                                                                                                                                        |
+| Codex                | `--agent codex`      | Install OpenAI's `codex` CLI and sign in first.                                                   | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                    |
+| Gemini CLI           | `--agent gemini`     | Install Google's `gemini` CLI and authenticate it first.                                          | `gnhf` invokes `gemini -p ... --output-format json` directly in non-interactive mode.                                                                                                                           |
+| GitHub Copilot CLI   | `--agent copilot`    | Install the GitHub Copilot CLI and authenticate it first.                                         | `gnhf` invokes Copilot CLI in autopilot mode with the structured-output prompt.                                                                                                                                  |
+| JetBrains Junie      | `--agent junie`      | Install the Junie CLI and authenticate it first.                                                  | `gnhf` invokes Junie directly in non-interactive task mode.                                                                                                                                                      |
+| Jules                | `--agent jules`      | Configure Jules access and set `JULES_API_KEY` if your Jules environment requires it.             | `gnhf` submits a cloud Jules session, polls it asynchronously, and records the final summary plus PR URL when available. Because Jules runs remotely, is slower than local work, and creates its own branch/PR, reserve it for isolated longer-running tasks where that separate handoff is valuable. |
+| Kilo Code            | `--agent kilo`       | Install Kilo Code CLI (`npm install -g @kilocode/cli`) and configure a provider first.            | `gnhf` starts a local `kilo serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.     |
+| Rovo Dev             | `--agent rovodev`    | Install Atlassian's `acli` and authenticate it with Rovo Dev first.                               | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                           |
+| OpenCode             | `--agent opencode`   | Install `opencode` and configure at least one usable model provider first.                        | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts. |
+
+All agents receive the same iteration prompt. That prompt explicitly allows using Jules CLI/tooling when the remote branch/PR handoff is worth the overhead, but the active agent still owns validation and the final JSON response. In practice, Jules is best for isolated longer-running tasks, parallelizable research or implementation spikes, and self-contained refactors. Keep quick edits, tight test loops, and branch-local iteration in the active local agent.
 
 ## Development
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -217,7 +217,10 @@ describe("cli", () => {
       preventSleep: false,
     });
 
-    expect(loadConfig).toHaveBeenCalledWith({});
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: undefined,
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("codex", stubRunInfo, undefined);
   });
 
@@ -232,7 +235,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "claude" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "claude",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("claude", stubRunInfo, undefined);
   });
 
@@ -247,7 +253,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "rovodev" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "rovodev",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith("rovodev", stubRunInfo, undefined);
   });
 
@@ -262,7 +271,10 @@ describe("cli", () => {
       },
     );
 
-    expect(loadConfig).toHaveBeenCalledWith({ agent: "opencode" });
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: "opencode",
+      preventSleep: undefined,
+    });
     expect(createAgent).toHaveBeenCalledWith(
       "opencode",
       stubRunInfo,
@@ -297,7 +309,10 @@ describe("cli", () => {
         preventSleep: false,
       });
 
-    expect(loadConfig).toHaveBeenCalledWith({});
+    expect(loadConfig).toHaveBeenCalledWith({
+      agent: undefined,
+      preventSleep: false,
+    });
     expect(startSleepPrevention).not.toHaveBeenCalled();
     expect(orchestratorCtor).toHaveBeenCalledTimes(1);
     expect(orchestratorCtor.mock.calls[0]?.[0]).toEqual({

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -49,6 +49,9 @@ async function runCliWithMocks(
   const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
     code?: string | number | null,
   ) => {
+    if (code === 0 || code === undefined) {
+      return undefined as never;
+    }
     throw new Error(
       `process.exit unexpectedly called with ${JSON.stringify(code)}`,
     );
@@ -90,7 +93,20 @@ async function runCliWithMocks(
   const orchestratorCtor = vi.fn();
 
   vi.resetModules();
-  vi.doMock("./core/config.js", () => ({ loadConfig }));
+  vi.doMock("./core/config.js", () => ({
+    loadConfig,
+    AGENT_NAMES: [
+      "claude",
+      "codex",
+      "rovodev",
+      "opencode",
+      "gemini",
+      "copilot",
+      "junie",
+      "jules",
+      "kilo",
+    ],
+  }));
   vi.doMock("./core/debug-log.js", () => ({ appendDebugLog }));
   vi.doMock("./core/git.js", () => ({
     ensureCleanWorkingTree: vi.fn(),
@@ -329,18 +345,16 @@ describe("cli", () => {
       Promise.resolve({ type: "reexeced" as const, exitCode: 0 }),
     );
 
-    await expect(
-      runCliWithMocks(
-        ["ship it"],
-        {
-          agent: "claude",
-          agentPathOverride: {},
-          maxConsecutiveFailures: 3,
-          preventSleep: true,
-        },
-        { appendDebugLog, startSleepPrevention },
-      ),
-    ).rejects.toThrow(/process\.exit unexpectedly called/);
+    await runCliWithMocks(
+      ["ship it"],
+      {
+        agent: "claude",
+        agentPathOverride: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: true,
+      },
+      { appendDebugLog, startSleepPrevention },
+    );
 
     expect(startSleepPrevention).toHaveBeenCalledTimes(1);
     expect(appendDebugLog).not.toHaveBeenCalledWith(

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -29,6 +29,7 @@ interface CliMockOverrides {
   appendDebugLog?: ReturnType<typeof vi.fn>;
   createAgent?: ReturnType<typeof vi.fn>;
   env?: Record<string, string | undefined>;
+  maybePromptForJulesSetup?: ReturnType<typeof vi.fn>;
   orchestratorStart?: ReturnType<typeof vi.fn>;
   readStdinText?: ReturnType<typeof vi.fn>;
   rendererWaitUntilExit?: ReturnType<typeof vi.fn>;
@@ -61,6 +62,8 @@ async function runCliWithMocks(
   const createAgent =
     overrides.createAgent ?? vi.fn(() => ({ name: config.agent }));
   const appendDebugLog = overrides.appendDebugLog ?? vi.fn();
+  const maybePromptForJulesSetup =
+    overrides.maybePromptForJulesSetup ?? vi.fn(async (cfg) => cfg);
   const readStdinText =
     overrides.readStdinText ?? vi.fn(() => Promise.resolve(""));
   const startSleepPrevention =
@@ -108,6 +111,24 @@ async function runCliWithMocks(
     ],
   }));
   vi.doMock("./core/debug-log.js", () => ({ appendDebugLog }));
+  vi.doMock("./core/jules-tooling.js", () => ({
+    getVisibleAgentNames: vi.fn((cfg, env) => {
+      const base = [
+        "claude",
+        "codex",
+        "rovodev",
+        "opencode",
+        "gemini",
+        "copilot",
+        "junie",
+        "kilo",
+      ];
+      return env?.JULES_API_KEY && !cfg?.jules?.dismissed
+        ? [...base, "jules"]
+        : base;
+    }),
+    maybePromptForJulesSetup,
+  }));
   vi.doMock("./core/git.js", () => ({
     ensureCleanWorkingTree: vi.fn(),
     createBranch: vi.fn(),
@@ -182,6 +203,7 @@ async function runCliWithMocks(
   return {
     appendDebugLog,
     loadConfig,
+    maybePromptForJulesSetup,
     createAgent,
     orchestratorCtor,
     readStdinText,
@@ -296,6 +318,63 @@ describe("cli", () => {
       stubRunInfo,
       undefined,
     );
+  });
+
+  it.each(["gemini", "copilot", "junie", "jules", "kilo"] as const)(
+    "accepts %s as an explicit --agent override",
+    async (agent) => {
+      const env = agent === "jules" ? { JULES_API_KEY: "secret" } : {};
+      const { loadConfig, createAgent } = await runCliWithMocks(
+        ["ship it", "--agent", agent],
+        {
+          agent,
+          agentPathOverride: {},
+          maxConsecutiveFailures: 3,
+          preventSleep: false,
+        },
+        { env },
+      );
+
+      expect(loadConfig).toHaveBeenCalledWith({
+        agent,
+        preventSleep: undefined,
+      });
+      expect(createAgent).toHaveBeenCalledWith(agent, stubRunInfo, undefined);
+    },
+  );
+
+  it("hides jules from the CLI when it is not configured", async () => {
+    await expect(
+      runCliWithMocks(
+        ["ship it", "--agent", "jules"],
+        {
+          agent: "claude",
+          agentPathOverride: {},
+          maxConsecutiveFailures: 3,
+          preventSleep: false,
+        },
+      ),
+    ).rejects.toThrow(/process\.exit unexpectedly called with 1/);
+  });
+
+  it("prompts for Jules setup once in interactive mode when not configured", async () => {
+    const maybePromptForJulesSetup = vi.fn(async (cfg) => cfg);
+
+    await runCliWithMocks(
+      ["ship it"],
+      {
+        agent: "claude",
+        agentPathOverride: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: false,
+      },
+      { maybePromptForJulesSetup },
+    );
+
+    expect(maybePromptForJulesSetup).toHaveBeenCalledTimes(1);
+    expect(
+      (maybePromptForJulesSetup.mock.calls[0] as unknown[] | undefined)?.[2],
+    ).toBe(true);
   });
 
   it("passes max iteration and token caps to the orchestrator", async () => {
@@ -815,6 +894,112 @@ describe("cli", () => {
     });
 
     await cliPromise;
+  });
+
+  it("exits with code 0 after a successful non-interrupted run", async () => {
+    const originalArgv = [...process.argv];
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as typeof process.exit);
+
+    vi.resetModules();
+    vi.doMock("./core/config.js", () => ({
+      loadConfig: vi.fn(() => ({
+        agent: "opencode",
+        agentPathOverride: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: false,
+      })),
+      AGENT_NAMES: [
+        "claude",
+        "codex",
+        "rovodev",
+        "opencode",
+        "gemini",
+        "copilot",
+        "junie",
+        "jules",
+        "kilo",
+      ],
+    }));
+    vi.doMock("./core/debug-log.js", () => ({ appendDebugLog: vi.fn() }));
+    vi.doMock("./core/jules-tooling.js", () => ({
+      getVisibleAgentNames: vi.fn(() => [
+        "claude",
+        "codex",
+        "rovodev",
+        "opencode",
+        "gemini",
+        "copilot",
+        "junie",
+        "kilo",
+      ]),
+      maybePromptForJulesSetup: vi.fn(async (cfg) => cfg),
+    }));
+    vi.doMock("./core/git.js", () => ({
+      ensureCleanWorkingTree: vi.fn(),
+      createBranch: vi.fn(),
+      getHeadCommit: vi.fn(() => "abc123"),
+      getCurrentBranch: vi.fn(() => "main"),
+    }));
+    vi.doMock("./core/run.js", () => ({
+      setupRun: vi.fn(() => stubRunInfo),
+      resumeRun: vi.fn(),
+      getLastIterationNumber: vi.fn(() => 0),
+    }));
+    vi.doMock("./core/stdin.js", () => ({
+      readStdinText: vi.fn(() => Promise.resolve("")),
+    }));
+    vi.doMock("./core/agents/factory.js", () => ({
+      createAgent: vi.fn(() => ({ name: "opencode" })),
+    }));
+    vi.doMock("./core/sleep.js", () => ({
+      startSleepPrevention: vi.fn(() =>
+        Promise.resolve({ type: "skipped", reason: "unsupported" }),
+      ),
+    }));
+    vi.doMock("./core/orchestrator.js", () => ({
+      Orchestrator: class MockOrchestrator {
+        start = vi.fn(() => Promise.resolve());
+        stop = vi.fn();
+        on = vi.fn();
+        getState = vi.fn(() => ({
+          status: "running" as const,
+          currentIteration: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          commitCount: 0,
+          iterations: [],
+          successCount: 0,
+          failCount: 0,
+          consecutiveFailures: 0,
+          startTime: new Date("2026-01-01T00:00:00Z"),
+          waitingUntil: null,
+          lastMessage: null,
+        }));
+      },
+    }));
+    vi.doMock("./renderer.js", () => ({
+      Renderer: class MockRenderer {
+        start = vi.fn();
+        stop = vi.fn();
+        waitUntilExit = vi.fn(() => Promise.resolve("stopped"));
+      }
+    }));
+
+    process.argv = ["node", "gnhf", "ship it"];
+
+    try {
+      await import("./cli.js");
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      process.argv = originalArgv;
+      stdoutWrite.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 
   it("prints a friendly message outside a git repository", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import { Orchestrator } from "./core/orchestrator.js";
 import { MockOrchestrator } from "./mock-orchestrator.js";
 import { Renderer } from "./renderer.js";
 import { slugifyPrompt } from "./utils/slugify.js";
+import { getVisibleAgentNames, maybePromptForJulesSetup } from "./core/jules-tooling.js";
 
 const packageVersion = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
@@ -90,6 +91,17 @@ function ask(question: string): Promise<string> {
       resolve(answer.trim().toLowerCase());
     });
   });
+}
+
+function formatAgentList(agentNames: readonly string[]): string {
+  if (agentNames.length === 1) return `"${agentNames[0]}"`;
+  if (agentNames.length === 2) {
+    return `"${agentNames[0]}" or "${agentNames[1]}"`;
+  }
+
+  const quoted = agentNames.map((name) => `"${name}"`);
+  const last = quoted.pop();
+  return `${quoted.join(", ")}, or ${last}`;
 }
 
 function getSignalExitCode(signal: NodeJS.Signals): number {
@@ -164,10 +176,7 @@ program
   .description("Before I go to bed, I tell my agents: good night, have fun")
   .version(packageVersion)
   .argument("[prompt]", "The objective for the coding agent")
-  .option(
-    "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, opencode, gemini, copilot, or junie)",
-  )
+  .option("--agent <agent>", "Agent to use")
   .option(
     "--max-iterations <n>",
     "Abort after N total iterations",
@@ -220,22 +229,32 @@ program
       let prompt = promptArg;
       let promptFromStdin = false;
 
+      let config = loadConfig({
+        agent: options.agent as (typeof AGENT_NAMES)[number] | undefined,
+        preventSleep: options.preventSleep,
+      });
+      config = await maybePromptForJulesSetup(
+        config,
+        process.env,
+        Boolean(process.stdin.isTTY),
+        {
+          ask,
+          write: (message) => process.stderr.write(message),
+        },
+      );
+
+      const visibleAgentNames = getVisibleAgentNames(config, process.env);
       const agentName = options.agent;
       if (
         agentName !== undefined &&
-        !AGENT_NAMES.includes(agentName as (typeof AGENT_NAMES)[number])
+        !visibleAgentNames.includes(agentName as (typeof AGENT_NAMES)[number])
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", "junie", or "jules".`,
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", or "junie".`,
+          `Unknown agent: ${options.agent}. Use ${formatAgentList(visibleAgentNames)}.`,
         );
         process.exit(1);
+        return;
       }
-
-      const config = loadConfig({
-        agent: agentName as (typeof AGENT_NAMES)[number] | undefined,
-        preventSleep: options.preventSleep,
-      });
 
       if (!prompt && process.env.GNHF_SLEEP_INHIBITED === "1") {
         prompt = readReexecStdinPrompt(process.env);
@@ -397,6 +416,7 @@ program
             `\n  gnhf: shutdown timed out after ${FORCE_EXIT_TIMEOUT_MS / 1000}s, forcing exit\n`,
           );
           process.exit(getSignalExitCode(shutdownSignal ?? "SIGINT"));
+          return;
         }
       } finally {
         process.off("SIGINT", handleSigInt);
@@ -410,7 +430,11 @@ program
 
       if (shutdownSignal) {
         process.exit(getSignalExitCode(shutdownSignal));
+        return;
       }
+
+      process.exit(0);
+      return;
     },
   );
 
@@ -427,6 +451,7 @@ function exitAltScreen() {
 function die(message: string): never {
   console.error(`\n  gnhf: ${humanizeErrorMessage(message)}\n`);
   process.exit(1);
+  throw new Error(`process.exit unexpectedly returned after fatal error: ${message}`);
 }
 
 try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, opencode, or kilo)",
+    "Agent to use (claude, codex, rovodev, opencode, kilo, gemini, copilot, junie, or jules)",
   )
   .option(
     "--max-iterations <n>",
@@ -223,48 +223,22 @@ program
       const agentName = options.agent;
       if (
         agentName !== undefined &&
-        agentName !== "claude" &&
-        agentName !== "codex" &&
-        agentName !== "rovodev" &&
-        agentName !== "opencode" &&
-        agentName !== "kilo"
+        agentName !== "kilo" &&
+        agentName !== "gemini" &&
+        agentName !== "copilot" &&
+        agentName !== "junie" &&
+        agentName !== "jules"
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
         );
         process.exit(1);
       }
 
-      const loadedConfig = loadConfig(
-        agentName
-          ? {
-              agent: agentName as
-                | "claude"
-                | "codex"
-                | "rovodev"
-                | "opencode"
-                | "kilo",
-            }
-          : {},
-      );
-      const config = {
-        ...loadedConfig,
-        ...(options.preventSleep === undefined
-          ? {}
-          : { preventSleep: options.preventSleep }),
-      };
-      if (
-        config.agent !== "claude" &&
-        config.agent !== "codex" &&
-        config.agent !== "rovodev" &&
-        config.agent !== "opencode" &&
-        config.agent !== "kilo"
-      ) {
-        console.error(
-          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
-        );
-        process.exit(1);
-      }
+      const config = loadConfig({
+        agent: agentName,
+        preventSleep: options.preventSleep,
+      });
 
       if (!prompt && process.env.GNHF_SLEEP_INHIBITED === "1") {
         prompt = readReexecStdinPrompt(process.env);
@@ -307,6 +281,7 @@ program
             runInfo = initializeNewBranch(prompt, cwd);
           } else {
             process.exit(0);
+            return;
           }
         }
       } else {
@@ -338,6 +313,7 @@ program
           if (sleepPrevention.type === "reexeced") {
             reexeced = true;
             process.exit(sleepPrevention.exitCode);
+            return;
           }
           if (sleepPrevention.type === "active") {
             sleepPreventionCleanup = sleepPrevention.cleanup;
@@ -424,6 +400,7 @@ program
             `\n  gnhf: shutdown timed out after ${FORCE_EXIT_TIMEOUT_MS / 1000}s, forcing exit\n`,
           );
           process.exit(getSignalExitCode(shutdownSignal ?? "SIGINT"));
+          return;
         }
       } finally {
         process.off("SIGINT", handleSigInt);
@@ -437,7 +414,11 @@ program
 
       if (shutdownSignal) {
         process.exit(getSignalExitCode(shutdownSignal));
+        return;
       }
+
+      process.exit(0);
+      return;
     },
   );
 
@@ -454,6 +435,7 @@ function exitAltScreen() {
 function die(message: string): never {
   console.error(`\n  gnhf: ${humanizeErrorMessage(message)}\n`);
   process.exit(1);
+  throw new Error(`process.exit unexpectedly returned after fatal error: ${message}`);
 }
 
 try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, or opencode)",
+    "Agent to use (claude, codex, rovodev, opencode, or kilo)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,10 +226,11 @@ program
         agentName !== "claude" &&
         agentName !== "codex" &&
         agentName !== "rovodev" &&
-        agentName !== "opencode"
+        agentName !== "opencode" &&
+        agentName !== "kilo"
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
         );
         process.exit(1);
       }
@@ -237,7 +238,12 @@ program
       const loadedConfig = loadConfig(
         agentName
           ? {
-              agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
+              agent: agentName as
+                | "claude"
+                | "codex"
+                | "rovodev"
+                | "opencode"
+                | "kilo",
             }
           : {},
       );
@@ -251,10 +257,11 @@ program
         config.agent !== "claude" &&
         config.agent !== "codex" &&
         config.agent !== "rovodev" &&
-        config.agent !== "opencode"
+        config.agent !== "opencode" &&
+        config.agent !== "kilo"
       ) {
         console.error(
-          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
         );
         process.exit(1);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ program
   .argument("[prompt]", "The objective for the coding agent")
   .option(
     "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, opencode, kilo, gemini, copilot, junie, or jules)",
+    "Agent to use (claude, codex, rovodev, opencode, gemini, copilot, or junie)",
   )
   .option(
     "--max-iterations <n>",
@@ -226,7 +226,8 @@ program
         !AGENT_NAMES.includes(agentName as (typeof AGENT_NAMES)[number])
       ) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", "junie", or "jules".`,
+          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", or "junie".`,
         );
         process.exit(1);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -397,7 +397,6 @@ program
             `\n  gnhf: shutdown timed out after ${FORCE_EXIT_TIMEOUT_MS / 1000}s, forcing exit\n`,
           );
           process.exit(getSignalExitCode(shutdownSignal ?? "SIGINT"));
-          return;
         }
       } finally {
         process.off("SIGINT", handleSigInt);
@@ -411,11 +410,7 @@ program
 
       if (shutdownSignal) {
         process.exit(getSignalExitCode(shutdownSignal));
-        return;
       }
-
-      process.exit(0);
-      return;
     },
   );
 
@@ -432,7 +427,6 @@ function exitAltScreen() {
 function die(message: string): never {
   console.error(`\n  gnhf: ${humanizeErrorMessage(message)}\n`);
   process.exit(1);
-  throw new Error(`process.exit unexpectedly returned after fatal error: ${message}`);
 }
 
 try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { createInterface } from "node:readline";
 import { Command, InvalidArgumentError } from "commander";
-import { loadConfig } from "./core/config.js";
+import { loadConfig, AGENT_NAMES } from "./core/config.js";
 import { appendDebugLog } from "./core/debug-log.js";
 import {
   ensureCleanWorkingTree,
@@ -223,11 +223,7 @@ program
       const agentName = options.agent;
       if (
         agentName !== undefined &&
-        agentName !== "kilo" &&
-        agentName !== "gemini" &&
-        agentName !== "copilot" &&
-        agentName !== "junie" &&
-        agentName !== "jules"
+        !AGENT_NAMES.includes(agentName as (typeof AGENT_NAMES)[number])
       ) {
         console.error(
           `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
@@ -236,7 +232,7 @@ program
       }
 
       const config = loadConfig({
-        agent: agentName,
+        agent: agentName as (typeof AGENT_NAMES)[number] | undefined,
         preventSleep: options.preventSleep,
       });
 

--- a/src/core/agents/async-adapter.test.ts
+++ b/src/core/agents/async-adapter.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncAgentAdapter } from "./async-adapter.js";
+import type { AsyncAgent, AsyncAgentPollResult } from "./types.js";
+
+function createAsyncAgent(overrides: Partial<AsyncAgent> = {}): AsyncAgent {
+  return {
+    name: "jules",
+    run: vi.fn(),
+    submit: vi.fn(async () => ({
+      id: "session-1",
+      url: "https://example.test",
+    })),
+    poll: vi.fn<() => Promise<AsyncAgentPollResult>>(async () => ({
+      status: "completed",
+      summary: "done",
+    })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("AsyncAgentAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("closes the async agent when polling fails", async () => {
+    const asyncAgent = createAsyncAgent({
+      poll: vi.fn(async () => {
+        throw new Error("poll failed");
+      }),
+    });
+    const adapter = new AsyncAgentAdapter(asyncAgent);
+
+    await expect(adapter.run("prompt", "/cwd")).rejects.toThrow("poll failed");
+    expect(asyncAgent.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+  type Agent,
+  type AgentResult,
+  type AgentRunOptions,
+  type AsyncAgent,
+  type AsyncAgentSession,
+  type AsyncAgentPollResult,
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATES = new Set(["completed", "failed"]);
+const POLLABLE_STATES = new Set([
+  "queued",
+  "planning",
+  "awaiting_plan_approval",
+  "in_progress",
+]);
+
+export interface AsyncAgentAdapterOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onStatusChange?: (status: AsyncAgentPollResult) => void;
+}
+
+export class AsyncAgentAdapter implements Agent {
+  name: string;
+
+  constructor(
+    private asyncAgent: AsyncAgent,
+    private options: AsyncAgentAdapterOptions = {},
+  ) {
+    this.name = asyncAgent.name;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const pollIntervalMs =
+      this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    const session = await this.asyncAgent.submit(prompt, cwd);
+
+    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
+    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+
+    const result = await this.pollUntilDone(
+      session,
+      pollIntervalMs,
+      timeoutMs,
+      startTime,
+      options,
+    );
+
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+
+    return result;
+  }
+
+  private async pollUntilDone(
+    session: AsyncAgentSession,
+    pollIntervalMs: number,
+    timeoutMs: number,
+    startTime: number,
+    runOptions?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    while (true) {
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `${this.name} session ${session.id} timed out after ${timeoutMs / 1000 / 60} minutes`,
+        );
+      }
+
+      if (runOptions?.signal?.aborted) {
+        throw new Error("Agent was aborted");
+      }
+
+      const pollResult = await this.asyncAgent.poll(session);
+
+      this.options.onStatusChange?.(pollResult);
+
+      if (pollResult.status === "completed") {
+        return this.buildResult(session, pollResult);
+      }
+
+      if (pollResult.status === "failed") {
+        throw new Error(
+          `${this.name} session failed: ${pollResult.reason ?? "Unknown reason"}`,
+        );
+      }
+
+      if (!POLLABLE_STATES.has(pollResult.status)) {
+        throw new Error(
+          `${this.name} session entered unexpected state: ${pollResult.status}`,
+        );
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      process.stderr.write(
+        `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
+      );
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  private buildResult(
+    session: AsyncAgentSession,
+    pollResult: AsyncAgentPollResult,
+  ): AgentResult {
+    return {
+      output: {
+        success: true,
+        summary:
+          pollResult.summary ??
+          `${this.name} completed session ${session.id}${pollResult.pullRequestUrl ? ` — PR: ${pollResult.pullRequestUrl}` : ""}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.asyncAgent.close) {
+      await this.asyncAgent.close();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/agents/async-adapter.ts
+++ b/src/core/agents/async-adapter.ts
@@ -45,24 +45,29 @@ export class AsyncAgentAdapter implements Agent {
     const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const startTime = Date.now();
 
-    const session = await this.asyncAgent.submit(prompt, cwd);
+    try {
+      const session = await Promise.race([
+        this.asyncAgent.submit(prompt, cwd),
+        waitForAbort(options?.signal),
+      ]);
 
-    process.stderr.write(`\n[${this.name}] Session started: ${session.url}\n`);
-    process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
+      process.stderr.write(
+        `\n[${this.name}] Session started: ${session.url}\n`,
+      );
+      process.stderr.write(`[${this.name}] Monitor at: ${session.url}\n\n`);
 
-    const result = await this.pollUntilDone(
-      session,
-      pollIntervalMs,
-      timeoutMs,
-      startTime,
-      options,
-    );
-
-    if (this.asyncAgent.close) {
-      await this.asyncAgent.close();
+      return await this.pollUntilDone(
+        session,
+        pollIntervalMs,
+        timeoutMs,
+        startTime,
+        options,
+      );
+    } finally {
+      if (this.asyncAgent.close) {
+        await this.asyncAgent.close();
+      }
     }
-
-    return result;
   }
 
   private async pollUntilDone(
@@ -108,7 +113,7 @@ export class AsyncAgentAdapter implements Agent {
         `[${this.name}] Session ${session.id} — ${pollResult.status} (${elapsed}s elapsed)\n`,
       );
 
-      await sleep(pollIntervalMs);
+      await sleep(pollIntervalMs, runOptions?.signal);
     }
   }
 
@@ -141,6 +146,24 @@ export class AsyncAgentAdapter implements Agent {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return Promise.race([
+    new Promise<void>((resolve) => setTimeout(resolve, ms)),
+    waitForAbort(signal),
+  ]);
+}
+
+function waitForAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (!signal) return;
+    if (signal.aborted) {
+      reject(new Error("Agent was aborted"));
+      return;
+    }
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new Error("Agent was aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/src/core/agents/codex.test.ts
+++ b/src/core/agents/codex.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
@@ -11,13 +12,25 @@ import { CodexAgent } from "./codex.js";
 
 const mockSpawn = vi.mocked(spawn);
 
-function createMockProcess() {
+function createMockProcess(jsonlLines: string[]) {
+  const stdout = Readable.from(
+    jsonlLines.map((line) => Buffer.from(line + "\n")),
+  );
+  const stderr = new Readable({
+    read() {},
+  }) as unknown as NodeJS.ReadableStream;
   const proc = Object.assign(new EventEmitter(), {
-    stdout: new EventEmitter(),
-    stderr: new EventEmitter(),
+    stdout,
+    stderr,
     stdin: null,
     kill: vi.fn(),
+    pid: 1234,
   });
+
+  stdout.on("end", () => {
+    setImmediate(() => proc.emit("close", 0));
+  });
+
   return proc as typeof proc & ReturnType<typeof spawn>;
 }
 
@@ -26,15 +39,37 @@ describe("CodexAgent", () => {
     vi.clearAllMocks();
   });
 
-  it("does not use a shell for direct Windows launches", () => {
-    const proc = createMockProcess();
+  const successJsonl = [
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: JSON.stringify({
+          success: true,
+          summary: "done",
+          key_changes_made: [],
+          key_learnings: [],
+        }),
+      },
+    }),
+    JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 },
+    }),
+  ];
+
+  it("does not use a shell for direct Windows launches", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
+
     const agent = new CodexAgent("/tmp/schema.json", {
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    const result = await agent.run("test prompt", "/work/dir");
 
+    expect(result.output.success).toBe(true);
+    expect(result.output.summary).toBe("done");
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex",
       [
@@ -56,15 +91,16 @@ describe("CodexAgent", () => {
     );
   });
 
-  it("uses a shell on Windows for cmd wrapper paths", () => {
-    const proc = createMockProcess();
+  it("uses a shell on Windows for cmd wrapper paths", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
+
     const agent = new CodexAgent("/tmp/schema.json", {
       bin: "C:\\tools\\codex.cmd",
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    await agent.run("test prompt", "/work/dir");
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "C:\\tools\\codex.cmd",
@@ -87,18 +123,19 @@ describe("CodexAgent", () => {
     );
   });
 
-  it("uses a shell on Windows when a bare override resolves to a cmd wrapper", () => {
-    const proc = createMockProcess();
+  it("uses a shell on Windows when a bare override resolves to a cmd wrapper", async () => {
+    const proc = createMockProcess(successJsonl);
     mockSpawn.mockReturnValue(proc);
     vi.mocked(execFileSync).mockReturnValue(
       "C:\\tools\\codex-switch.cmd\r\n" as never,
     );
+
     const agent = new CodexAgent("/tmp/schema.json", {
       bin: "codex-switch",
       platform: "win32",
     });
 
-    agent.run("test prompt", "/work/dir");
+    await agent.run("test prompt", "/work/dir");
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "codex-switch",
@@ -122,7 +159,7 @@ describe("CodexAgent", () => {
   });
 
   it("kills the full process tree on Windows when aborted", async () => {
-    const proc = createMockProcess();
+    const proc = createMockProcess([]);
     Object.defineProperty(proc, "pid", { value: 6789 });
     mockSpawn.mockReturnValue(proc);
     const controller = new AbortController();
@@ -142,5 +179,33 @@ describe("CodexAgent", () => {
       { stdio: "ignore" },
     );
     expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it("rejects when codex exits with non-zero code", async () => {
+    const stderr = new Readable({
+      read() {},
+    }) as unknown as NodeJS.ReadableStream;
+    const stdout = Readable.from([]);
+    const proc = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      kill: vi.fn(),
+    }) as ReturnType<typeof spawn>;
+
+    mockSpawn.mockReturnValue(proc);
+
+    const agent = new CodexAgent("/tmp/schema.json", {
+      platform: "linux",
+    });
+
+    setImmediate(() => {
+      (stderr as EventEmitter).emit("data", Buffer.from("something went wrong"));
+      proc.emit("close", 1);
+    });
+
+    await expect(agent.run("test prompt", "/work/dir")).rejects.toThrow(
+      "codex exited with code 1: something went wrong",
+    );
   });
 });

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -7,11 +7,7 @@ import type {
   TokenUsage,
   AgentRunOptions,
 } from "./types.js";
-import {
-  parseJSONLStream,
-  setupAbortHandler,
-  setupChildProcessHandlers,
-} from "./stream-utils.js";
+import { consumeJSONLStream } from "./stream-utils.js";
 
 interface CodexItemCompleted {
   type: "item.completed";
@@ -33,6 +29,9 @@ interface CodexAgentDeps {
   bin?: string;
   platform?: NodeJS.Platform;
 }
+
+const CODEX_STARTUP_TIMEOUT_MS = 60_000;
+const MAX_STDERR_BUFFER = 64 * 1024;
 
 function shouldUseWindowsShell(
   bin: string,
@@ -97,53 +96,60 @@ export class CodexAgent implements Agent {
     this.schemaPath = schemaPath;
   }
 
-  run(
+  async run(
     prompt: string,
     cwd: string,
     options?: AgentRunOptions,
   ): Promise<AgentResult> {
     const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
 
-    return new Promise((resolve, reject) => {
-      const logStream = logPath ? createWriteStream(logPath) : null;
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
 
-      const child = spawn(
-        this.bin,
-        [
-          "exec",
-          prompt,
-          "--json",
-          "--output-schema",
-          this.schemaPath,
-          "--dangerously-bypass-approvals-and-sandbox",
-          "--color",
-          "never",
-        ],
-        {
-          cwd,
-          shell: shouldUseWindowsShell(this.bin, this.platform),
-          stdio: ["ignore", "pipe", "pipe"],
-          env: process.env,
-        },
-      );
+    const child = spawn(
+      this.bin,
+      [
+        "exec",
+        prompt,
+        "--json",
+        "--output-schema",
+        this.schemaPath,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--color",
+        "never",
+      ],
+      {
+        cwd,
+        shell: shouldUseWindowsShell(this.bin, this.platform),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      },
+    );
 
-      if (
-        setupAbortHandler(signal, child, reject, () =>
-          terminateCodexProcess(child, this.platform),
-        )
-      ) {
-        return;
+    let stderr = "";
+    const stderrHandler = (data: Buffer) => {
+      stderr += data.toString();
+      if (stderr.length > MAX_STDERR_BUFFER) {
+        stderr = stderr.slice(-MAX_STDERR_BUFFER);
       }
+    };
+    child.stderr?.on("data", stderrHandler);
 
-      let lastAgentMessage: string | null = null;
-      const cumulative: TokenUsage = {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-      };
+    let lastAgentMessage: string | null = null;
+    const cumulative: TokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
 
-      parseJSONLStream<CodexEvent>(child.stdout!, logStream, (event) => {
+    const streamPromise = consumeJSONLStream<CodexEvent>(
+      child,
+      logStream,
+      (event) => {
         if (
           event.type === "item.completed" &&
           "item" in event &&
@@ -160,25 +166,83 @@ export class CodexAgent implements Agent {
           cumulative.cacheReadTokens += u.cached_input_tokens ?? 0;
           onUsage?.({ ...cumulative });
         }
-      });
+      },
+    );
 
-      setupChildProcessHandlers(child, "codex", logStream, reject, () => {
-        if (!lastAgentMessage) {
-          reject(new Error("codex returned no agent message"));
-          return;
-        }
-
-        try {
-          const output = JSON.parse(lastAgentMessage) as AgentOutput;
-          resolve({ output, usage: cumulative });
-        } catch (err) {
-          reject(
-            new Error(
-              `Failed to parse codex output: ${err instanceof Error ? err.message : err}`,
-            ),
-          );
-        }
+    let exitCode: number | null = null;
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        child.stderr?.off("data", stderrHandler);
+        exitCode = code;
+        resolve(code);
       });
     });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        child.stderr?.off("data", stderrHandler);
+        reject(new Error(`Failed to spawn codex: ${err.message}`));
+      });
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateCodexProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateCodexProcess(child, this.platform);
+        reject(
+          new Error(
+            `codex did not produce output within ${CODEX_STARTUP_TIMEOUT_MS / 1000}s — it may be hanging on MCP startup or backpressure`,
+          ),
+        );
+      }, CODEX_STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    try {
+      await Promise.race([
+        Promise.all([streamPromise, exitPromise]),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`codex exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`codex exited with code ${exitCode}: ${stderr}`);
+    }
+
+    if (!lastAgentMessage) {
+      throw new Error("codex returned no agent message");
+    }
+
+    try {
+      const output = JSON.parse(lastAgentMessage) as AgentOutput;
+      return { output, usage: cumulative };
+    } catch (err) {
+      throw new Error(
+        `Failed to parse codex output: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 }

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -138,6 +138,11 @@ export class CodexAgent implements Agent {
     };
     child.stderr?.on("data", stderrHandler);
 
+    let sawOutput = false;
+    child.stdout?.once("data", () => {
+      sawOutput = true;
+    });
+
     let lastAgentMessage: string | null = null;
     const cumulative: TokenUsage = {
       inputTokens: 0,

--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { CopilotAgent } from "./copilot.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("CopilotAgent", () => {
+  it("has the correct name", () => {
+    const agent = new CopilotAgent();
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("builds args with --autopilot --yolo", () => {
+    const agent = new CopilotAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--autopilot");
+    expect(args).toContain("--yolo");
+    expect(args).toContain("--max-autopilot-continues");
+    expect(args).toContain("50");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new CopilotAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new CopilotAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new CopilotAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -1,0 +1,64 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class CopilotAgent extends TextBasedAgent {
+  name = "copilot";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("copilot", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return [
+      "--autopilot",
+      "--yolo",
+      "--max-autopilot-continues",
+      "50",
+      "-p",
+      fullPrompt,
+    ];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -30,10 +30,23 @@ vi.mock("./rovodev.js", () => {
 });
 
 vi.mock("./opencode.js", () => {
+  const ServeBasedAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps: { name?: string } = {},
+  ) {
+    this.name = deps.name ?? "serve-agent";
+  });
   const OpenCodeAgent = vi.fn(function (this: Record<string, unknown>) {
     this.name = "opencode";
   });
-  return { OpenCodeAgent };
+  return { ServeBasedAgent, OpenCodeAgent };
+});
+
+vi.mock("./kilo.js", () => {
+  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "kilo";
+  });
+  return { KiloAgent };
 });
 
 import { createAgent } from "./factory.js";
@@ -41,6 +54,7 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -78,5 +92,11 @@ describe("createAgent", () => {
     const agent = createAgent("opencode", stubRunInfo);
     expect(OpenCodeAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("opencode");
+  });
+
+  it("creates a KiloAgent when name is 'kilo'", () => {
+    const agent = createAgent("kilo", stubRunInfo);
+    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("kilo");
   });
 });

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -87,6 +87,23 @@ vi.mock("./async-adapter.js", () => {
   return { AsyncAgentAdapter };
 });
 
+vi.mock("./jules.js", () => {
+  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "jules";
+  });
+  return { JulesAgent };
+});
+
+vi.mock("./async-adapter.js", () => {
+  const AsyncAgentAdapter = vi.fn(function (
+    this: Record<string, unknown>,
+    agent: { name: string },
+  ) {
+    this.name = agent.name;
+  });
+  return { AsyncAgentAdapter };
+});
+
 import { createAgent } from "./factory.js";
 import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
@@ -163,7 +180,10 @@ describe("createAgent", () => {
 
   it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
     const agent = createAgent("jules", stubRunInfo);
-    expect(JulesAgent).toHaveBeenCalled();
+    expect(JulesAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      platform: process.platform,
+    });
     expect(AsyncAgentAdapter).toHaveBeenCalled();
     expect(agent.name).toBe("jules");
   });

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -49,12 +49,55 @@ vi.mock("./kilo.js", () => {
   return { KiloAgent };
 });
 
+vi.mock("./gemini.js", () => {
+  const GeminiAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "gemini";
+  });
+  return { GeminiAgent };
+});
+
+vi.mock("./copilot.js", () => {
+  const CopilotAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "copilot";
+  });
+  return { CopilotAgent };
+});
+
+vi.mock("./junie.js", () => {
+  const JunieAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "junie";
+  });
+  return { JunieAgent };
+});
+
+vi.mock("./jules.js", () => {
+  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "jules";
+  });
+  return { JulesAgent };
+});
+
+vi.mock("./async-adapter.js", () => {
+  const AsyncAgentAdapter = vi.fn(function (
+    this: Record<string, unknown>,
+    agent: { name: string },
+  ) {
+    this.name = agent.name;
+  });
+  return { AsyncAgentAdapter };
+});
+
 import { createAgent } from "./factory.js";
 import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
 import { KiloAgent } from "./kilo.js";
+import { GeminiAgent } from "./gemini.js";
+import { CopilotAgent } from "./copilot.js";
+import { JunieAgent } from "./junie.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -98,5 +141,30 @@ describe("createAgent", () => {
     const agent = createAgent("kilo", stubRunInfo);
     expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
     expect(agent.name).toBe("kilo");
+  });
+
+  it("creates a GeminiAgent when name is 'gemini'", () => {
+    const agent = createAgent("gemini", stubRunInfo);
+    expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("creates a CopilotAgent when name is 'copilot'", () => {
+    const agent = createAgent("copilot", stubRunInfo);
+    expect(CopilotAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("creates a JunieAgent when name is 'junie'", () => {
+    const agent = createAgent("junie", stubRunInfo);
+    expect(JunieAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("junie");
+  });
+
+  it("creates a JulesAgent wrapped in AsyncAgentAdapter when name is 'jules'", () => {
+    const agent = createAgent("jules", stubRunInfo);
+    expect(JulesAgent).toHaveBeenCalled();
+    expect(AsyncAgentAdapter).toHaveBeenCalled();
+    expect(agent.name).toBe("jules");
   });
 });

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -42,13 +42,6 @@ vi.mock("./opencode.js", () => {
   return { ServeBasedAgent, OpenCodeAgent };
 });
 
-vi.mock("./kilo.js", () => {
-  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
-    this.name = "kilo";
-  });
-  return { KiloAgent };
-});
-
 vi.mock("./gemini.js", () => {
   const GeminiAgent = vi.fn(function (this: Record<string, unknown>) {
     this.name = "gemini";
@@ -87,21 +80,11 @@ vi.mock("./async-adapter.js", () => {
   return { AsyncAgentAdapter };
 });
 
-vi.mock("./jules.js", () => {
-  const JulesAgent = vi.fn(function (this: Record<string, unknown>) {
-    this.name = "jules";
+vi.mock("./kilo.js", () => {
+  const KiloAgent = vi.fn(function (this: Record<string, unknown>) {
+    this.name = "kilo";
   });
-  return { JulesAgent };
-});
-
-vi.mock("./async-adapter.js", () => {
-  const AsyncAgentAdapter = vi.fn(function (
-    this: Record<string, unknown>,
-    agent: { name: string },
-  ) {
-    this.name = agent.name;
-  });
-  return { AsyncAgentAdapter };
+  return { KiloAgent };
 });
 
 import { createAgent } from "./factory.js";
@@ -109,12 +92,12 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
-import { KiloAgent } from "./kilo.js";
 import { GeminiAgent } from "./gemini.js";
 import { CopilotAgent } from "./copilot.js";
 import { JunieAgent } from "./junie.js";
 import { JulesAgent } from "./jules.js";
 import { AsyncAgentAdapter } from "./async-adapter.js";
+import { KiloAgent } from "./kilo.js";
 import type { RunInfo } from "../run.js";
 
 const stubRunInfo: RunInfo = {
@@ -154,12 +137,6 @@ describe("createAgent", () => {
     expect(agent.name).toBe("opencode");
   });
 
-  it("creates a KiloAgent when name is 'kilo'", () => {
-    const agent = createAgent("kilo", stubRunInfo);
-    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
-    expect(agent.name).toBe("kilo");
-  });
-
   it("creates a GeminiAgent when name is 'gemini'", () => {
     const agent = createAgent("gemini", stubRunInfo);
     expect(GeminiAgent).toHaveBeenCalledWith({ bin: undefined });
@@ -184,7 +161,19 @@ describe("createAgent", () => {
       bin: undefined,
       platform: process.platform,
     });
-    expect(AsyncAgentAdapter).toHaveBeenCalled();
+    expect(AsyncAgentAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "jules" }),
+      {
+        pollIntervalMs: 30_000,
+        timeoutMs: 60 * 60 * 1000,
+      },
+    );
     expect(agent.name).toBe("jules");
+  });
+
+  it("creates a KiloAgent when name is 'kilo'", () => {
+    const agent = createAgent("kilo", stubRunInfo);
+    expect(KiloAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(agent.name).toBe("kilo");
   });
 });

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -35,7 +35,10 @@ export function createAgent(
     case "junie":
       return new JunieAgent({ bin: pathOverride });
     case "jules": {
-      const julesAgent = new JulesAgent({ platform: process.platform });
+      const julesAgent = new JulesAgent({
+        bin: pathOverride,
+        platform: process.platform,
+      });
       return new AsyncAgentAdapter(julesAgent, {
         pollIntervalMs: 30_000,
         timeoutMs: 60 * 60 * 1000,

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -8,6 +8,9 @@ import { RovoDevAgent } from "./rovodev.js";
 import { GeminiAgent } from "./gemini.js";
 import { CopilotAgent } from "./copilot.js";
 import { JunieAgent } from "./junie.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
+import { KiloAgent } from "./kilo.js";
 
 export function createAgent(
   name: AgentName,
@@ -29,5 +32,17 @@ export function createAgent(
       return new CopilotAgent({ bin: pathOverride });
     case "junie":
       return new JunieAgent({ bin: pathOverride });
+    case "jules": {
+      const julesAgent = new JulesAgent({
+        bin: pathOverride,
+        platform: process.platform,
+      });
+      return new AsyncAgentAdapter(julesAgent, {
+        pollIntervalMs: 30_000,
+        timeoutMs: 60 * 60 * 1000,
+      });
+    }
+    case "kilo":
+      return new KiloAgent({ bin: pathOverride });
   }
 }

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,12 +5,9 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
-import { KiloAgent } from "./kilo.js";
 import { GeminiAgent } from "./gemini.js";
 import { CopilotAgent } from "./copilot.js";
 import { JunieAgent } from "./junie.js";
-import { JulesAgent } from "./jules.js";
-import { AsyncAgentAdapter } from "./async-adapter.js";
 
 export function createAgent(
   name: AgentName,
@@ -26,23 +23,11 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
-    case "kilo":
-      return new KiloAgent({ bin: pathOverride });
     case "gemini":
       return new GeminiAgent({ bin: pathOverride });
     case "copilot":
       return new CopilotAgent({ bin: pathOverride });
     case "junie":
       return new JunieAgent({ bin: pathOverride });
-    case "jules": {
-      const julesAgent = new JulesAgent({
-        bin: pathOverride,
-        platform: process.platform,
-      });
-      return new AsyncAgentAdapter(julesAgent, {
-        pollIntervalMs: 30_000,
-        timeoutMs: 60 * 60 * 1000,
-      });
-    }
   }
 }

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -6,6 +6,11 @@ import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
 import { KiloAgent } from "./kilo.js";
+import { GeminiAgent } from "./gemini.js";
+import { CopilotAgent } from "./copilot.js";
+import { JunieAgent } from "./junie.js";
+import { JulesAgent } from "./jules.js";
+import { AsyncAgentAdapter } from "./async-adapter.js";
 
 export function createAgent(
   name: AgentName,
@@ -23,5 +28,18 @@ export function createAgent(
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
     case "kilo":
       return new KiloAgent({ bin: pathOverride });
+    case "gemini":
+      return new GeminiAgent({ bin: pathOverride });
+    case "copilot":
+      return new CopilotAgent({ bin: pathOverride });
+    case "junie":
+      return new JunieAgent({ bin: pathOverride });
+    case "jules": {
+      const julesAgent = new JulesAgent({ platform: process.platform });
+      return new AsyncAgentAdapter(julesAgent, {
+        pollIntervalMs: 30_000,
+        timeoutMs: 60 * 60 * 1000,
+      });
+    }
   }
 }

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -5,6 +5,7 @@ import { ClaudeAgent } from "./claude.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
+import { KiloAgent } from "./kilo.js";
 
 export function createAgent(
   name: AgentName,
@@ -20,5 +21,7 @@ export function createAgent(
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
+    case "kilo":
+      return new KiloAgent({ bin: pathOverride });
   }
 }

--- a/src/core/agents/gemini.test.ts
+++ b/src/core/agents/gemini.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { GeminiAgent } from "./gemini.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("GeminiAgent", () => {
+  it("has the correct name", () => {
+    const agent = new GeminiAgent();
+    expect(agent.name).toBe("gemini");
+  });
+
+  it("builds args with --output-format json", () => {
+    const agent = new GeminiAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("json");
+    expect(args).toContain("-p");
+  });
+
+  it("parses a wrapped response with { response: '...' }", () => {
+    const agent = new GeminiAgent();
+    const wrapped = JSON.stringify({
+      response: JSON.stringify({
+        success: true,
+        summary: "done",
+        key_changes_made: ["changed foo"],
+        key_learnings: ["learned bar"],
+      }),
+    });
+    const result = (agent as any).parseOutput(wrapped);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new GeminiAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new GeminiAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new GeminiAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/gemini.ts
+++ b/src/core/agents/gemini.ts
@@ -1,0 +1,67 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class GeminiAgent extends TextBasedAgent {
+  name = "gemini";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("gemini", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["-p", fullPrompt, "--output-format", "json"];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    let raw = stdout.trim();
+
+    try {
+      const wrapper = JSON.parse(raw) as { response?: string };
+      if (wrapper.response) {
+        raw = wrapper.response;
+      }
+    } catch {
+      // Not a wrapper object, try to extract JSON from the raw text
+    }
+
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/jules-api.test.ts
+++ b/src/core/agents/jules-api.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JulesClient, JulesRateLimitError } from "./jules-api.js";
+
+const fetchMock = vi.fn();
+
+describe("JulesClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("includes authorization when an API key is configured", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "session-1", state: "queued", prompt: "x" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = new JulesClient({ apiKey: "secret", baseUrl: "https://example.test" });
+    await client.getSession("session-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/sessions/session-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+      }),
+    );
+  });
+
+  it("preserves request headers while adding authorization", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ id: "session-1", state: "queued", prompt: "x" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = new JulesClient({ apiKey: "secret", baseUrl: "https://example.test" });
+    await client.createSession({ prompt: "ship it" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/sessions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret",
+        }),
+      }),
+    );
+  });
+
+  it("throws a JulesRateLimitError with retryAfterMs on 429", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("slow down", {
+        status: 429,
+        headers: { "Retry-After": "7" },
+      }),
+    );
+
+    const client = new JulesClient({ baseUrl: "https://example.test" });
+
+    await expect(client.getSession("session-1")).rejects.toMatchObject({
+      name: "JulesRateLimitError",
+      retryAfterMs: 7000,
+    } satisfies Partial<JulesRateLimitError>);
+  });
+
+  it("falls back to statusText when an error body cannot be read", async () => {
+    const response = {
+      ok: false,
+      status: 500,
+      statusText: "Server exploded",
+      headers: new Headers(),
+      text: vi.fn(async () => {
+        throw new Error("unreadable");
+      }),
+    } as unknown as Response;
+    fetchMock.mockResolvedValue(response);
+
+    const client = new JulesClient({ baseUrl: "https://example.test" });
+
+    await expect(client.getActivities("session-1")).rejects.toThrow(
+      "Jules API error (500): Server exploded",
+    );
+  });
+});

--- a/src/core/agents/jules-api.ts
+++ b/src/core/agents/jules-api.ts
@@ -1,0 +1,141 @@
+const DEFAULT_BASE_URL = "https://jules.google.com/api/v1";
+
+export interface JulesClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface JulesCreateSessionRequest {
+  prompt: string;
+  title?: string;
+  sourceContext?: {
+    source: string;
+    githubRepoContext?: {
+      startingBranch?: string;
+    };
+  };
+  requirePlanApproval?: boolean;
+  automationMode?: "AUTO_CREATE_PR" | "MANUAL";
+}
+
+export interface JulesSession {
+  id: string;
+  url?: string;
+  state: string;
+  prompt: string;
+  title?: string;
+  outputs?: Array<{
+    pullRequest?: {
+      url: string;
+      title?: string;
+    };
+  }>;
+}
+
+export interface JulesActivity {
+  type: string;
+  changeSet?: {
+    gitPatch?: {
+      unidiffPatch: string;
+      suggestedCommitMessage?: string;
+    };
+  };
+}
+
+export class JulesRateLimitError extends Error {
+  constructor(
+    message: string,
+    public readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = "JulesRateLimitError";
+  }
+}
+
+export class JulesClient {
+  private baseUrl: string;
+  private apiKey: string | undefined;
+
+  constructor(options: JulesClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.apiKey = options.apiKey ?? process.env.JULES_API_KEY;
+  }
+
+  async createSession(
+    request: JulesCreateSessionRequest,
+  ): Promise<JulesSession> {
+    const response = await this.fetchWithAuth("/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesSession;
+  }
+
+  async getSession(sessionId: string): Promise<JulesSession> {
+    const response = await this.fetchWithAuth(`/sessions/${sessionId}`);
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesSession;
+  }
+
+  async getActivities(sessionId: string): Promise<JulesActivity[]> {
+    const response = await this.fetchWithAuth(
+      `/sessions/${sessionId}/activities`,
+    );
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    return (await response.json()) as JulesActivity[];
+  }
+
+  private async fetchWithAuth(
+    path: string,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      ...((init?.headers as Record<string, string> | undefined) ?? {}),
+    };
+
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    return fetch(url, { ...init, headers });
+  }
+
+  private async parseError(response: Response): Promise<Error> {
+    if (response.status === 429) {
+      const retryAfter = response.headers.get("Retry-After");
+      const retryAfterMs = retryAfter
+        ? Number.parseInt(retryAfter, 10) * 1000
+        : undefined;
+      return new JulesRateLimitError(
+        `Rate limited by Jules API (${response.status})`,
+        retryAfterMs,
+      );
+    }
+
+    let body: string | undefined;
+    try {
+      body = await response.text();
+    } catch {
+      // Ignore
+    }
+
+    return new Error(
+      `Jules API error (${response.status}): ${body ?? response.statusText}`,
+    );
+  }
+}

--- a/src/core/agents/jules.test.ts
+++ b/src/core/agents/jules.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+  getActivities: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: mocks.execFileSync,
+}));
+
+vi.mock("./jules-api.js", () => ({
+  JulesClient: vi.fn(function (this: Record<string, unknown>) {
+    this.createSession = mocks.createSession;
+    this.getSession = mocks.getSession;
+    this.getActivities = mocks.getActivities;
+  }),
+}));
+
+import { JulesAgent } from "./jules.js";
+
+describe("JulesAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits a session with the current git branch", async () => {
+    mocks.execFileSync.mockReturnValue("feat/test-branch\n" as never);
+    mocks.createSession.mockResolvedValue({
+      id: "session-123",
+      url: "https://jules.google.com/s/123",
+    });
+
+    const agent = new JulesAgent();
+    const session = await agent.submit("ship it", "C:/repo");
+
+    expect(mocks.createSession).toHaveBeenCalledWith({
+      prompt: "ship it",
+      sourceContext: {
+        source: "github",
+        githubRepoContext: {
+          startingBranch: "feat/test-branch",
+        },
+      },
+      automationMode: "MANUAL",
+      requirePlanApproval: false,
+    });
+    expect(session).toEqual({
+      id: "session-123",
+      url: "https://jules.google.com/s/123",
+      repo: "file://C:/repo",
+    });
+  });
+
+  it("falls back to main when git branch lookup fails", async () => {
+    mocks.execFileSync.mockImplementation(() => {
+      throw new Error("git failed");
+    });
+    mocks.createSession.mockResolvedValue({ id: "session-456" });
+
+    const agent = new JulesAgent();
+    await agent.submit("ship it", "C:/repo");
+
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceContext: {
+          source: "github",
+          githubRepoContext: {
+            startingBranch: "main",
+          },
+        },
+      }),
+    );
+  });
+
+  it("maps completed sessions into completed poll results", async () => {
+    mocks.getSession.mockResolvedValue({
+      id: "session-123",
+      state: "completed",
+      prompt: "ship it",
+      title: "Done",
+      outputs: [
+        {
+          pullRequest: {
+            url: "https://github.com/example/repo/pull/1",
+          },
+        },
+      ],
+    });
+    mocks.getActivities.mockResolvedValue([
+      {
+        type: "changes",
+        changeSet: {
+          gitPatch: {
+            unidiffPatch: "diff --git a b",
+            suggestedCommitMessage: "Add feature",
+          },
+        },
+      },
+      {
+        type: "changes",
+        changeSet: {
+          gitPatch: {
+            unidiffPatch: "diff --git c d",
+          },
+        },
+      },
+    ]);
+
+    const agent = new JulesAgent();
+    const result = await agent.poll({
+      id: "session-123",
+      url: "https://jules.google.com/s/123",
+    });
+
+    expect(result).toEqual({
+      status: "completed",
+      summary: "Done",
+      keyChangesMade: ["Add feature", "Applied changes"],
+      pullRequestUrl: "https://github.com/example/repo/pull/1",
+    });
+  });
+
+  it("maps failed sessions into failed poll results", async () => {
+    mocks.getSession.mockResolvedValue({
+      id: "session-123",
+      state: "failed",
+      prompt: "ship it",
+    });
+
+    const agent = new JulesAgent();
+    const result = await agent.poll({
+      id: "session-123",
+      url: "https://jules.google.com/s/123",
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      reason: "Session state: failed",
+    });
+  });
+
+  it("maps pending and queued sessions into queued poll results", async () => {
+    const agent = new JulesAgent();
+
+    mocks.getSession.mockResolvedValueOnce({
+      id: "session-pending",
+      state: "pending",
+      prompt: "ship it",
+    });
+    await expect(
+      agent.poll({ id: "session-pending", url: "https://jules/pending" }),
+    ).resolves.toEqual({ status: "queued" });
+
+    mocks.getSession.mockResolvedValueOnce({
+      id: "session-queued",
+      state: "queued",
+      prompt: "ship it",
+    });
+    await expect(
+      agent.poll({ id: "session-queued", url: "https://jules/queued" }),
+    ).resolves.toEqual({ status: "queued" });
+  });
+
+  it("maps unknown session states to in_progress", async () => {
+    mocks.getSession.mockResolvedValue({
+      id: "session-unknown",
+      state: "mystery-state",
+      prompt: "ship it",
+    });
+
+    const agent = new JulesAgent();
+    const result = await agent.poll({
+      id: "session-unknown",
+      url: "https://jules/unknown",
+    });
+
+    expect(result).toEqual({ status: "in_progress" });
+  });
+});

--- a/src/core/agents/jules.ts
+++ b/src/core/agents/jules.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from "node:child_process";
+import type {
+  AgentResult,
+  AsyncAgentSession,
+  AsyncAgentPollResult,
+  AgentRunOptions,
+} from "./types.js";
+import { JulesClient } from "./jules-api.js";
+
+export class JulesAgent {
+  name = "jules";
+
+  private client: JulesClient;
+  private platform: NodeJS.Platform;
+
+  constructor(deps: { platform?: NodeJS.Platform } = {}) {
+    this.client = new JulesClient();
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  async run(
+    prompt: string,
+    cwd: string,
+    _options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const session = await this.submit(prompt, cwd);
+
+    let pollResult = await this.poll(session);
+    while (
+      pollResult.status !== "completed" &&
+      pollResult.status !== "failed"
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 30_000));
+      pollResult = await this.poll(session);
+    }
+
+    if (pollResult.status === "failed") {
+      throw new Error(
+        `Jules session failed: ${pollResult.reason ?? "Unknown reason"}`,
+      );
+    }
+
+    return {
+      output: {
+        success: true,
+        summary: pollResult.summary ?? `Jules completed session ${session.id}`,
+        key_changes_made: pollResult.keyChangesMade ?? [],
+        key_learnings: pollResult.keyLearnings ?? [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+  }
+
+  async submit(prompt: string, cwd: string): Promise<AsyncAgentSession> {
+    const cwdUrl = `file://${cwd}`;
+    const session = await this.client.createSession({
+      prompt,
+      sourceContext: {
+        source: "gnhf",
+        githubRepoContext: {
+          startingBranch: this.getCurrentBranch(cwd),
+        },
+      },
+      automationMode: "MANUAL",
+      requirePlanApproval: false,
+    });
+
+    return {
+      id: session.id,
+      url: session.url ?? `https://jules.google.com/workspace/${session.id}`,
+      repo: cwdUrl,
+    };
+  }
+
+  async poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult> {
+    const julesSession = await this.client.getSession(session.id);
+
+    switch (julesSession.state) {
+      case "completed":
+        const activities = await this.client.getActivities(session.id);
+        const changes = activities
+          .filter((a) => a.changeSet?.gitPatch?.unidiffPatch)
+          .map(
+            (a) =>
+              a.changeSet!.gitPatch!.suggestedCommitMessage ??
+              "Applied changes",
+          );
+
+        return {
+          status: "completed",
+          summary: julesSession.title ?? `Completed session ${session.id}`,
+          keyChangesMade: changes,
+        };
+
+      case "failed":
+        return {
+          status: "failed",
+          reason: `Session state: failed`,
+        };
+
+      case "pending":
+      case "queued":
+        return { status: "queued" };
+
+      case "planning":
+        return { status: "planning" };
+
+      case "in_progress":
+        return { status: "in_progress" };
+
+      default:
+        return { status: "in_progress" };
+    }
+  }
+
+  private getCurrentBranch(cwd: string): string {
+    try {
+      return execFileSync("git", ["branch", "--show-current"], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return "main";
+    }
+  }
+
+  async close(): Promise<void> {}
+}

--- a/src/core/agents/jules.ts
+++ b/src/core/agents/jules.ts
@@ -13,47 +13,18 @@ export class JulesAgent {
   private client: JulesClient;
   private platform: NodeJS.Platform;
 
-  constructor(deps: { platform?: NodeJS.Platform } = {}) {
+  constructor(deps: { bin?: string; platform?: NodeJS.Platform } = {}) {
+    // bin is accepted for API consistency but ignored — Jules is cloud-only
     this.client = new JulesClient();
     this.platform = deps.platform ?? process.platform;
   }
 
   async run(
-    prompt: string,
-    cwd: string,
+    _prompt: string,
+    _cwd: string,
     _options?: AgentRunOptions,
   ): Promise<AgentResult> {
-    const session = await this.submit(prompt, cwd);
-
-    let pollResult = await this.poll(session);
-    while (
-      pollResult.status !== "completed" &&
-      pollResult.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 30_000));
-      pollResult = await this.poll(session);
-    }
-
-    if (pollResult.status === "failed") {
-      throw new Error(
-        `Jules session failed: ${pollResult.reason ?? "Unknown reason"}`,
-      );
-    }
-
-    return {
-      output: {
-        success: true,
-        summary: pollResult.summary ?? `Jules completed session ${session.id}`,
-        key_changes_made: pollResult.keyChangesMade ?? [],
-        key_learnings: pollResult.keyLearnings ?? [],
-      },
-      usage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-      },
-    };
+    throw new Error("JulesAgent must be wrapped by AsyncAgentAdapter");
   }
 
   async submit(prompt: string, cwd: string): Promise<AsyncAgentSession> {
@@ -61,7 +32,7 @@ export class JulesAgent {
     const session = await this.client.createSession({
       prompt,
       sourceContext: {
-        source: "gnhf",
+        source: "github",
         githubRepoContext: {
           startingBranch: this.getCurrentBranch(cwd),
         },
@@ -83,6 +54,9 @@ export class JulesAgent {
     switch (julesSession.state) {
       case "completed":
         const activities = await this.client.getActivities(session.id);
+        const pullRequestUrl = julesSession.outputs?.find(
+          (output) => output.pullRequest?.url,
+        )?.pullRequest?.url;
         const changes = activities
           .filter((a) => a.changeSet?.gitPatch?.unidiffPatch)
           .map(
@@ -95,6 +69,7 @@ export class JulesAgent {
           status: "completed",
           summary: julesSession.title ?? `Completed session ${session.id}`,
           keyChangesMade: changes,
+          pullRequestUrl,
         };
 
       case "failed":

--- a/src/core/agents/junie.test.ts
+++ b/src/core/agents/junie.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { JunieAgent } from "./junie.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+    pid: 12345,
+  })),
+  execFileSync: vi.fn(),
+}));
+
+describe("JunieAgent", () => {
+  it("has the correct name", () => {
+    const agent = new JunieAgent();
+    expect(agent.name).toBe("junie");
+  });
+
+  it("builds args with --task", () => {
+    const agent = new JunieAgent();
+    const args = (agent as any).buildArgs("do something");
+    expect(args).toContain("--task");
+  });
+
+  it("parses a direct JSON response", () => {
+    const agent = new JunieAgent();
+    const direct = JSON.stringify({
+      success: true,
+      summary: "done directly",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+    const result = (agent as any).parseOutput(direct);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("done directly");
+  });
+
+  it("extracts JSON from fenced code blocks", () => {
+    const agent = new JunieAgent();
+    const fenced = [
+      "Some thinking here...",
+      "```json",
+      '{"success":true,"summary":"fenced","key_changes_made":[],"key_learnings":[]}',
+      "```",
+    ].join("\n");
+    const result = (agent as any).parseOutput(fenced);
+    expect(result.success).toBe(true);
+    expect(result.summary).toBe("fenced");
+  });
+
+  it("returns zero usage", () => {
+    const agent = new JunieAgent();
+    const usage = (agent as any).parseUsage("");
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(0);
+  });
+});

--- a/src/core/agents/junie.ts
+++ b/src/core/agents/junie.ts
@@ -1,0 +1,57 @@
+import {
+  AGENT_OUTPUT_SCHEMA,
+  type AgentOutput,
+  type TokenUsage,
+} from "./types.js";
+import { TextBasedAgent, type TextBasedAgentDeps } from "./text-based-agent.js";
+
+const JSON_FENCE_RE = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/;
+const TRAILING_JSON_RE = /\{[\s\S]*\}\s*$/;
+
+function extractJson(text: string): string {
+  const fenceMatch = text.match(JSON_FENCE_RE);
+  if (fenceMatch) return fenceMatch[1];
+  const trailingMatch = text.match(TRAILING_JSON_RE);
+  if (trailingMatch) return trailingMatch[0];
+  return text;
+}
+
+export class JunieAgent extends TextBasedAgent {
+  name = "junie";
+
+  constructor(deps: TextBasedAgentDeps = {}) {
+    super("junie", deps);
+  }
+
+  protected buildArgs(prompt: string): string[] {
+    const fullPrompt = [
+      prompt,
+      "",
+      "When you finish, reply with only valid JSON.",
+      "Do not wrap the JSON in markdown fences.",
+      "Do not include any prose before or after the JSON.",
+      `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    ].join("\n");
+
+    return ["--task", fullPrompt];
+  }
+
+  protected parseOutput(stdout: string): AgentOutput {
+    const raw = stdout.trim();
+    try {
+      return JSON.parse(raw) as AgentOutput;
+    } catch {
+      const extracted = extractJson(raw);
+      return JSON.parse(extracted) as AgentOutput;
+    }
+  }
+
+  protected parseUsage(_stdout: string): TokenUsage {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}

--- a/src/core/agents/kilo.test.ts
+++ b/src/core/agents/kilo.test.ts
@@ -1,0 +1,297 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { KiloAgent } from "./kilo.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  return proc as unknown as ChildProcessWithoutNullStreams;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sseResponse(chunks: string | string[]): Response {
+  const values = Array.isArray(chunks) ? chunks : [chunks];
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of values) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+function finalMessageResponse(
+  summary: string,
+  usage: { input: number; output: number; read: number; write: number },
+  messageId = "msg-123",
+) {
+  return jsonResponse({
+    info: {
+      id: messageId,
+      sessionID: "session-123",
+      role: "assistant",
+      structured: {
+        success: true,
+        summary,
+        key_changes_made: [],
+        key_learnings: [],
+      },
+      tokens: {
+        input: usage.input,
+        output: usage.output,
+        cache: {
+          read: usage.read,
+          write: usage.write,
+        },
+      },
+    },
+    parts: [
+      {
+        id: "part-final",
+        type: "text",
+        text: JSON.stringify({
+          success: true,
+          summary,
+          key_changes_made: [],
+          key_learnings: [],
+        }),
+        metadata: {
+          openai: {
+            phase: "final_answer",
+          },
+        },
+      },
+    ],
+  });
+}
+
+const SSE_SESSION_IDLE = `data: {"payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n`;
+
+describe("KiloAgent", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    tempDir = mkdtempSync(join(tmpdir(), "gnhf-kilo-test-"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses 'kilo' as the default binary name", () => {
+    const agent = new KiloAgent();
+    expect(agent.name).toBe("kilo");
+  });
+
+  it("accepts a custom binary path", () => {
+    const agent = new KiloAgent({ bin: "/custom/kilo" });
+    expect(agent.name).toBe("kilo");
+  });
+
+  it("spawns kilo serve with correct arguments", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      platform: "linux",
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    setTimeout(() => proc.emit("close", 0), 10);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await promise;
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "kilo",
+      expect.any(Array),
+      expect.objectContaining({ shell: false, detached: true }),
+    );
+  });
+
+  it("uses shell on Windows", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      platform: "win32",
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    setTimeout(() => proc.emit("close", 0), 10);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await promise;
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "kilo",
+      expect.any(Array),
+      expect.objectContaining({ shell: true, detached: false }),
+    );
+  });
+
+  it("reports token usage correctly", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 100,
+          output: 50,
+          read: 20,
+          write: 10,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+    });
+
+    const usageCalls: { inputTokens: number; outputTokens: number }[] = [];
+    const result = await agent.run("test prompt", "/work/dir", {
+      onUsage: (u) =>
+        usageCalls.push({
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+        }),
+    });
+
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.outputTokens).toBe(50);
+    expect(result.usage.cacheReadTokens).toBe(20);
+    expect(result.usage.cacheCreationTokens).toBe(10);
+  });
+
+  it("rejects when kilo exits before becoming ready", async () => {
+    vi.useRealTimers();
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+    });
+
+    const promise = agent.run("test prompt", "/work/dir");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    (proc.stderr as EventEmitter).emit("data", Buffer.from("binary not found"));
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow("kilo exited before becoming ready");
+  });
+
+  it("closes the server on close()", async () => {
+    const proc = createMockProcess();
+    let closeHandler: ((code: number | null) => void) | null = null;
+    proc.on = vi.fn((event: string, handler: unknown) => {
+      if (event === "close") {
+        closeHandler = handler as (code: number | null) => void;
+      }
+      return proc;
+    });
+
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.0.0" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(sseResponse(SSE_SESSION_IDLE))
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 10,
+          output: 5,
+          read: 0,
+          write: 0,
+        }),
+      );
+
+    const agent = new KiloAgent({
+      fetch: fetchMock as typeof fetch,
+      spawn: mockSpawn,
+      getPort: async () => 9999,
+      killProcess: () => {},
+    });
+
+    await agent.run("test prompt", "/work/dir");
+
+    closeHandler?.(0);
+
+    await agent.close();
+  });
+});

--- a/src/core/agents/kilo.ts
+++ b/src/core/agents/kilo.ts
@@ -1,0 +1,10 @@
+import type { ServeAgentDeps } from "./opencode.js";
+import { ServeBasedAgent } from "./opencode.js";
+
+export class KiloAgent extends ServeBasedAgent {
+  name = "kilo";
+
+  constructor(deps: ServeAgentDeps = {}) {
+    super({ ...deps, name: "kilo" });
+  }
+}

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -513,6 +513,62 @@ describe("OpenCodeAgent", () => {
     );
   });
 
+  it("starts successfully without an external abort signal", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", { input: 1, output: 1, read: 0, write: 0 }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 1,
+          output: 1,
+          read: 0,
+          write: 0,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test prompt", "/repo")).resolves.toMatchObject({
+      output: expect.objectContaining({ summary: "done" }),
+    });
+  });
+
+  it("merges custom request headers", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", { input: 1, output: 1, read: 0, write: 0 }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 1,
+          output: 1,
+          read: 0,
+          write: 0,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await agent.run("test prompt", "/repo");
+
+    expect(
+      new Headers(fetchMock.mock.calls[2]?.[1]?.headers).get("accept"),
+    ).toBe("text/event-stream");
+  });
+
   it("kills the full process tree on Windows so the opencode server does not survive shutdown", async () => {
     const proc = createMockProcess();
     Object.defineProperty(proc, "pid", { value: 5678 });

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -604,9 +604,90 @@ describe("OpenCodeAgent", () => {
     expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
       "taskkill",
       ["/T", "/F", "/PID", "5678"],
-      { stdio: "ignore" },
+      { stdio: "ignore", timeout: 1_000 },
     );
     expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a PowerShell descendant kill when taskkill times out on Windows", async () => {
+    const proc = createMockProcess();
+    Object.defineProperty(proc, "pid", { value: 5678 });
+    mockSpawn.mockReturnValue(proc);
+
+    vi.mocked(execFileSync)
+      .mockImplementationOnce(() => {
+        const error = new Error("taskkill timed out") as Error & {
+          code?: string;
+        };
+        error.code = "ETIMEDOUT";
+        throw error;
+      })
+      .mockImplementationOnce(
+        () =>
+          [
+            "  TCP    127.0.0.1:8765    0.0.0.0:0    LISTENING    8765",
+          ].join("\r\n"),
+      )
+      .mockImplementationOnce(() => Buffer.from(""));
+
+    const windowsAgent = new OpenCodeAgent({
+      fetch: fetchMock as typeof fetch,
+      getPort,
+      platform: "win32",
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", { input: 1, output: 1, read: 0, write: 0 }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        finalMessageResponse("done", {
+          input: 1,
+          output: 1,
+          read: 0,
+          write: 0,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await windowsAgent.run("test", "/repo");
+    await windowsAgent.close();
+
+    expect(vi.mocked(execFileSync)).toHaveBeenNthCalledWith(
+      1,
+      "taskkill",
+      ["/T", "/F", "/PID", "5678"],
+      { stdio: "ignore", timeout: 1_000 },
+    );
+
+    expect(vi.mocked(execFileSync)).toHaveBeenNthCalledWith(
+      2,
+      "netstat",
+      ["-ano", "-p", "tcp"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1_000,
+      },
+    );
+    expect(vi.mocked(execFileSync)).toHaveBeenNthCalledWith(
+      3,
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Stop-Process -Id 8765 -Force -ErrorAction SilentlyContinue",
+      ],
+      { stdio: "ignore", timeout: 1_000 },
+    );
   });
 
   it("reuses the existing server process across runs in the same cwd", async () => {

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -16,7 +16,7 @@ import {
 import { appendDebugLog } from "../debug-log.js";
 import { shutdownChildProcess } from "./managed-process.js";
 
-interface OpenCodeMessagePart {
+interface ServeMessagePart {
   type?: string;
   text?: string;
   metadata?: {
@@ -26,7 +26,7 @@ interface OpenCodeMessagePart {
   };
 }
 
-interface OpenCodeTokens {
+interface ServeTokens {
   input?: number;
   output?: number;
   cache?: {
@@ -35,21 +35,21 @@ interface OpenCodeTokens {
   };
 }
 
-interface OpenCodeMessageResponse {
+interface ServeMessageResponse {
   info?: {
     id?: string;
     role?: string;
     structured?: AgentOutput;
-    tokens?: OpenCodeTokens;
+    tokens?: ServeTokens;
   };
-  parts?: OpenCodeMessagePart[];
+  parts?: ServeMessagePart[];
 }
 
-interface OpenCodeSessionResponse {
+interface ServeSessionResponse {
   id: string;
 }
 
-interface OpenCodeStreamEvent {
+interface ServeStreamEvent {
   directory?: string;
   payload?: {
     type?: string;
@@ -63,7 +63,7 @@ interface OpenCodeStreamEvent {
         messageID?: string;
         type?: string;
         text?: string;
-        tokens?: OpenCodeTokens;
+        tokens?: ServeTokens;
         metadata?: {
           openai?: {
             phase?: string;
@@ -73,13 +73,13 @@ interface OpenCodeStreamEvent {
       info?: {
         id?: string;
         role?: string;
-        tokens?: OpenCodeTokens;
+        tokens?: ServeTokens;
       };
     };
   };
 }
 
-interface OpenCodeDeps {
+export interface ServeAgentDeps {
   bin?: string;
   fetch?: typeof fetch;
   getPort?: () => Promise<number>;
@@ -88,7 +88,7 @@ interface OpenCodeDeps {
   spawn?: typeof spawn;
 }
 
-interface OpenCodeServer {
+export interface ServeAgentServer {
   baseUrl: string;
   child: ChildProcessWithoutNullStreams;
   closed: boolean;
@@ -108,7 +108,7 @@ interface RequestOptions {
   timeoutMs?: number;
 }
 
-interface OpenCodeTextPartState {
+interface ServeTextPartState {
   phase?: string;
   text: string;
 }
@@ -127,7 +127,7 @@ const STRUCTURED_OUTPUT_FORMAT = {
   retryCount: 1,
 } as const;
 
-function buildOpencodeChildEnv(): NodeJS.ProcessEnv {
+function buildServeChildEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   delete env.OPENCODE_SERVER_USERNAME;
   delete env.OPENCODE_SERVER_PASSWORD;
@@ -145,11 +145,6 @@ function buildPrompt(prompt: string): string {
   ].join("\n");
 }
 
-/**
- * On Windows with `shell: true`, `child.pid` is the `cmd.exe` wrapper, not
- * the actual server process.  `taskkill /T` terminates the entire process
- * tree rooted at that PID so the real server doesn't survive shutdown.
- */
 async function killWindowsProcessTree(pid: number): Promise<void> {
   try {
     execFileSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
@@ -172,7 +167,7 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
-function getAvailablePort(): Promise<number> {
+function getAvailablePort(label: string): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.unref();
@@ -181,7 +176,7 @@ function getAvailablePort(): Promise<number> {
       const address = server.address();
       if (!address || typeof address === "string") {
         server.close();
-        reject(new Error("Failed to allocate a port for opencode"));
+        reject(new Error(`Failed to allocate a port for ${label}`));
         return;
       }
 
@@ -223,7 +218,7 @@ async function delay(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-function toUsage(tokens?: OpenCodeTokens): TokenUsage {
+function toUsage(tokens?: ServeTokens): TokenUsage {
   return {
     inputTokens: tokens?.input ?? 0,
     outputTokens: tokens?.output ?? 0,
@@ -242,22 +237,59 @@ function withTimeoutSignal(
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
-export class OpenCodeAgent implements Agent {
-  name = "opencode";
+export class ServeBasedAgent implements Agent {
+  name: string;
 
-  private bin: string;
-  private fetchFn: typeof fetch;
-  private getPortFn: () => Promise<number>;
-  private killProcessFn: typeof process.kill;
-  private platform: NodeJS.Platform;
-  private spawnFn: typeof spawn;
-  private server: OpenCodeServer | null = null;
-  private closingPromise: Promise<void> | null = null;
+  protected bin: string;
+  protected fetchFn: typeof fetch;
+  protected getPortFn: () => Promise<number>;
+  protected killProcessFn: typeof process.kill;
+  protected platform: NodeJS.Platform;
+  protected spawnFn: typeof spawn;
+  protected server: ServeAgentServer | null = null;
+  protected closingPromise: Promise<void> | null = null;
 
-  constructor(deps: OpenCodeDeps = {}) {
-    this.bin = deps.bin ?? "opencode";
+  protected get debugLogPrefix(): string {
+    return this.name;
+  }
+
+  protected get portLabel(): string {
+    return this.name;
+  }
+
+  protected get spawnErrorMessage(): string {
+    return `Failed to spawn ${this.name}`;
+  }
+
+  protected get exitedErrorMessage(): string {
+    return `${this.name} exited before becoming ready`;
+  }
+
+  protected get noStreamBodyError(): string {
+    return `${this.name} returned no event stream body`;
+  }
+
+  protected get noTextOutputError(): string {
+    return `${this.name} returned no text output`;
+  }
+
+  protected get parseResponseError(): string {
+    return `Failed to parse ${this.name} response`;
+  }
+
+  protected get parseOutputError(): string {
+    return `Failed to parse ${this.name} output`;
+  }
+
+  protected get requestErrorPrefix(): string {
+    return this.name;
+  }
+
+  constructor(deps: ServeAgentDeps & { name?: string } = {}) {
+    this.name = deps.name ?? "serve-agent";
+    this.bin = deps.bin ?? this.name;
     this.fetchFn = deps.fetch ?? fetch;
-    this.getPortFn = deps.getPort ?? getAvailablePort;
+    this.getPortFn = deps.getPort ?? (() => getAvailablePort(this.portLabel));
     this.killProcessFn = deps.killProcess ?? process.kill.bind(process);
     this.platform = deps.platform ?? process.platform;
     this.spawnFn = deps.spawn ?? spawn;
@@ -317,10 +349,10 @@ export class OpenCodeAgent implements Agent {
     await this.shutdownServer();
   }
 
-  private async ensureServer(
+  protected async ensureServer(
     cwd: string,
     signal?: AbortSignal,
-  ): Promise<OpenCodeServer> {
+  ): Promise<ServeAgentServer> {
     if (this.server && !this.server.closed) {
       if (this.server.cwd !== cwd) {
         await this.shutdownServer();
@@ -328,11 +360,6 @@ export class OpenCodeAgent implements Agent {
         await this.server.readyPromise;
         return this.server;
       }
-    }
-
-    if (this.server && !this.server.closed) {
-      await this.server.readyPromise;
-      return this.server;
     }
 
     const port = await this.getPortFn();
@@ -353,11 +380,11 @@ export class OpenCodeAgent implements Agent {
         detached,
         shell: isWindows,
         stdio: ["ignore", "pipe", "pipe"],
-        env: buildOpencodeChildEnv(),
+        env: buildServeChildEnv(),
       },
     ) as unknown as ChildProcessWithoutNullStreams;
 
-    const server: OpenCodeServer = {
+    const server: ServeAgentServer = {
       baseUrl: `http://127.0.0.1:${port}`,
       child,
       closed: false,
@@ -392,7 +419,7 @@ export class OpenCodeAgent implements Agent {
     });
 
     this.server = server;
-    appendDebugLog("opencode:spawn", { cwd, port, detached });
+    appendDebugLog(`${this.debugLogPrefix}:spawn`, { cwd, port, detached });
     server.readyPromise = this.waitForHealthy(server, signal).catch(
       async (error) => {
         await this.shutdownServer();
@@ -404,61 +431,72 @@ export class OpenCodeAgent implements Agent {
     return server;
   }
 
-  private async waitForHealthy(
-    server: OpenCodeServer,
+  protected async waitForHealthy(
+    server: ServeAgentServer,
     signal?: AbortSignal,
   ): Promise<void> {
-    const deadline = Date.now() + 30_000;
-    let spawnErrorMessage: string | null = null;
+    const timeoutController = new AbortController();
+    const timeoutTimer = setTimeout(() => {
+      timeoutController.abort();
+    }, 30_000);
+    const combined = signal
+      ? AbortSignal.any([signal, timeoutController.signal])
+      : timeoutController.signal.signal;
+    let spawnErr: string | null = null;
 
     server.child.once("error", (error) => {
-      spawnErrorMessage = error.message;
+      spawnErr = error.message;
     });
 
-    while (Date.now() < deadline) {
-      if (signal?.aborted) {
-        throw createAbortError();
-      }
-
-      if (spawnErrorMessage) {
-        throw new Error(`Failed to spawn opencode: ${spawnErrorMessage}`);
-      }
-
-      if (server.closed) {
-        const output = server.stderr.trim() || server.stdout.trim();
-        throw new Error(
-          output
-            ? `opencode exited before becoming ready: ${output}`
-            : "opencode exited before becoming ready",
-        );
-      }
-
-      try {
-        const response = await this.fetchFn(`${server.baseUrl}/global/health`, {
-          method: "GET",
-          signal,
-        });
-        if (response.ok) return;
-      } catch (error) {
-        if (isAbortError(error)) {
-          throw createAbortError();
+    const poll = async (): Promise<void> => {
+      while (!combined.aborted) {
+        if (spawnErr) {
+          throw new Error(`${this.spawnErrorMessage}: ${spawnErr}`);
         }
+
+        if (server.closed) {
+          const output = server.stderr.trim() || server.stdout.trim();
+          throw new Error(
+            output
+              ? `${this.exitedErrorMessage}: ${output}`
+              : this.exitedErrorMessage,
+          );
+        }
+
+        try {
+          const response = await this.fetchFn(
+            `${server.baseUrl}/global/health`,
+            {
+              method: "GET",
+              signal: combined,
+            },
+          );
+          if (response.ok) {
+            clearTimeout(timeoutTimer);
+            return;
+          }
+        } catch (error) {
+          if (isAbortError(error)) {
+            throw createAbortError();
+          }
+        }
+
+        await delay(250, combined);
       }
 
-      await delay(250, signal);
-    }
+      clearTimeout(timeoutTimer);
+      throw createAbortError();
+    };
 
-    throw new Error(
-      `Timed out waiting for opencode serve to become ready on port ${server.port}`,
-    );
+    await poll();
   }
 
-  private async createSession(
-    server: OpenCodeServer,
+  protected async createSession(
+    server: ServeAgentServer,
     cwd: string,
     signal?: AbortSignal,
   ): Promise<string> {
-    const response = await this.requestJSON<OpenCodeSessionResponse>(
+    const response = await this.requestJSON<ServeSessionResponse>(
       server,
       "/session",
       {
@@ -474,8 +512,8 @@ export class OpenCodeAgent implements Agent {
     return response.id;
   }
 
-  private async streamMessage(
-    server: OpenCodeServer,
+  protected async streamMessage(
+    server: ServeAgentServer,
     sessionId: string,
     prompt: string,
     signal: AbortSignal,
@@ -495,7 +533,7 @@ export class OpenCodeAgent implements Agent {
     });
 
     if (!eventResponse.body) {
-      throw new Error("opencode returned no event stream body");
+      throw new Error(this.noStreamBodyError);
     }
 
     let messageRequestError: unknown = null;
@@ -528,44 +566,42 @@ export class OpenCodeAgent implements Agent {
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
     };
-    const usageByMessageId = new Map<string, TokenUsage>();
-    const textParts = new Map<string, OpenCodeTextPartState>();
+    const prevUsageByMessageId = new Map<string, TokenUsage>();
+    const textParts = new Map<string, ServeTextPartState>();
     let lastText: string | null = null;
     let lastFinalAnswerText: string | null = null;
-    let lastUsageSignature = "0:0:0:0";
 
     const updateUsage = (
       messageId: string | undefined,
-      tokens?: OpenCodeTokens,
+      tokens?: ServeTokens,
     ) => {
       if (!messageId || !tokens) return;
-      usageByMessageId.set(messageId, toUsage(tokens));
-
-      let nextInputTokens = 0;
-      let nextOutputTokens = 0;
-      let nextCacheReadTokens = 0;
-      let nextCacheCreationTokens = 0;
-      for (const messageUsage of usageByMessageId.values()) {
-        nextInputTokens += messageUsage.inputTokens;
-        nextOutputTokens += messageUsage.outputTokens;
-        nextCacheReadTokens += messageUsage.cacheReadTokens;
-        nextCacheCreationTokens += messageUsage.cacheCreationTokens;
+      const prev = prevUsageByMessageId.get(messageId) ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      };
+      const next = toUsage(tokens);
+      const dInput = next.inputTokens - prev.inputTokens;
+      const dOutput = next.outputTokens - prev.outputTokens;
+      const dCacheRead = next.cacheReadTokens - prev.cacheReadTokens;
+      const dCacheWrite = next.cacheCreationTokens - prev.cacheCreationTokens;
+      if (
+        dInput === 0 &&
+        dOutput === 0 &&
+        dCacheRead === 0 &&
+        dCacheWrite === 0
+      ) {
+        prevUsageByMessageId.set(messageId, next);
+        return;
       }
-
-      const signature = [
-        nextInputTokens,
-        nextOutputTokens,
-        nextCacheReadTokens,
-        nextCacheCreationTokens,
-      ].join(":");
-      usage.inputTokens = nextInputTokens;
-      usage.outputTokens = nextOutputTokens;
-      usage.cacheReadTokens = nextCacheReadTokens;
-      usage.cacheCreationTokens = nextCacheCreationTokens;
-      if (signature !== lastUsageSignature) {
-        lastUsageSignature = signature;
-        onUsage?.({ ...usage });
-      }
+      usage.inputTokens += dInput;
+      usage.outputTokens += dOutput;
+      usage.cacheReadTokens += dCacheRead;
+      usage.cacheCreationTokens += dCacheWrite;
+      prevUsageByMessageId.set(messageId, next);
+      onUsage?.({ ...usage });
     };
 
     const emitText = (partId: string, nextText: string, phase?: string) => {
@@ -579,7 +615,7 @@ export class OpenCodeAgent implements Agent {
       onMessage?.(trimmed);
     };
 
-    const handleEvent = (event: OpenCodeStreamEvent) => {
+    const handleEvent = (event: ServeStreamEvent) => {
       const payload = event.payload;
       const properties = payload?.properties;
       if (!properties || properties.sessionID !== sessionId) return false;
@@ -634,14 +670,18 @@ export class OpenCodeAgent implements Agent {
     const processRawEvent = (rawEvent: string) => {
       if (!rawEvent.trim()) return;
 
-      const dataLines = rawEvent
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice("data:".length).trimStart());
-      if (dataLines.length === 0) return;
+      let dataContent = "";
+      for (const line of rawEvent.split(/\r?\n/)) {
+        if (line.startsWith("data:")) {
+          const content = line.slice(5).trimStart();
+          if (dataContent) dataContent += "\n";
+          dataContent += content;
+        }
+      }
+      if (!dataContent) return;
 
       try {
-        const event = JSON.parse(dataLines.join("\n")) as OpenCodeStreamEvent;
+        const event = JSON.parse(dataContent) as ServeStreamEvent;
         if (handleEvent(event)) {
           sawSessionIdle = true;
         }
@@ -719,6 +759,7 @@ export class OpenCodeAgent implements Agent {
     } finally {
       streamAbortController.abort();
       await reader.cancel().catch(() => undefined);
+      textParts.clear();
     }
 
     const messageResult = await messageRequest;
@@ -733,12 +774,12 @@ export class OpenCodeAgent implements Agent {
     }
 
     const body = messageResult.body;
-    let response: OpenCodeMessageResponse;
+    let response: ServeMessageResponse;
     try {
-      response = JSON.parse(body) as OpenCodeMessageResponse;
+      response = JSON.parse(body) as ServeMessageResponse;
     } catch (error) {
       throw new Error(
-        `Failed to parse opencode response: ${error instanceof Error ? error.message : String(error)}`,
+        `${this.parseResponseError}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
@@ -755,6 +796,8 @@ export class OpenCodeAgent implements Agent {
       }
     }
 
+    prevUsageByMessageId.clear();
+
     if (response.info?.structured) {
       return {
         output: response.info.structured,
@@ -764,7 +807,7 @@ export class OpenCodeAgent implements Agent {
 
     const outputText = lastFinalAnswerText ?? lastText;
     if (!outputText) {
-      throw new Error("opencode returned no text output");
+      throw new Error(this.noTextOutputError);
     }
 
     try {
@@ -774,13 +817,13 @@ export class OpenCodeAgent implements Agent {
       };
     } catch (error) {
       throw new Error(
-        `Failed to parse opencode output: ${error instanceof Error ? error.message : String(error)}`,
+        `${this.parseOutputError}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
 
-  private async deleteSession(
-    server: OpenCodeServer,
+  protected async deleteSession(
+    server: ServeAgentServer,
     sessionId: string,
   ): Promise<void> {
     try {
@@ -793,8 +836,8 @@ export class OpenCodeAgent implements Agent {
     }
   }
 
-  private async abortSession(
-    server: OpenCodeServer,
+  protected async abortSession(
+    server: ServeAgentServer,
     sessionId: string,
   ): Promise<void> {
     try {
@@ -807,7 +850,7 @@ export class OpenCodeAgent implements Agent {
     }
   }
 
-  private async shutdownServer(): Promise<void> {
+  protected async shutdownServer(): Promise<void> {
     if (!this.server || this.server.closed) {
       this.server = null;
       return;
@@ -819,7 +862,10 @@ export class OpenCodeAgent implements Agent {
     }
 
     const server = this.server;
-    appendDebugLog("opencode:shutdown", { cwd: server.cwd, port: server.port });
+    appendDebugLog(`${this.debugLogPrefix}:shutdown`, {
+      cwd: server.cwd,
+      port: server.port,
+    });
 
     this.closingPromise = (
       this.platform === "win32" && server.child.pid
@@ -839,8 +885,8 @@ export class OpenCodeAgent implements Agent {
     await this.closingPromise;
   }
 
-  private async requestJSON<T>(
-    server: OpenCodeServer,
+  protected async requestJSON<T>(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<T> {
@@ -848,8 +894,8 @@ export class OpenCodeAgent implements Agent {
     return JSON.parse(body) as T;
   }
 
-  private async requestText(
-    server: OpenCodeServer,
+  protected async requestText(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<string> {
@@ -857,14 +903,20 @@ export class OpenCodeAgent implements Agent {
     return await response.text();
   }
 
-  private async request(
-    server: OpenCodeServer,
+  protected async request(
+    server: ServeAgentServer,
     path: string,
     options: RequestOptions,
   ): Promise<Response> {
-    const headers = new Headers(options.headers);
+    const headers: Record<string, string> = {};
     if (options.body !== undefined) {
-      headers.set("content-type", "application/json");
+      headers["content-type"] = "application/json";
+    }
+    if (options.headers) {
+      const h = options.headers as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        headers[k] = v;
+      }
     }
 
     const signal = withTimeoutSignal(options.signal, options.timeoutMs);
@@ -877,12 +929,25 @@ export class OpenCodeAgent implements Agent {
     });
 
     if (!response.ok) {
-      const body = await response.text();
+      let body = "";
+      try {
+        body = await response.text();
+      } catch {
+        body = "[could not read body]";
+      }
       throw new Error(
-        `opencode ${options.method} ${path} failed with ${response.status}: ${body}`,
+        `${this.requestErrorPrefix} ${options.method} ${path} failed with ${response.status}: ${body}`,
       );
     }
 
     return response;
+  }
+}
+
+export class OpenCodeAgent extends ServeBasedAgent {
+  name = "opencode";
+
+  constructor(deps: ServeAgentDeps = {}) {
+    super({ ...deps, name: "opencode" });
   }
 }

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -441,7 +441,7 @@ export class ServeBasedAgent implements Agent {
     }, 30_000);
     const combined = signal
       ? AbortSignal.any([signal, timeoutController.signal])
-      : timeoutController.signal.signal;
+      : timeoutController.signal;
     let spawnErr: string | null = null;
 
     server.child.once("error", (error) => {
@@ -913,9 +913,15 @@ export class ServeBasedAgent implements Agent {
       headers["content-type"] = "application/json";
     }
     if (options.headers) {
-      const h = options.headers as Record<string, string>;
-      for (const [k, v] of Object.entries(h)) {
-        headers[k] = v;
+      const h = options.headers;
+      if (h instanceof Headers) {
+        for (const [k, v] of h.entries()) {
+          headers[k] = v;
+        }
+      } else {
+        for (const [k, v] of Object.entries(h as Record<string, string>)) {
+          headers[k] = v;
+        }
       }
     }
 

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -145,14 +145,78 @@ function buildPrompt(prompt: string): string {
   ].join("\n");
 }
 
-async function killWindowsProcessTree(pid: number): Promise<void> {
+function findWindowsProcessListeningOnPort(port: number): number | null {
+  try {
+    const output = execFileSync("netstat", ["-ano", "-p", "tcp"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    });
+
+    for (const line of output.split(/\r?\n/)) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 5 || parts[0] !== "TCP") continue;
+      if (!parts[1]?.endsWith(`:${port}`)) continue;
+      if (parts[3] !== "LISTENING") continue;
+
+      const pid = Number.parseInt(parts[4] ?? "", 10);
+      if (Number.isInteger(pid) && pid > 0) {
+        return pid;
+      }
+    }
+  } catch {
+    // Best-effort only.
+  }
+
+  return null;
+}
+
+function forceStopWindowsProcess(pid: number): void {
+  try {
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        `Stop-Process -Id ${pid} -Force -ErrorAction SilentlyContinue`,
+      ],
+      {
+        stdio: "ignore",
+        timeout: 1_000,
+      },
+    );
+  } catch {
+    // Best-effort only.
+  }
+}
+
+async function killWindowsProcessTree(pid: number, port: number): Promise<void> {
   try {
     execFileSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
       stdio: "ignore",
+      timeout: 1_000,
     });
-  } catch {
-    // Best-effort: the process may have already exited.
+    return;
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String(error.code)
+        : undefined;
+    if (code !== "ETIMEDOUT") {
+      return;
+    }
   }
+
+  const listeningPid = findWindowsProcessListeningOnPort(port);
+  if (!listeningPid || listeningPid === pid) {
+    return;
+  }
+
+  forceStopWindowsProcess(listeningPid);
 }
 
 function createAbortError(): Error {
@@ -869,7 +933,7 @@ export class ServeBasedAgent implements Agent {
 
     this.closingPromise = (
       this.platform === "win32" && server.child.pid
-        ? killWindowsProcessTree(server.child.pid)
+        ? killWindowsProcessTree(server.child.pid, server.port)
         : shutdownChildProcess(server.child, {
             detached: server.detached,
             killProcess: this.killProcessFn,

--- a/src/core/agents/stream-utils.ts
+++ b/src/core/agents/stream-utils.ts
@@ -2,6 +2,8 @@ import type { ChildProcess } from "node:child_process";
 import type { Readable } from "node:stream";
 import type { WriteStream } from "node:fs";
 
+const MAX_STDERR_BUFFER = 64 * 1024;
+
 /**
  * Wire stderr collection, spawn-error handling, and the common close-handler
  * prefix (logStream.end + non-zero exit code rejection) for a child process.
@@ -16,15 +18,21 @@ export function setupChildProcessHandlers(
 ): void {
   let stderr = "";
 
-  child.stderr!.on("data", (data: Buffer) => {
+  const stderrHandler = (data: Buffer) => {
     stderr += data.toString();
-  });
+    if (stderr.length > MAX_STDERR_BUFFER) {
+      stderr = stderr.slice(-MAX_STDERR_BUFFER);
+    }
+  };
+  child.stderr!.on("data", stderrHandler);
 
   child.on("error", (err) => {
+    child.stderr?.off("data", stderrHandler);
     reject(new Error(`Failed to spawn ${agentName}: ${err.message}`));
   });
 
   child.on("close", (code) => {
+    child.stderr?.off("data", stderrHandler);
     logStream?.end();
     if (code !== 0) {
       reject(new Error(`${agentName} exited with code ${code}: ${stderr}`));
@@ -37,14 +45,15 @@ export function setupChildProcessHandlers(
 /**
  * Parse a JSONL stream, calling the callback for each parsed event.
  * Handles buffering of incomplete lines and skips unparseable lines.
+ * Returns a cleanup function to remove the data listener.
  */
 export function parseJSONLStream<T>(
   stream: Readable,
   logStream: WriteStream | null,
   callback: (event: T) => void,
-): void {
+): () => void {
   let buffer = "";
-  stream.on("data", (data: Buffer) => {
+  const handler = (data: Buffer) => {
     logStream?.write(data);
     buffer += data.toString();
     const lines = buffer.split("\n");
@@ -58,7 +67,77 @@ export function parseJSONLStream<T>(
         // Skip unparseable lines
       }
     }
+  };
+  stream.on("data", handler);
+  return () => stream.off("data", handler);
+}
+
+/**
+ * Async JSONL stream parser that properly handles backpressure.
+ * Uses `for await...of` on the stream to ensure the consumer
+ * controls the flow and prevents pipe-buffer deadlock.
+ *
+ * Drains stderr concurrently to prevent the child from blocking
+ * on stderr writes.
+ */
+export async function consumeJSONLStream<T>(
+  child: ChildProcess,
+  logStream: WriteStream | null,
+  onEvent: (event: T) => void,
+): Promise<void> {
+  const stdout = child.stdout;
+  const stderr = child.stderr;
+
+  if (!stdout) {
+    throw new Error("Child process has no stdout");
+  }
+
+  // Drain stderr by putting it into flowing mode without a listener.
+  // This prevents backpressure on stderr from blocking the child process.
+  if (stderr) {
+    stderr.resume();
+  }
+
+  // Propagate child process errors (e.g., spawn failures) through the stream.
+  const errorPromise = new Promise<never>((_, reject) => {
+    child.once("error", (err) => {
+      stdout.destroy();
+      reject(new Error(`Child process error: ${err.message}`));
+    });
   });
+
+  let buffer = "";
+
+  const consume = async () => {
+    for await (const chunk of stdout) {
+      const text = chunk.toString();
+      logStream?.write(text);
+      buffer += text;
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          onEvent(JSON.parse(line) as T);
+        } catch {
+          // Skip unparseable lines
+        }
+      }
+    }
+
+    // Process any remaining buffer after stream ends.
+    if (buffer.trim()) {
+      try {
+        onEvent(JSON.parse(buffer) as T);
+      } catch {
+        // Skip unparseable trailing data
+      }
+    }
+  };
+
+  await Promise.race([consume(), errorPromise]);
 }
 
 /**
@@ -75,7 +154,10 @@ export function setupAbortHandler(
 ): boolean {
   if (!signal) return false;
 
+  let settled = false;
   const onAbort = () => {
+    if (settled) return;
+    settled = true;
     abortChild();
     reject(new Error("Agent was aborted"));
   };
@@ -84,6 +166,9 @@ export function setupAbortHandler(
     return true;
   }
   signal.addEventListener("abort", onAbort, { once: true });
-  child.on("close", () => signal.removeEventListener("abort", onAbort));
+  child.on("close", () => {
+    settled = true;
+    signal.removeEventListener("abort", onAbort);
+  });
   return false;
 }

--- a/src/core/agents/text-based-agent.test.ts
+++ b/src/core/agents/text-based-agent.test.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  createWriteStream: vi.fn(() => ({
+    write: vi.fn(),
+    end: vi.fn(),
+  })),
+}));
+
+import { spawn } from "node:child_process";
+import { TextBasedAgent } from "./text-based-agent.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+class TestTextBasedAgent extends TextBasedAgent {
+  name = "test-agent";
+
+  protected buildArgs(prompt: string): string[] {
+    return [prompt];
+  }
+
+  protected parseOutput(stdout: string) {
+    return {
+      success: true,
+      summary: stdout.trim(),
+      key_changes_made: [],
+      key_learnings: [],
+    };
+  }
+
+  protected parseUsage() {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    };
+  }
+}
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  return proc as typeof proc & ReturnType<typeof spawn>;
+}
+
+describe("TextBasedAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it("does not time out after output has already started", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new TestTextBasedAgent("test-agent");
+
+    const promise = agent.run("prompt", "/cwd");
+
+    proc.stdout.emit("data", Buffer.from("still working\n"));
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(proc.kill).not.toHaveBeenCalled();
+
+    proc.stdout.emit("data", Buffer.from("done\n"));
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      output: expect.objectContaining({ summary: "still working\ndone" }),
+    });
+  });
+});

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -1,0 +1,204 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import type {
+  Agent,
+  AgentResult,
+  AgentOutput,
+  TokenUsage,
+  AgentRunOptions,
+} from "./types.js";
+
+const MAX_OUTPUT_BUFFER = 256 * 1024;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ANSI_ESCAPE_RE =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_ESCAPE_RE, "");
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (/\.(cmd|bat)$/i.test(bin)) return true;
+  if (/[\\/]/.test(bin)) return false;
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort
+    }
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+export interface TextBasedAgentDeps {
+  bin?: string;
+  platform?: NodeJS.Platform;
+}
+
+export abstract class TextBasedAgent implements Agent {
+  abstract name: string;
+
+  protected bin: string;
+  protected platform: NodeJS.Platform;
+
+  constructor(bin: string, deps: TextBasedAgentDeps = {}) {
+    this.bin = deps.bin ?? bin;
+    this.platform = deps.platform ?? process.platform;
+  }
+
+  protected abstract buildArgs(prompt: string): string[];
+  protected abstract parseOutput(stdout: string): AgentOutput;
+  protected abstract parseUsage(stdout: string): TokenUsage;
+
+  async run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+    const logStream = logPath ? createWriteStream(logPath) : null;
+
+    if (signal?.aborted) {
+      logStream?.end();
+      throw new Error("Agent was aborted");
+    }
+
+    const child = spawn(this.bin, this.buildArgs(prompt), {
+      cwd,
+      shell: shouldUseWindowsShell(this.bin, this.platform),
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      const text = data.toString();
+      stdout += text;
+      if (stdout.length > MAX_OUTPUT_BUFFER) {
+        stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
+      }
+      logStream?.write(data);
+      const cleaned = stripAnsi(text).trim();
+      if (cleaned) onMessage?.(cleaned);
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+      logStream?.write(data);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        terminateProcess(child, this.platform);
+        reject(new Error("Agent was aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      child.once("close", () => {
+        signal?.removeEventListener("abort", onAbort);
+      });
+    });
+
+    const startupTimeout = new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        terminateProcess(child, this.platform);
+        reject(
+          new Error(
+            `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
+          ),
+        );
+      }, STARTUP_TIMEOUT_MS);
+      timer.unref();
+      child.once("close", () => clearTimeout(timer));
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => {
+        logStream?.end();
+        resolve(code);
+      });
+    });
+
+    const errorPromise = new Promise<never>((_, reject) => {
+      child.once("error", (err) => {
+        logStream?.end();
+        reject(new Error(`Failed to spawn ${this.name}: ${err.message}`));
+      });
+    });
+
+    let exitCode: number | null = null;
+
+    try {
+      const result = await Promise.race([
+        exitPromise.then((code) => {
+          exitCode = code;
+          return { done: true } as const;
+        }),
+        abortPromise,
+        errorPromise,
+        startupTimeout,
+      ]);
+
+      if ("done" in result) {
+        // Process completed normally
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Agent was aborted") {
+        throw err;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+      }
+      throw err;
+    }
+
+    if (exitCode !== null && exitCode !== 0) {
+      throw new Error(`${this.name} exited with code ${exitCode}: ${stderr}`);
+    }
+
+    const cleaned = stripAnsi(stdout);
+    let output: AgentOutput;
+    try {
+      output = this.parseOutput(cleaned);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${this.name} output: ${err instanceof Error ? err.message : err}\n\nRaw output (last 500 chars):\n${cleaned.slice(-500)}`,
+      );
+    }
+
+    const usage = this.parseUsage(cleaned);
+    if (onUsage && Object.values(usage).some((v) => v > 0)) {
+      onUsage(usage);
+    }
+
+    return { output, usage };
+  }
+}

--- a/src/core/agents/text-based-agent.ts
+++ b/src/core/agents/text-based-agent.ts
@@ -99,9 +99,18 @@ export abstract class TextBasedAgent implements Agent {
 
     let stdout = "";
     let stderr = "";
+    let startupTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearStartupTimer = () => {
+      if (startupTimer) {
+        clearTimeout(startupTimer);
+        startupTimer = null;
+      }
+    };
 
     child.stdout.on("data", (data: Buffer) => {
       const text = data.toString();
+      clearStartupTimer();
       stdout += text;
       if (stdout.length > MAX_OUTPUT_BUFFER) {
         stdout = stdout.slice(-MAX_OUTPUT_BUFFER);
@@ -112,6 +121,7 @@ export abstract class TextBasedAgent implements Agent {
     });
 
     child.stderr.on("data", (data: Buffer) => {
+      clearStartupTimer();
       stderr += data.toString();
       logStream?.write(data);
     });
@@ -128,16 +138,17 @@ export abstract class TextBasedAgent implements Agent {
     });
 
     const startupTimeout = new Promise<never>((_, reject) => {
-      const timer = setTimeout(() => {
+      startupTimer = setTimeout(() => {
         terminateProcess(child, this.platform);
+        startupTimer = null;
         reject(
           new Error(
             `${this.name} did not produce output within ${STARTUP_TIMEOUT_MS / 1000}s`,
           ),
         );
       }, STARTUP_TIMEOUT_MS);
-      timer.unref();
-      child.once("close", () => clearTimeout(timer));
+      startupTimer.unref();
+      child.once("close", clearStartupTimer);
     });
 
     const exitPromise = new Promise<number | null>((resolve) => {

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -49,3 +49,59 @@ export interface Agent {
     options?: AgentRunOptions,
   ): Promise<AgentResult>;
 }
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}
+
+export interface AsyncAgentSession {
+  id: string;
+  url: string;
+  repo?: string;
+}
+
+export interface AsyncAgentPollResult {
+  status:
+    | "queued"
+    | "planning"
+    | "awaiting_plan_approval"
+    | "in_progress"
+    | "completed"
+    | "failed";
+  reason?: string;
+  pullRequestUrl?: string;
+  patch?: string;
+  commitMessage?: string;
+  summary?: string;
+  keyChangesMade?: string[];
+  keyLearnings?: string[];
+}
+
+export interface AsyncAgent extends Agent {
+  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
+  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
+}

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -77,31 +77,3 @@ export interface AsyncAgent extends Agent {
   submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
   poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
 }
-
-export interface AsyncAgentSession {
-  id: string;
-  url: string;
-  repo?: string;
-}
-
-export interface AsyncAgentPollResult {
-  status:
-    | "queued"
-    | "planning"
-    | "awaiting_plan_approval"
-    | "in_progress"
-    | "completed"
-    | "failed";
-  reason?: string;
-  pullRequestUrl?: string;
-  patch?: string;
-  commitMessage?: string;
-  summary?: string;
-  keyChangesMade?: string[];
-  keyLearnings?: string[];
-}
-
-export interface AsyncAgent extends Agent {
-  submit(prompt: string, cwd: string): Promise<AsyncAgentSession>;
-  poll(session: AsyncAgentSession): Promise<AsyncAgentPollResult>;
-}

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -39,12 +39,18 @@ describe("loadConfig", () => {
     });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: claude\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      expect.stringContaining("agent: claude"),
+      "utf-8",
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CONFIG_PATH,
+      expect.stringContaining("# Jules setup state (optional)"),
       "utf-8",
     );
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -65,6 +71,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -81,12 +88,13 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: codex\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      expect.stringContaining("agent: codex"),
       "utf-8",
     );
     expect(config).toEqual({
       agent: "codex",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -125,6 +133,7 @@ describe("loadConfig", () => {
         claude: resolvedClaude,
         codex: resolvedCodex,
       },
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -141,12 +150,13 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: rovodev\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      expect.stringContaining("agent: rovodev"),
       "utf-8",
     );
     expect(config).toEqual({
       agent: "rovodev",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -163,15 +173,62 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: opencode\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      expect.stringContaining("agent: opencode"),
       "utf-8",
     );
     expect(config).toEqual({
       agent: "opencode",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
+  });
+
+  it("supports bootstrapping all newly added agents as the configured agent", () => {
+    mockReadFileSync.mockImplementation(() => {
+      const error = new Error("ENOENT");
+      Object.assign(error, { code: "ENOENT" });
+      throw error;
+    });
+
+    for (const agent of [
+      "gemini",
+      "copilot",
+      "junie",
+      "jules",
+      "kilo",
+    ] as const) {
+      mockWriteFileSync.mockClear();
+
+      const config = loadConfig({ agent });
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        CONFIG_PATH,
+        expect.stringContaining(`agent: ${agent}`),
+        "utf-8",
+      );
+      expect(config).toMatchObject({ agent });
+    }
+  });
+
+  it("persists jules dismissal when bootstrapping a missing config file", () => {
+    mockReadFileSync.mockImplementation(() => {
+      const error = new Error("ENOENT");
+      Object.assign(error, { code: "ENOENT" });
+      throw error;
+    });
+
+    const config = loadConfig({
+      jules: { dismissed: true },
+    });
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CONFIG_PATH,
+      expect.stringContaining("jules:\n  dismissed: true"),
+      "utf-8",
+    );
+    expect(config.jules).toEqual({ dismissed: true });
   });
 
   it("reads config from ~/.gnhf/config.yml", () => {
@@ -190,6 +247,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 10,
       preventSleep: true,
     });
@@ -203,6 +261,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -216,6 +275,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -241,9 +301,18 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
+  });
+
+  it("reads jules dismissal from config", () => {
+    mockReadFileSync.mockReturnValue("jules:\n  dismissed: true\n");
+
+    const config = loadConfig();
+
+    expect(config.jules).toEqual({ dismissed: true });
   });
 
   it("handles empty config file gracefully", () => {
@@ -253,6 +322,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      jules: undefined,
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -337,5 +407,11 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow(
       /Invalid path for agentPathOverride.claude/,
     );
+  });
+
+  it("throws when jules.dismissed is not a boolean", () => {
+    mockReadFileSync.mockReturnValue('jules:\n  dismissed: "yes"\n');
+
+    expect(() => loadConfig()).toThrow(/Invalid config value for jules.dismissed/);
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,28 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode" | "kilo";
+export type AgentName =
+  | "claude"
+  | "codex"
+  | "rovodev"
+  | "opencode"
+  | "kilo"
+  | "gemini"
+  | "copilot"
+  | "junie"
+  | "jules";
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode", "kilo"] as const;
+const AGENT_NAMES = [
+  "claude",
+  "codex",
+  "rovodev",
+  "opencode",
+  "kilo",
+  "gemini",
+  "copilot",
+  "junie",
+  "jules",
+] as const;
 
 export interface Config {
   agent: AgentName;
@@ -79,7 +98,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
       );
     }
     if (typeof val !== "string") {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -25,6 +25,9 @@ export const AGENT_NAMES = [
 export interface Config {
   agent: AgentName;
   agentPathOverride: Partial<Record<AgentName, string>>;
+  jules?: {
+    dismissed?: boolean;
+  };
   maxConsecutiveFailures: number;
   preventSleep: boolean;
 }
@@ -113,6 +116,31 @@ function normalizeAgentPathOverride(
   return result;
 }
 
+function normalizeJulesConfig(
+  value: unknown,
+): Config["jules"] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidConfigError(
+      `Invalid config value for jules: expected an object`,
+    );
+  }
+
+  const raw = value as Record<string, unknown>;
+  const result: NonNullable<Config["jules"]> = {};
+
+  if (Object.prototype.hasOwnProperty.call(raw, "dismissed")) {
+    if (typeof raw.dismissed !== "boolean") {
+      throw new InvalidConfigError(
+        `Invalid config value for jules.dismissed: expected a boolean`,
+      );
+    }
+    result.dismissed = raw.dismissed;
+  }
+
+  return Object.keys(result).length > 0 ? result : {};
+}
+
 function normalizeConfig(
   config: Partial<Config>,
   configDir?: string,
@@ -152,6 +180,18 @@ function normalizeConfig(
     }
   } else {
     delete normalized.agentPathOverride;
+  }
+
+  const hasJules = Object.prototype.hasOwnProperty.call(config, "jules");
+  if (hasJules) {
+    const jules = normalizeJulesConfig(config.jules);
+    if (jules === undefined) {
+      delete normalized.jules;
+    } else {
+      normalized.jules = jules;
+    }
+  } else {
+    delete normalized.jules;
   }
 
   return normalized;
@@ -209,6 +249,25 @@ function serializeConfig(config: Config): string {
 
   lines.push(
     "",
+    "# Jules setup state (optional)",
+    "# jules:",
+    "#   dismissed: true",
+  );
+
+  if (config.jules && Object.keys(config.jules).length > 0) {
+    lines.push(
+      ...yaml
+        .dump(
+          { jules: config.jules },
+          { lineWidth: -1, noRefs: true, sortKeys: false },
+        )
+        .trimEnd()
+        .split("\n"),
+    );
+  }
+
+  lines.push(
+    "",
     "# Abort after this many consecutive failures",
     `maxConsecutiveFailures: ${config.maxConsecutiveFailures}`,
     "",
@@ -259,4 +318,11 @@ export function loadConfig(overrides?: Partial<Config>): Config {
   }
 
   return resolvedConfig;
+}
+
+export function saveConfig(config: Config): void {
+  const configDir = join(homedir(), ".gnhf");
+  const configPath = join(configDir, "config.yml");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(configPath, serializeConfig(config), "utf-8");
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,7 +14,7 @@ export type AgentName =
   | "junie"
   | "jules";
 
-const AGENT_NAMES = [
+export const AGENT_NAMES = [
   "claude",
   "codex",
   "rovodev",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -8,22 +8,18 @@ export type AgentName =
   | "codex"
   | "rovodev"
   | "opencode"
-  | "kilo"
   | "gemini"
   | "copilot"
-  | "junie"
-  | "jules";
+  | "junie";
 
 export const AGENT_NAMES = [
   "claude",
   "codex",
   "rovodev",
   "opencode",
-  "kilo",
   "gemini",
   "copilot",
   "junie",
-  "jules",
 ] as const;
 
 export interface Config {
@@ -98,7 +94,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "kilo", "gemini", "copilot", "junie", or "jules".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", "gemini", "copilot", or "junie".`,
       );
     }
     if (typeof val !== "string") {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,9 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
+export type AgentName = "claude" | "codex" | "rovodev" | "opencode" | "kilo";
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
+const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode", "kilo"] as const;
 
 export interface Config {
   agent: AgentName;
@@ -79,7 +79,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", "opencode", or "kilo".`,
       );
     }
     if (typeof val !== "string") {

--- a/src/core/jules-tooling.test.ts
+++ b/src/core/jules-tooling.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "./config.js";
+import {
+  getVisibleAgentNames,
+  isJulesConfigured,
+  maybePromptForJulesSetup,
+} from "./jules-tooling.js";
+
+function createConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    agent: "claude",
+    agentPathOverride: {},
+    maxConsecutiveFailures: 3,
+    preventSleep: true,
+    ...overrides,
+  };
+}
+
+describe("jules-tooling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("treats JULES_API_KEY as the Jules configuration signal", () => {
+    expect(isJulesConfigured({})).toBe(false);
+    expect(isJulesConfigured({ JULES_API_KEY: "   " })).toBe(false);
+    expect(isJulesConfigured({ JULES_API_KEY: "secret" })).toBe(true);
+  });
+
+  it("hides jules from visible agent names when it is not configured", () => {
+    expect(getVisibleAgentNames(createConfig(), {})).not.toContain("jules");
+  });
+
+  it("shows jules in visible agent names when it is configured", () => {
+    expect(
+      getVisibleAgentNames(createConfig(), { JULES_API_KEY: "secret" }),
+    ).toContain("jules");
+  });
+
+  it("does not prompt when Jules is already configured", async () => {
+    const ask = vi.fn();
+
+    const result = await maybePromptForJulesSetup(
+      createConfig(),
+      { JULES_API_KEY: "secret" },
+      true,
+      { ask },
+    );
+
+    expect(ask).not.toHaveBeenCalled();
+    expect(result).toEqual(createConfig());
+  });
+
+  it("does not prompt when stdin is not interactive", async () => {
+    const ask = vi.fn();
+
+    await maybePromptForJulesSetup(createConfig(), {}, false, { ask });
+
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it("prints setup guidance without enabling Jules when the user asks to set it up", async () => {
+    const ask = vi.fn(async () => "y");
+    const write = vi.fn();
+    const saveConfig = vi.fn();
+
+    const result = await maybePromptForJulesSetup(createConfig(), {}, true, {
+      ask,
+      write,
+      saveConfig,
+    });
+
+    expect(write).toHaveBeenCalledWith(expect.stringContaining("JULES_API_KEY"));
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(result).toEqual(createConfig());
+  });
+
+  it("persists dismissal and keeps Jules hidden when the user dismisses setup", async () => {
+    const ask = vi.fn(async () => "d");
+    const saveConfig = vi.fn();
+
+    const result = await maybePromptForJulesSetup(createConfig(), {}, true, {
+      ask,
+      saveConfig,
+    });
+
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jules: { dismissed: true },
+      }),
+    );
+    expect(result).toMatchObject({
+      jules: { dismissed: true },
+    });
+    expect(getVisibleAgentNames(result, {})).not.toContain("jules");
+  });
+
+  it("does not prompt again after Jules setup was dismissed", async () => {
+    const ask = vi.fn();
+
+    await maybePromptForJulesSetup(
+      createConfig({ jules: { dismissed: true } }),
+      {},
+      true,
+      { ask },
+    );
+
+    expect(ask).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/jules-tooling.ts
+++ b/src/core/jules-tooling.ts
@@ -1,0 +1,90 @@
+import type { Config, AgentName } from "./config.js";
+import { saveConfig } from "./config.js";
+import { buildJulesGuidance } from "../templates/jules-guidance.js";
+
+type JulesAwareAgentName = Exclude<AgentName, "jules">;
+
+export function isJulesConfigured(env: NodeJS.ProcessEnv): boolean {
+  return (env.JULES_API_KEY ?? "").trim().length > 0;
+}
+
+export function getVisibleAgentNames(
+  config: Config,
+  env: NodeJS.ProcessEnv,
+): AgentName[] {
+  const allAgents: AgentName[] = [
+    "claude",
+    "codex",
+    "rovodev",
+    "opencode",
+    "gemini",
+    "copilot",
+    "junie",
+    "jules",
+    "kilo",
+  ];
+
+  if (isJulesVisible(config, env)) {
+    return allAgents;
+  }
+
+  return allAgents.filter((agent) => agent !== "jules");
+}
+
+export function getJulesPromptGuidance(
+  agent: AgentName,
+  config: Config,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  if (agent === "jules") return undefined;
+  if (!isJulesVisible(config, env)) return undefined;
+  return buildJulesGuidance();
+}
+
+export async function maybePromptForJulesSetup(
+  config: Config,
+  env: NodeJS.ProcessEnv,
+  isInteractive: boolean,
+  deps: {
+    ask?: (question: string) => Promise<string>;
+    write?: (message: string) => void;
+    saveConfig?: (config: Config) => void;
+  } = {},
+): Promise<Config> {
+  if (!isInteractive) return config;
+  if (isJulesConfigured(env)) return config;
+  if (config.jules?.dismissed) return config;
+
+  const ask = deps.ask ?? (async () => "d");
+  const write = deps.write ?? (() => {});
+  const persist = deps.saveConfig ?? saveConfig;
+
+  const answer = (await ask(
+    'Jules is available as an optional remote tool. It runs slower than local work and creates its own branch/PR. Set it up now or dismiss it? [y/d]: ',
+  ))
+    .trim()
+    .toLowerCase();
+
+  if (answer === "y") {
+    write(
+      '\nTo enable Jules, install/configure your Jules environment and set JULES_API_KEY in your shell. Until then, gnhf will keep Jules hidden from prompts and agent selection.\n',
+    );
+    return config;
+  }
+
+  const nextConfig: Config = {
+    ...config,
+    jules: {
+      ...config.jules,
+      dismissed: true,
+    },
+  };
+  persist(nextConfig);
+  return nextConfig;
+}
+
+function isJulesVisible(config: Config, env: NodeJS.ProcessEnv): boolean {
+  return isJulesConfigured(env) && !config.jules?.dismissed;
+}
+
+export type { JulesAwareAgentName };

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -14,15 +14,21 @@ vi.mock("../templates/iteration-prompt.js", () => ({
   buildIterationPrompt: vi.fn(() => "iteration prompt"),
 }));
 
+vi.mock("./jules-tooling.js", () => ({
+  getJulesPromptGuidance: vi.fn(() => undefined),
+}));
+
 import { commitAll } from "./git.js";
 import { appendNotes } from "./run.js";
 import { Orchestrator } from "./orchestrator.js";
+import { getJulesPromptGuidance } from "./jules-tooling.js";
 import type { Agent, AgentResult } from "./agents/types.js";
 import type { Config } from "./config.js";
 import type { RunInfo } from "./run.js";
 
 const mockCommitAll = vi.mocked(commitAll);
 const mockAppendNotes = vi.mocked(appendNotes);
+const mockGetJulesPromptGuidance = vi.mocked(getJulesPromptGuidance);
 
 const config: Config = {
   agent: "claude",
@@ -62,6 +68,34 @@ describe("Orchestrator stop limits", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+  });
+
+  it("passes gated Jules guidance into the iteration prompt", async () => {
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => createSuccessResult()),
+    };
+    mockGetJulesPromptGuidance.mockReturnValue("Use Jules remotely.");
+    const { buildIterationPrompt } = await import("../templates/iteration-prompt.js");
+    const mockBuildIterationPrompt = vi.mocked(buildIterationPrompt);
+
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { maxIterations: 1 },
+    );
+
+    await orchestrator.start();
+
+    expect(mockBuildIterationPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        julesGuidance: "Use Jules remotely.",
+      }),
+    );
   });
 
   it("aborts before starting when the max iteration cap is already reached", async () => {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -6,6 +6,7 @@ import type { RunInfo } from "./run.js";
 import { commitAll, getBranchCommitCount, resetHard } from "./git.js";
 import { appendNotes } from "./run.js";
 import { buildIterationPrompt } from "../templates/iteration-prompt.js";
+import { getJulesPromptGuidance } from "./jules-tooling.js";
 
 export interface IterationRecord {
   number: number;
@@ -169,6 +170,11 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           n: this.state.currentIteration,
           runId: this.runInfo.runId,
           prompt: this.prompt,
+          julesGuidance: getJulesPromptGuidance(
+            this.config.agent,
+            this.config,
+            process.env,
+          ),
         });
 
         this.activeIterationPromise = this.runIteration(iterationPrompt);

--- a/src/templates/iteration-prompt.test.ts
+++ b/src/templates/iteration-prompt.test.ts
@@ -40,4 +40,25 @@ describe("buildIterationPrompt", () => {
     expect(result).toContain("Read .gnhf/runs/");
     expect(result).toContain("smallest logical unit");
   });
+
+  it("injects Jules guidance when Jules tooling is available", () => {
+    const result = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "test",
+      julesGuidance: "Jules is available for remote delegation.",
+    });
+
+    expect(result).toContain("Jules is available for remote delegation.");
+  });
+
+  it("omits Jules guidance when Jules tooling is unavailable", () => {
+    const result = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "test",
+    });
+
+    expect(result).not.toContain("Jules CLI/tooling is available");
+  });
 });

--- a/src/templates/iteration-prompt.ts
+++ b/src/templates/iteration-prompt.ts
@@ -1,7 +1,10 @@
+import { buildJulesGuidance } from "./jules-guidance.js";
+
 export function buildIterationPrompt(params: {
   n: number;
   runId: string;
   prompt: string;
+  julesGuidance?: string;
 }): string {
   return `You are working autonomously towards an objective given below.
 This is iteration ${params.n}. Each iteration aims to make an incremental step forward, not to complete the entire objective.
@@ -12,7 +15,8 @@ This is iteration ${params.n}. Each iteration aims to make an incremental step f
 2. Identify the next smallest logical unit of work that's individually verifiable and would make incremental progress towards the objective, and treat that as the scope of this iteration
 3. If you attempted a solution and it didn't end up moving the needle on the objective, document learnings and record success=false, then conclude the iteration rather than continuously pivoting
 4. If you made code changes, run build/tests/linters/formatters if available to validate your work. Do NOT make any git commits - that will be handled automatically by the gnhf orchestrator
-6. Finally, respond with a JSON object according to the provided schema
+${params.julesGuidance ? `5. ${params.julesGuidance}
+` : ""}6. Finally, respond with a JSON object according to the provided schema
 
 ## Output
 

--- a/src/templates/jules-guidance.test.ts
+++ b/src/templates/jules-guidance.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildJulesGuidance, JULES_GUIDANCE } from "./jules-guidance.js";
+
+describe("buildJulesGuidance", () => {
+  it("captures the remote Jules delegation policy", () => {
+    const guidance = buildJulesGuidance();
+
+    expect(guidance).toContain("runs remotely");
+    expect(guidance).toContain("slower than local work");
+    expect(guidance).toContain("creates its own branch and PR");
+    expect(guidance).toContain("Prefer Jules for isolated, longer-running tasks");
+    expect(guidance).toContain("Do not use Jules for quick local edits");
+    expect(guidance).toContain("You remain responsible for verifying any Jules result");
+  });
+
+  it("is assembled from the canonical guidance list", () => {
+    expect(buildJulesGuidance()).toBe(JULES_GUIDANCE.join(" "));
+  });
+});

--- a/src/templates/jules-guidance.ts
+++ b/src/templates/jules-guidance.ts
@@ -1,0 +1,11 @@
+export const JULES_GUIDANCE = [
+  "Jules CLI/tooling is available.",
+  "Use it selectively: it runs remotely, is slower than local work, and creates its own branch and PR.",
+  "Prefer Jules for isolated, longer-running tasks where a separate remote branch/PR is useful, such as broad codebase analysis, parallelizable implementation spikes, or self-contained refactors.",
+  "Do not use Jules for quick local edits, tight test-fix loops, or work that depends on rapid iteration in the current branch.",
+  "You remain responsible for verifying any Jules result.",
+] as const;
+
+export function buildJulesGuidance(): string {
+  return JULES_GUIDANCE.join(" ");
+}


### PR DESCRIPTION
## Summary
This PR finishes the user-facing Jules work and includes the Windows cleanup fix required to restore E2E behavior. It adds Jules setup gating and dismissal persistence, prompt guidance visibility control, README guidance, and the Windows serve-agent shutdown fallback.

This PR should be reviewed and merged after the earlier split PRs, especially #51. It is presented separately because it mixes product behavior, prompt wording, docs, and the Windows-specific cleanup fix.

## Dependency
- Depends on #51
- Also logically follows the new agent wiring PR
- Review after: #51 and the agent-additions PR
- Merge after: #51 and the agent-additions PR

## Included scope
- Jules setup gating and dismissal persistence
- reusable Jules guidance and prompt injection changes
- CLI behavior for hidden vs visible Jules availability
- README updates describing Jules usage expectations
- Windows cleanup fallback for serve-mode agents
- E2E restoration

## Reviewer Notes
This PR is expected to overlap with the new-agent wiring work if that upstream dependency has not landed yet. The intended review focus here is Jules product behavior, user-facing guidance, and the Windows cleanup fix.

## Testing
- `npx vitest run src/core/jules-tooling.test.ts src/core/agents/jules-api.test.ts src/core/agents/jules.test.ts src/core/orchestrator.test.ts src/templates/jules-guidance.test.ts src/templates/iteration-prompt.test.ts src/cli.test.ts`
- `npm run test:e2e`
