### PR TITLE
feat(codex): allow per-agent cli arg overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,11 @@ If the file does not exist yet, `gnhf` creates it on first run using the resolve
 CLI flags override config file values. `--prevent-sleep` accepts `on`/`off` as well as `true`/`false`; the config file always uses a boolean.
 The iteration and token caps are runtime-only flags and are not persisted in `config.yml`.
 
-Use `agentArgsOverride.<name>` to pass through additional CLI flags for any supported agent without needing a dedicated `gnhf` config field for each one. For example, the `codex` snippet above sets the model, reasoning effort, and full-auto mode directly. If you do not specify any Codex execution-mode flags there, `gnhf` keeps its current default of `--dangerously-bypass-approvals-and-sandbox`. If you do override Codex sandbox or approval flags, `gnhf` treats that as fully user-managed and will not add its default execution-mode flag for you. Flags that `gnhf` manages itself for a given agent are rejected during config loading so users get a clear error instead of duplicate-argument ambiguity.
+`agentArgsOverride.<name>` lets you pass through extra CLI flags for any supported agent.
+
+- Use it for agent-specific options like models, profiles, or reasoning settings without adding a dedicated `gnhf` config field for each one.
+- For `codex` and `claude`, `gnhf` adds its usual non-interactive permission default only when you do not provide your own permission or execution-mode flag. If you set one explicitly, `gnhf` treats that as user-managed and does not add its default on top.
+- Flags that `gnhf` manages itself for a given agent, such as output-shaping or local-server startup flags, are rejected during config loading so you get a clear error instead of duplicate-argument ambiguity.
 
 ### Custom Agent Paths
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ agent: claude
 #   claude: /path/to/custom-claude
 #   codex: /path/to/custom-codex
 
+# Per-agent CLI arg overrides (optional)
+# agentArgsOverride:
+#   codex:
+#     - -m
+#     - gpt-5.4
+#     - -c
+#     - model_reasoning_effort="high"
+#     - --full-auto
+
 # Abort after this many consecutive failures
 maxConsecutiveFailures: 3
 
@@ -176,6 +185,8 @@ If the file does not exist yet, `gnhf` creates it on first run using the resolve
 
 CLI flags override config file values. `--prevent-sleep` accepts `on`/`off` as well as `true`/`false`; the config file always uses a boolean.
 The iteration and token caps are runtime-only flags and are not persisted in `config.yml`.
+
+Use `agentArgsOverride.<name>` to pass through additional CLI flags for a specific agent without needing a dedicated `gnhf` config field for each one. For example, the `codex` snippet above sets the model, reasoning effort, and full-auto mode directly. If you do not specify any Codex execution-mode flags there, `gnhf` keeps its current default of `--dangerously-bypass-approvals-and-sandbox`. If you do override Codex sandbox or approval flags, `gnhf` treats that as fully user-managed and will not add its default execution-mode flag for you.
 
 ### Custom Agent Paths
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If the file does not exist yet, `gnhf` creates it on first run using the resolve
 CLI flags override config file values. `--prevent-sleep` accepts `on`/`off` as well as `true`/`false`; the config file always uses a boolean.
 The iteration and token caps are runtime-only flags and are not persisted in `config.yml`.
 
-Use `agentArgsOverride.<name>` to pass through additional CLI flags for a specific agent without needing a dedicated `gnhf` config field for each one. For example, the `codex` snippet above sets the model, reasoning effort, and full-auto mode directly. If you do not specify any Codex execution-mode flags there, `gnhf` keeps its current default of `--dangerously-bypass-approvals-and-sandbox`. If you do override Codex sandbox or approval flags, `gnhf` treats that as fully user-managed and will not add its default execution-mode flag for you.
+Use `agentArgsOverride.<name>` to pass through additional CLI flags for any supported agent without needing a dedicated `gnhf` config field for each one. For example, the `codex` snippet above sets the model, reasoning effort, and full-auto mode directly. If you do not specify any Codex execution-mode flags there, `gnhf` keeps its current default of `--dangerously-bypass-approvals-and-sandbox`. If you do override Codex sandbox or approval flags, `gnhf` treats that as fully user-managed and will not add its default execution-mode flag for you. Flags that `gnhf` manages itself for a given agent are rejected during config loading so users get a clear error instead of duplicate-argument ambiguity.
 
 ### Custom Agent Paths
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -311,12 +311,11 @@ describe("cli", () => {
       preventSleep: false,
     });
 
-    expect(createAgent).toHaveBeenCalledWith(
-      "codex",
-      stubRunInfo,
-      undefined,
-      ["-m", "gpt-5.4", "--full-auto"],
-    );
+    expect(createAgent).toHaveBeenCalledWith("codex", stubRunInfo, undefined, [
+      "-m",
+      "gpt-5.4",
+      "--full-auto",
+    ]);
   });
 
   it("passes max iteration and token caps to the orchestrator", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -223,6 +223,7 @@ describe("cli", () => {
     const { loadConfig, createAgent } = await runCliWithMocks(["ship it"], {
       agent: "codex",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -242,6 +243,7 @@ describe("cli", () => {
       {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -262,6 +264,7 @@ describe("cli", () => {
       {
         agent: "rovodev",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -282,6 +285,7 @@ describe("cli", () => {
       {
         agent: "opencode",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -321,6 +325,7 @@ describe("cli", () => {
       {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -338,6 +343,7 @@ describe("cli", () => {
       await runCliWithMocks(["ship it", "--prevent-sleep", "off"], {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       });
@@ -348,6 +354,7 @@ describe("cli", () => {
     expect(orchestratorCtor.mock.calls[0]?.[0]).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -365,6 +372,7 @@ describe("cli", () => {
         {
           agent: "claude",
           agentPathOverride: {},
+          agentArgsOverride: {},
           maxConsecutiveFailures: 3,
           preventSleep: true,
         },
@@ -397,6 +405,7 @@ describe("cli", () => {
       {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: true,
       },
@@ -431,6 +440,7 @@ describe("cli", () => {
         {
           agent: "claude",
           agentPathOverride: {},
+          agentArgsOverride: {},
           maxConsecutiveFailures: 3,
           preventSleep: true,
         },
@@ -470,6 +480,7 @@ describe("cli", () => {
       {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: true,
       },
@@ -511,6 +522,7 @@ describe("cli", () => {
         {
           agent: "claude",
           agentPathOverride: {},
+          agentArgsOverride: {},
           maxConsecutiveFailures: 3,
           preventSleep: true,
         },
@@ -546,6 +558,7 @@ describe("cli", () => {
         {
           agent: "claude",
           agentPathOverride: {},
+          agentArgsOverride: {},
           maxConsecutiveFailures: 3,
           preventSleep: true,
         },
@@ -576,6 +589,7 @@ describe("cli", () => {
     const loadConfig = vi.fn(() => ({
       agent: "claude" as const,
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     }));
@@ -713,6 +727,7 @@ describe("cli", () => {
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: true,
       })),
@@ -788,6 +803,7 @@ describe("cli", () => {
       {
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -824,6 +840,7 @@ describe("cli", () => {
       {
         agent: "opencode",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       },
@@ -862,6 +879,7 @@ describe("cli", () => {
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       })),
@@ -937,6 +955,7 @@ describe("cli", () => {
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       })),
@@ -1030,6 +1049,7 @@ describe("cli", () => {
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
+        agentArgsOverride: {},
         maxConsecutiveFailures: 3,
         preventSleep: false,
       })),

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -228,7 +228,12 @@ describe("cli", () => {
     });
 
     expect(loadConfig).toHaveBeenCalledWith({});
-    expect(createAgent).toHaveBeenCalledWith("codex", stubRunInfo, undefined);
+    expect(createAgent).toHaveBeenCalledWith(
+      "codex",
+      stubRunInfo,
+      undefined,
+      undefined,
+    );
   });
 
   it("uses the explicit --agent flag as an override", async () => {
@@ -243,7 +248,12 @@ describe("cli", () => {
     );
 
     expect(loadConfig).toHaveBeenCalledWith({ agent: "claude" });
-    expect(createAgent).toHaveBeenCalledWith("claude", stubRunInfo, undefined);
+    expect(createAgent).toHaveBeenCalledWith(
+      "claude",
+      stubRunInfo,
+      undefined,
+      undefined,
+    );
   });
 
   it("accepts rovodev as an explicit --agent override", async () => {
@@ -258,7 +268,12 @@ describe("cli", () => {
     );
 
     expect(loadConfig).toHaveBeenCalledWith({ agent: "rovodev" });
-    expect(createAgent).toHaveBeenCalledWith("rovodev", stubRunInfo, undefined);
+    expect(createAgent).toHaveBeenCalledWith(
+      "rovodev",
+      stubRunInfo,
+      undefined,
+      undefined,
+    );
   });
 
   it("accepts opencode as an explicit --agent override", async () => {
@@ -277,6 +292,26 @@ describe("cli", () => {
       "opencode",
       stubRunInfo,
       undefined,
+      undefined,
+    );
+  });
+
+  it("passes per-agent config through to agent creation", async () => {
+    const { createAgent } = await runCliWithMocks(["ship it"], {
+      agent: "codex",
+      agentPathOverride: {},
+      agentArgsOverride: {
+        codex: ["-m", "gpt-5.4", "--full-auto"],
+      },
+      maxConsecutiveFailures: 3,
+      preventSleep: false,
+    });
+
+    expect(createAgent).toHaveBeenCalledWith(
+      "codex",
+      stubRunInfo,
+      undefined,
+      ["-m", "gpt-5.4", "--full-auto"],
     );
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -238,13 +238,13 @@ program
         process.exit(1);
       }
 
-      const loadedConfig = loadConfig({
-        ...(agentName
+      const loadedConfig = loadConfig(
+        agentName
           ? {
               agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
             }
-          : {}),
-      });
+          : {},
+      );
       const config = {
         ...loadedConfig,
         ...(options.preventSleep === undefined

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -238,13 +238,13 @@ program
         process.exit(1);
       }
 
-      const loadedConfig = loadConfig(
-        agentName
+      const loadedConfig = loadConfig({
+        ...(agentName
           ? {
               agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
             }
-          : {},
-      );
+          : {}),
+      });
       const config = {
         ...loadedConfig,
         ...(options.preventSleep === undefined
@@ -358,6 +358,7 @@ program
         maxIterations: options.maxIterations,
         maxTokens: options.maxTokens,
         preventSleep: config.preventSleep,
+        agentArgsOverride: config.agentArgsOverride?.[config.agent],
         platform: process.platform,
         nodeVersion: process.version,
         gnhfVersion: packageVersion,
@@ -367,6 +368,7 @@ program
         config.agent,
         runInfo,
         config.agentPathOverride[config.agent],
+        config.agentArgsOverride?.[config.agent],
       );
       const orchestrator = new Orchestrator(
         config,

--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -159,6 +159,33 @@ describe("ClaudeAgent", () => {
     );
   });
 
+  it("passes configured extra args through to claude", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new ClaudeAgent({
+      extraArgs: ["--model", "sonnet", "--permission-mode=plan"],
+    });
+
+    configuredAgent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      [
+        "--model",
+        "sonnet",
+        "--permission-mode=plan",
+        "-p",
+        "test prompt",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--json-schema",
+        expect.any(String),
+      ],
+      expect.any(Object),
+    );
+  });
+
   it("kills the full process tree on Windows when aborted", async () => {
     const proc = createMockProcess();
     Object.defineProperty(proc, "pid", { value: 5678 });

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -145,16 +145,12 @@ export class ClaudeAgent implements Agent {
     return new Promise((resolve, reject) => {
       const logStream = logPath ? createWriteStream(logPath) : null;
 
-      const child = spawn(
-        this.bin,
-        buildClaudeArgs(prompt, this.extraArgs),
-        {
-          cwd,
-          shell: shouldUseWindowsShell(this.bin, this.platform),
-          stdio: ["ignore", "pipe", "pipe"],
-          env: process.env,
-        },
-      );
+      const child = spawn(this.bin, buildClaudeArgs(prompt, this.extraArgs), {
+        cwd,
+        shell: shouldUseWindowsShell(this.bin, this.platform),
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      });
 
       if (
         setupAbortHandler(signal, child, reject, () =>

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -44,6 +44,7 @@ type ClaudeEvent = ClaudeAssistantEvent | ClaudeResultEvent | { type: string };
 
 interface ClaudeAgentDeps {
   bin?: string;
+  extraArgs?: string[];
   platform?: NodeJS.Platform;
 }
 
@@ -96,15 +97,41 @@ function terminateClaudeProcess(
   child.kill("SIGTERM");
 }
 
+function buildClaudeArgs(prompt: string, extraArgs?: string[]): string[] {
+  const userArgs = extraArgs ?? [];
+  const userSpecifiedPermissionMode = userArgs.some(
+    (arg) =>
+      arg === "--dangerously-skip-permissions" ||
+      arg === "--permission-mode" ||
+      arg.startsWith("--permission-mode=") ||
+      arg === "--permission-prompt-tool" ||
+      arg.startsWith("--permission-prompt-tool="),
+  );
+
+  return [
+    ...userArgs,
+    "-p",
+    prompt,
+    "--verbose",
+    "--output-format",
+    "stream-json",
+    "--json-schema",
+    JSON.stringify(AGENT_OUTPUT_SCHEMA),
+    ...(userSpecifiedPermissionMode ? [] : ["--dangerously-skip-permissions"]),
+  ];
+}
+
 export class ClaudeAgent implements Agent {
   name = "claude";
 
   private bin: string;
+  private extraArgs?: string[];
   private platform: NodeJS.Platform;
 
   constructor(binOrDeps: string | ClaudeAgentDeps = {}) {
     const deps = typeof binOrDeps === "string" ? { bin: binOrDeps } : binOrDeps;
     this.bin = deps.bin ?? "claude";
+    this.extraArgs = deps.extraArgs;
     this.platform = deps.platform ?? process.platform;
   }
 
@@ -120,16 +147,7 @@ export class ClaudeAgent implements Agent {
 
       const child = spawn(
         this.bin,
-        [
-          "-p",
-          prompt,
-          "--verbose",
-          "--output-format",
-          "stream-json",
-          "--json-schema",
-          JSON.stringify(AGENT_OUTPUT_SCHEMA),
-          "--dangerously-skip-permissions",
-        ],
+        buildClaudeArgs(prompt, this.extraArgs),
         {
           cwd,
           shell: shouldUseWindowsShell(this.bin, this.platform),

--- a/src/core/agents/codex.test.ts
+++ b/src/core/agents/codex.test.ts
@@ -156,6 +156,31 @@ describe("CodexAgent", () => {
     );
   });
 
+  it("suppresses the default dangerous flag when the user sets sandbox mode with = syntax", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CodexAgent("/tmp/schema.json", {
+      extraArgs: ["--sandbox=workspace-write"],
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "codex",
+      [
+        "exec",
+        "--sandbox=workspace-write",
+        "test prompt",
+        "--json",
+        "--output-schema",
+        "/tmp/schema.json",
+        "--color",
+        "never",
+      ],
+      expect.any(Object),
+    );
+  });
+
   it("kills the full process tree on Windows when aborted", async () => {
     const proc = createMockProcess();
     Object.defineProperty(proc, "pid", { value: 6789 });

--- a/src/core/agents/codex.test.ts
+++ b/src/core/agents/codex.test.ts
@@ -121,6 +121,41 @@ describe("CodexAgent", () => {
     );
   });
 
+  it("passes configured extra args through to codex exec", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CodexAgent("/tmp/schema.json", {
+      extraArgs: [
+        "-m",
+        "gpt-5.4",
+        "-c",
+        'model_reasoning_effort="high"',
+        "--full-auto",
+      ],
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "codex",
+      [
+        "exec",
+        "-m",
+        "gpt-5.4",
+        "-c",
+        'model_reasoning_effort="high"',
+        "--full-auto",
+        "test prompt",
+        "--json",
+        "--output-schema",
+        "/tmp/schema.json",
+        "--color",
+        "never",
+      ],
+      expect.any(Object),
+    );
+  });
+
   it("kills the full process tree on Windows when aborted", async () => {
     const proc = createMockProcess();
     Object.defineProperty(proc, "pid", { value: 6789 });

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -31,6 +31,7 @@ type CodexEvent = CodexItemCompleted | CodexTurnCompleted | { type: string };
 
 interface CodexAgentDeps {
   bin?: string;
+  extraArgs?: string[];
   platform?: NodeJS.Platform;
 }
 
@@ -83,16 +84,48 @@ function terminateCodexProcess(
   child.kill("SIGTERM");
 }
 
+function buildCodexArgs(
+  prompt: string,
+  schemaPath: string,
+  extraArgs?: string[],
+): string[] {
+  const userArgs = extraArgs ?? [];
+  const userSpecifiedExecutionMode = userArgs.some((arg) =>
+    arg === "--full-auto" ||
+    arg === "--dangerously-bypass-approvals-and-sandbox" ||
+    arg === "--sandbox" ||
+    arg === "-s" ||
+    arg === "--ask-for-approval" ||
+    arg === "-a",
+  );
+
+  return [
+    "exec",
+    ...userArgs,
+    prompt,
+    "--json",
+    "--output-schema",
+    schemaPath,
+    ...(userSpecifiedExecutionMode
+      ? []
+      : ["--dangerously-bypass-approvals-and-sandbox"]),
+    "--color",
+    "never",
+  ];
+}
+
 export class CodexAgent implements Agent {
   name = "codex";
 
   private bin: string;
+  private extraArgs?: string[];
   private platform: NodeJS.Platform;
   private schemaPath: string;
 
   constructor(schemaPath: string, binOrDeps: string | CodexAgentDeps = {}) {
     const deps = typeof binOrDeps === "string" ? { bin: binOrDeps } : binOrDeps;
     this.bin = deps.bin ?? "codex";
+    this.extraArgs = deps.extraArgs;
     this.platform = deps.platform ?? process.platform;
     this.schemaPath = schemaPath;
   }
@@ -109,16 +142,7 @@ export class CodexAgent implements Agent {
 
       const child = spawn(
         this.bin,
-        [
-          "exec",
-          prompt,
-          "--json",
-          "--output-schema",
-          this.schemaPath,
-          "--dangerously-bypass-approvals-and-sandbox",
-          "--color",
-          "never",
-        ],
+        buildCodexArgs(prompt, this.schemaPath, this.extraArgs),
         {
           cwd,
           shell: shouldUseWindowsShell(this.bin, this.platform),

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -90,15 +90,16 @@ function buildCodexArgs(
   extraArgs?: string[],
 ): string[] {
   const userArgs = extraArgs ?? [];
-  const userSpecifiedExecutionMode = userArgs.some((arg) =>
-    arg === "--full-auto" ||
-    arg === "--dangerously-bypass-approvals-and-sandbox" ||
-    arg === "--sandbox" ||
-    arg.startsWith("--sandbox=") ||
-    arg === "-s" ||
-    arg === "--ask-for-approval" ||
-    arg.startsWith("--ask-for-approval=") ||
-    arg === "-a",
+  const userSpecifiedExecutionMode = userArgs.some(
+    (arg) =>
+      arg === "--full-auto" ||
+      arg === "--dangerously-bypass-approvals-and-sandbox" ||
+      arg === "--sandbox" ||
+      arg.startsWith("--sandbox=") ||
+      arg === "-s" ||
+      arg === "--ask-for-approval" ||
+      arg.startsWith("--ask-for-approval=") ||
+      arg === "-a",
   );
 
   return [

--- a/src/core/agents/codex.ts
+++ b/src/core/agents/codex.ts
@@ -94,8 +94,10 @@ function buildCodexArgs(
     arg === "--full-auto" ||
     arg === "--dangerously-bypass-approvals-and-sandbox" ||
     arg === "--sandbox" ||
+    arg.startsWith("--sandbox=") ||
     arg === "-s" ||
     arg === "--ask-for-approval" ||
+    arg.startsWith("--ask-for-approval=") ||
     arg === "-a",
   );
 

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("./claude.js", () => {
-  const ClaudeAgent = vi.fn(function (this: Record<string, unknown>) {
+  const ClaudeAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps?: Record<string, unknown>,
+  ) {
     this.name = "claude";
+    this.deps = deps;
   });
   return { ClaudeAgent };
 });
@@ -22,16 +26,22 @@ vi.mock("./rovodev.js", () => {
   const RovoDevAgent = vi.fn(function (
     this: Record<string, unknown>,
     schemaPath: string,
+    deps?: Record<string, unknown>,
   ) {
     this.name = "rovodev";
     this.schemaPath = schemaPath;
+    this.deps = deps;
   });
   return { RovoDevAgent };
 });
 
 vi.mock("./opencode.js", () => {
-  const OpenCodeAgent = vi.fn(function (this: Record<string, unknown>) {
+  const OpenCodeAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps?: Record<string, unknown>,
+  ) {
     this.name = "opencode";
+    this.deps = deps;
   });
   return { OpenCodeAgent };
 });
@@ -56,7 +66,23 @@ const stubRunInfo: RunInfo = {
 describe("createAgent", () => {
   it("creates a ClaudeAgent when name is 'claude'", () => {
     const agent = createAgent("claude", stubRunInfo);
-    expect(ClaudeAgent).toHaveBeenCalledWith(undefined);
+    expect(ClaudeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+    });
+    expect(agent.name).toBe("claude");
+  });
+
+  it("passes per-agent extra args through to the ClaudeAgent", () => {
+    const agent = createAgent("claude", stubRunInfo, undefined, [
+      "--model",
+      "sonnet",
+    ]);
+
+    expect(ClaudeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: ["--model", "sonnet"],
+    });
     expect(agent.name).toBe("claude");
   });
 
@@ -87,13 +113,43 @@ describe("createAgent", () => {
     const agent = createAgent("rovodev", stubRunInfo);
     expect(RovoDevAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
       bin: undefined,
+      extraArgs: undefined,
+    });
+    expect(agent.name).toBe("rovodev");
+  });
+
+  it("passes per-agent extra args through to the RovoDevAgent", () => {
+    const agent = createAgent("rovodev", stubRunInfo, undefined, [
+      "--profile",
+      "work",
+    ]);
+
+    expect(RovoDevAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
+      bin: undefined,
+      extraArgs: ["--profile", "work"],
     });
     expect(agent.name).toBe("rovodev");
   });
 
   it("creates an OpenCodeAgent when name is 'opencode'", () => {
     const agent = createAgent("opencode", stubRunInfo);
-    expect(OpenCodeAgent).toHaveBeenCalledWith({ bin: undefined });
+    expect(OpenCodeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+    });
+    expect(agent.name).toBe("opencode");
+  });
+
+  it("passes per-agent extra args through to the OpenCodeAgent", () => {
+    const agent = createAgent("opencode", stubRunInfo, undefined, [
+      "--model",
+      "gpt-5",
+    ]);
+
+    expect(OpenCodeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: ["--model", "gpt-5"],
+    });
     expect(agent.name).toBe("opencode");
   });
 });

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -62,7 +62,24 @@ describe("createAgent", () => {
 
   it("creates a CodexAgent when name is 'codex'", () => {
     const agent = createAgent("codex", stubRunInfo);
-    expect(CodexAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, undefined);
+    expect(CodexAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
+      bin: undefined,
+      extraArgs: undefined,
+    });
+    expect(agent.name).toBe("codex");
+  });
+
+  it("passes per-agent extra args through to the CodexAgent", () => {
+    const agent = createAgent("codex", stubRunInfo, undefined, [
+      "-m",
+      "gpt-5.4",
+      "--full-auto",
+    ]);
+
+    expect(CodexAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
+      bin: undefined,
+      extraArgs: ["-m", "gpt-5.4", "--full-auto"],
+    });
     expect(agent.name).toBe("codex");
   });
 

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -14,15 +14,24 @@ export function createAgent(
 ): Agent {
   switch (name) {
     case "claude":
-      return new ClaudeAgent(pathOverride);
+      return new ClaudeAgent({
+        bin: pathOverride,
+        extraArgs: agentArgsOverride,
+      });
     case "codex":
       return new CodexAgent(runInfo.schemaPath, {
         bin: pathOverride,
         extraArgs: agentArgsOverride,
       });
     case "opencode":
-      return new OpenCodeAgent({ bin: pathOverride });
+      return new OpenCodeAgent({
+        bin: pathOverride,
+        extraArgs: agentArgsOverride,
+      });
     case "rovodev":
-      return new RovoDevAgent(runInfo.schemaPath, { bin: pathOverride });
+      return new RovoDevAgent(runInfo.schemaPath, {
+        bin: pathOverride,
+        extraArgs: agentArgsOverride,
+      });
   }
 }

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -10,12 +10,16 @@ export function createAgent(
   name: AgentName,
   runInfo: RunInfo,
   pathOverride?: string,
+  agentArgsOverride?: string[],
 ): Agent {
   switch (name) {
     case "claude":
       return new ClaudeAgent(pathOverride);
     case "codex":
-      return new CodexAgent(runInfo.schemaPath, pathOverride);
+      return new CodexAgent(runInfo.schemaPath, {
+        bin: pathOverride,
+        extraArgs: agentArgsOverride,
+      });
     case "opencode":
       return new OpenCodeAgent({ bin: pathOverride });
     case "rovodev":

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -501,12 +501,12 @@ describe("OpenCodeAgent", () => {
       jsonResponse({ healthy: true, version: "1.3.13" }),
     );
 
-    await expect(configuredAgent["ensureServer"]("/repo")).resolves.toMatchObject(
-      {
-        cwd: "/repo",
-        port: 8765,
-      },
-    );
+    await expect(
+      configuredAgent["ensureServer"]("/repo"),
+    ).resolves.toMatchObject({
+      cwd: "/repo",
+      port: 8765,
+    });
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "opencode",

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -488,6 +488,44 @@ describe("OpenCodeAgent", () => {
     );
   });
 
+  it("passes configured extra args through to opencode serve", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new OpenCodeAgent({
+      extraArgs: ["--model", "gpt-5"],
+      fetch: fetchMock as typeof fetch,
+      getPort,
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ healthy: true, version: "1.3.13" }),
+    );
+
+    await expect(configuredAgent["ensureServer"]("/repo")).resolves.toMatchObject(
+      {
+        cwd: "/repo",
+        port: 8765,
+      },
+    );
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "opencode",
+      [
+        "serve",
+        "--model",
+        "gpt-5",
+        "--hostname",
+        "127.0.0.1",
+        "--port",
+        "8765",
+        "--print-logs",
+      ],
+      expect.objectContaining({
+        cwd: "/repo",
+      }),
+    );
+  });
+
   it("uses a shell on Windows so PATH-resolved .cmd shims can launch", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -81,6 +81,7 @@ interface OpenCodeStreamEvent {
 
 interface OpenCodeDeps {
   bin?: string;
+  extraArgs?: string[];
   fetch?: typeof fetch;
   getPort?: () => Promise<number>;
   killProcess?: typeof process.kill;
@@ -257,6 +258,7 @@ export class OpenCodeAgent implements Agent {
   name = "opencode";
 
   private bin: string;
+  private extraArgs?: string[];
   private fetchFn: typeof fetch;
   private getPortFn: () => Promise<number>;
   private killProcessFn: typeof process.kill;
@@ -267,6 +269,7 @@ export class OpenCodeAgent implements Agent {
 
   constructor(deps: OpenCodeDeps = {}) {
     this.bin = deps.bin ?? "opencode";
+    this.extraArgs = deps.extraArgs;
     this.fetchFn = deps.fetch ?? fetch;
     this.getPortFn = deps.getPort ?? getAvailablePort;
     this.killProcessFn = deps.killProcess ?? process.kill.bind(process);
@@ -380,6 +383,7 @@ export class OpenCodeAgent implements Agent {
       this.bin,
       [
         "serve",
+        ...(this.extraArgs ?? []),
         "--hostname",
         "127.0.0.1",
         "--port",

--- a/src/core/agents/rovodev.test.ts
+++ b/src/core/agents/rovodev.test.ts
@@ -273,6 +273,41 @@ describe("RovoDevAgent", () => {
     );
   });
 
+  it("passes configured extra args through to rovodev serve", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new RovoDevAgent(schemaPath, {
+      extraArgs: ["--profile", "work"],
+      fetch: fetchMock as typeof fetch,
+      getPort,
+      platform: "linux",
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "healthy" }));
+
+    await expect(configuredAgent["ensureServer"]("/repo")).resolves.toMatchObject(
+      {
+        cwd: "/repo",
+        port: 8765,
+      },
+    );
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "acli",
+      [
+        "rovodev",
+        "serve",
+        "--profile",
+        "work",
+        "--disable-session-token",
+        "8765",
+      ],
+      expect.objectContaining({
+        cwd: "/repo",
+      }),
+    );
+  });
+
   it("reuses the existing server process across runs", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/rovodev.test.ts
+++ b/src/core/agents/rovodev.test.ts
@@ -285,12 +285,12 @@ describe("RovoDevAgent", () => {
 
     fetchMock.mockResolvedValueOnce(jsonResponse({ status: "healthy" }));
 
-    await expect(configuredAgent["ensureServer"]("/repo")).resolves.toMatchObject(
-      {
-        cwd: "/repo",
-        port: 8765,
-      },
-    );
+    await expect(
+      configuredAgent["ensureServer"]("/repo"),
+    ).resolves.toMatchObject({
+      cwd: "/repo",
+      port: 8765,
+    });
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "acli",

--- a/src/core/agents/rovodev.ts
+++ b/src/core/agents/rovodev.ts
@@ -28,6 +28,7 @@ interface RovoDevSessionResponse {
 
 interface RovoDevDeps {
   bin?: string;
+  extraArgs?: string[];
   fetch?: typeof fetch;
   getPort?: () => Promise<number>;
   killProcess?: typeof process.kill;
@@ -170,6 +171,7 @@ export class RovoDevAgent implements Agent {
   name = "rovodev";
 
   private bin: string;
+  private extraArgs?: string[];
   private schemaPath: string;
   private fetchFn: typeof fetch;
   private getPortFn: () => Promise<number>;
@@ -181,6 +183,7 @@ export class RovoDevAgent implements Agent {
 
   constructor(schemaPath: string, deps: RovoDevDeps = {}) {
     this.bin = deps.bin ?? "acli";
+    this.extraArgs = deps.extraArgs;
     this.schemaPath = schemaPath;
     this.fetchFn = deps.fetch ?? fetch;
     this.getPortFn = deps.getPort ?? getAvailablePort;
@@ -294,7 +297,13 @@ export class RovoDevAgent implements Agent {
     const detached = this.platform !== "win32";
     const child = this.spawnFn(
       this.bin,
-      ["rovodev", "serve", "--disable-session-token", String(port)],
+      [
+        "rovodev",
+        "serve",
+        ...(this.extraArgs ?? []),
+        "--disable-session-token",
+        String(port),
+      ],
       {
         cwd,
         detached,

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -22,7 +22,7 @@ const HOME = "/mock-home";
 const CONFIG_DIR = join(HOME, ".gnhf");
 const CONFIG_PATH = join(CONFIG_DIR, "config.yml");
 const BOOTSTRAP_CONFIG_TEMPLATE = (agent: string) =>
-  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort=\"high\"\n#     - --full-auto\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
+  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort="high"\n#     - --full-auto\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -47,6 +47,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -67,6 +68,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -89,6 +91,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "codex",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -127,6 +130,7 @@ describe("loadConfig", () => {
         claude: resolvedClaude,
         codex: resolvedCodex,
       },
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -149,6 +153,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "rovodev",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -171,6 +176,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "opencode",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -192,6 +198,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 10,
       preventSleep: true,
     });
@@ -205,6 +212,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -218,6 +226,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: false,
     });
@@ -237,12 +246,14 @@ describe("loadConfig", () => {
     const config = loadConfig({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -260,6 +271,36 @@ describe("loadConfig", () => {
     });
   });
 
+  it("reads per-agent extra args for all supported agents", () => {
+    mockReadFileSync.mockReturnValue(
+      [
+        "agentArgsOverride:",
+        "  claude:",
+        "    - --model",
+        "    - sonnet",
+        "  codex:",
+        "    - -m",
+        "    - gpt-5.4",
+        "  rovodev:",
+        "    - --profile",
+        "    - work",
+        "  opencode:",
+        "    - --model",
+        "    - gpt-5",
+        "",
+      ].join("\n"),
+    );
+
+    const config = loadConfig();
+
+    expect(config.agentArgsOverride).toEqual({
+      claude: ["--model", "sonnet"],
+      codex: ["-m", "gpt-5.4"],
+      rovodev: ["--profile", "work"],
+      opencode: ["--model", "gpt-5"],
+    });
+  });
+
   it("handles empty config file gracefully", () => {
     mockReadFileSync.mockReturnValue("");
 
@@ -267,6 +308,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -281,6 +323,7 @@ describe("loadConfig", () => {
     expect(config).toEqual({
       agent: "claude",
       agentPathOverride: {},
+      agentArgsOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
@@ -378,6 +421,26 @@ describe("loadConfig", () => {
 
     expect(() => loadConfig()).toThrow(
       /Invalid config value for agentArgsOverride\.codex\[0\]/,
+    );
+  });
+
+  it("throws when agentArgsOverride.codex contains gnhf-managed flags", () => {
+    mockReadFileSync.mockReturnValue(
+      "agentArgsOverride:\n  codex:\n    - --output-schema=custom.json\n",
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /agentArgsOverride\.codex\[0\].*managed by gnhf/,
+    );
+  });
+
+  it("throws when agentArgsOverride.rovodev contains gnhf-managed flags", () => {
+    mockReadFileSync.mockReturnValue(
+      "agentArgsOverride:\n  rovodev:\n    - serve\n",
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /agentArgsOverride\.rovodev\[0\].*managed by gnhf/,
     );
   });
 });

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -261,7 +261,7 @@ describe("loadConfig", () => {
 
   it("reads per-agent extra args from config", () => {
     mockReadFileSync.mockReturnValue(
-      'agentArgsOverride:\n  codex:\n    - -m\n    - gpt-5.4\n    - --full-auto\n',
+      "agentArgsOverride:\n  codex:\n    - -m\n    - gpt-5.4\n    - --full-auto\n",
     );
 
     const config = loadConfig();
@@ -401,7 +401,9 @@ describe("loadConfig", () => {
       "agentArgsOverride:\n  unknown:\n    - --flag\n",
     );
 
-    expect(() => loadConfig()).toThrow(/Invalid agent name in agentArgsOverride/);
+    expect(() => loadConfig()).toThrow(
+      /Invalid agent name in agentArgsOverride/,
+    );
   });
 
   it("throws when agentArgsOverride.codex is not an array", () => {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -436,6 +436,18 @@ describe("loadConfig", () => {
     );
   });
 
+  it("allows agentArgsOverride.claude to set the dangerous permission flag explicitly", () => {
+    mockReadFileSync.mockReturnValue(
+      "agentArgsOverride:\n  claude:\n    - --dangerously-skip-permissions\n",
+    );
+
+    const config = loadConfig();
+
+    expect(config.agentArgsOverride).toEqual({
+      claude: ["--dangerously-skip-permissions"],
+    });
+  });
+
   it("throws when agentArgsOverride.rovodev contains gnhf-managed flags", () => {
     mockReadFileSync.mockReturnValue(
       "agentArgsOverride:\n  rovodev:\n    - serve\n",

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -21,6 +21,8 @@ const mockWriteFileSync = vi.mocked(writeFileSync);
 const HOME = "/mock-home";
 const CONFIG_DIR = join(HOME, ".gnhf");
 const CONFIG_PATH = join(CONFIG_DIR, "config.yml");
+const BOOTSTRAP_CONFIG_TEMPLATE = (agent: string) =>
+  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort=\"high\"\n#     - --full-auto\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -39,7 +41,7 @@ describe("loadConfig", () => {
     });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: claude\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      BOOTSTRAP_CONFIG_TEMPLATE("claude"),
       "utf-8",
     );
     expect(config).toEqual({
@@ -81,7 +83,7 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: codex\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      BOOTSTRAP_CONFIG_TEMPLATE("codex"),
       "utf-8",
     );
     expect(config).toEqual({
@@ -141,7 +143,7 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: rovodev\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      BOOTSTRAP_CONFIG_TEMPLATE("rovodev"),
       "utf-8",
     );
     expect(config).toEqual({
@@ -163,7 +165,7 @@ describe("loadConfig", () => {
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       CONFIG_PATH,
-      "# Agent to use by default\nagent: opencode\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n",
+      BOOTSTRAP_CONFIG_TEMPLATE("opencode"),
       "utf-8",
     );
     expect(config).toEqual({
@@ -243,6 +245,18 @@ describe("loadConfig", () => {
       agentPathOverride: {},
       maxConsecutiveFailures: 3,
       preventSleep: true,
+    });
+  });
+
+  it("reads per-agent extra args from config", () => {
+    mockReadFileSync.mockReturnValue(
+      'agentArgsOverride:\n  codex:\n    - -m\n    - gpt-5.4\n    - --full-auto\n',
+    );
+
+    const config = loadConfig();
+
+    expect(config.agentArgsOverride).toEqual({
+      codex: ["-m", "gpt-5.4", "--full-auto"],
     });
   });
 
@@ -336,6 +350,34 @@ describe("loadConfig", () => {
 
     expect(() => loadConfig()).toThrow(
       /Invalid path for agentPathOverride.claude/,
+    );
+  });
+
+  it("throws when agentArgsOverride contains an unknown agent name", () => {
+    mockReadFileSync.mockReturnValue(
+      "agentArgsOverride:\n  unknown:\n    - --flag\n",
+    );
+
+    expect(() => loadConfig()).toThrow(/Invalid agent name in agentArgsOverride/);
+  });
+
+  it("throws when agentArgsOverride.codex is not an array", () => {
+    mockReadFileSync.mockReturnValue(
+      'agentArgsOverride:\n  codex: "--full-auto"\n',
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for agentArgsOverride\.codex/,
+    );
+  });
+
+  it("throws when agentArgsOverride.codex contains blank values", () => {
+    mockReadFileSync.mockReturnValue(
+      'agentArgsOverride:\n  codex:\n    - "   "\n',
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for agentArgsOverride\.codex\[0\]/,
     );
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,7 +10,7 @@ const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
 export interface Config {
   agent: AgentName;
   agentPathOverride: Partial<Record<AgentName, string>>;
-  agentArgsOverride?: Partial<Record<AgentName, string[]>>;
+  agentArgsOverride: Partial<Record<AgentName, string[]>>;
   maxConsecutiveFailures: number;
   preventSleep: boolean;
 }
@@ -18,13 +18,14 @@ export interface Config {
 const DEFAULT_CONFIG: Config = {
   agent: "claude",
   agentPathOverride: {},
+  agentArgsOverride: {},
   maxConsecutiveFailures: 3,
   preventSleep: true,
 };
 
 class InvalidConfigError extends Error {}
 
-function normalizeBooleanLike(value: unknown): boolean | undefined {
+function normalizePreventSleep(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value !== "string") return undefined;
 
@@ -33,6 +34,46 @@ function normalizeBooleanLike(value: unknown): boolean | undefined {
   if (value === "on") return true;
   if (value === "off") return false;
   return undefined;
+}
+
+function isReservedAgentArg(agent: AgentName, arg: string): boolean {
+  switch (agent) {
+    case "claude":
+      return (
+        arg === "-p" ||
+        arg === "--print" ||
+        arg === "--verbose" ||
+        arg === "--dangerously-skip-permissions" ||
+        arg === "--output-format" ||
+        arg.startsWith("--output-format=") ||
+        arg === "--json-schema" ||
+        arg.startsWith("--json-schema=")
+      );
+    case "codex":
+      return (
+        arg === "exec" ||
+        arg === "--json" ||
+        arg === "--output-schema" ||
+        arg.startsWith("--output-schema=") ||
+        arg === "--color" ||
+        arg.startsWith("--color=")
+      );
+    case "opencode":
+      return (
+        arg === "serve" ||
+        arg === "--hostname" ||
+        arg.startsWith("--hostname=") ||
+        arg === "--port" ||
+        arg.startsWith("--port=") ||
+        arg === "--print-logs"
+      );
+    case "rovodev":
+      return (
+        arg === "rovodev" ||
+        arg === "serve" ||
+        arg === "--disable-session-token"
+      );
+  }
 }
 
 /**
@@ -102,6 +143,7 @@ function normalizeAgentPathOverride(
 function normalizeAgentExtraArgs(
   value: unknown,
   label: string,
+  agent: AgentName,
 ): string[] | undefined {
   if (value === undefined || value === null) return undefined;
   if (!Array.isArray(value)) {
@@ -121,6 +163,12 @@ function normalizeAgentExtraArgs(
     if (trimmed === "") {
       throw new InvalidConfigError(
         `Invalid config value for ${label}[${index}]: expected a non-empty string`,
+      );
+    }
+
+    if (isReservedAgentArg(agent, trimmed)) {
+      throw new InvalidConfigError(
+        `Invalid config value for ${label}[${index}]: "${trimmed}" is managed by gnhf and cannot be overridden`,
       );
     }
 
@@ -150,6 +198,7 @@ function normalizeAgentArgsOverride(
     const args = normalizeAgentExtraArgs(
       rawConfig,
       `agentArgsOverride.${key}`,
+      key as AgentName,
     );
     if (args !== undefined) {
       result[key as AgentName] = args;
@@ -168,7 +217,7 @@ function normalizeConfig(
     config,
     "preventSleep",
   );
-  const preventSleep = normalizeBooleanLike(config.preventSleep);
+  const preventSleep = normalizePreventSleep(config.preventSleep);
 
   if (preventSleep === undefined) {
     if (hasPreventSleep && config.preventSleep !== undefined) {
@@ -250,9 +299,9 @@ function serializeAgentPathOverride(
 }
 
 function serializeAgentArgsOverride(
-  agentArgsOverride?: Partial<Record<AgentName, string[]>>,
+  agentArgsOverride: Partial<Record<AgentName, string[]>>,
 ): string {
-  if (!agentArgsOverride || Object.keys(agentArgsOverride).length === 0) {
+  if (Object.keys(agentArgsOverride).length === 0) {
     return "";
   }
 
@@ -289,7 +338,7 @@ function serializeConfig(config: Config): string {
     "#     - -m",
     "#     - gpt-5.4",
     "#     - -c",
-    '#     - model_reasoning_effort=\"high\"',
+    '#     - model_reasoning_effort="high"',
     "#     - --full-auto",
   ];
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,6 +10,7 @@ const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
 export interface Config {
   agent: AgentName;
   agentPathOverride: Partial<Record<AgentName, string>>;
+  agentArgsOverride?: Partial<Record<AgentName, string[]>>;
   maxConsecutiveFailures: number;
   preventSleep: boolean;
 }
@@ -23,7 +24,7 @@ const DEFAULT_CONFIG: Config = {
 
 class InvalidConfigError extends Error {}
 
-function normalizePreventSleep(value: unknown): boolean | undefined {
+function normalizeBooleanLike(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value !== "string") return undefined;
 
@@ -98,6 +99,66 @@ function normalizeAgentPathOverride(
   return result;
 }
 
+function normalizeAgentExtraArgs(
+  value: unknown,
+  label: string,
+): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new InvalidConfigError(
+      `Invalid config value for ${label}: expected an array of strings`,
+    );
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry !== "string") {
+      throw new InvalidConfigError(
+        `Invalid config value for ${label}[${index}]: expected a string`,
+      );
+    }
+
+    const trimmed = entry.trim();
+    if (trimmed === "") {
+      throw new InvalidConfigError(
+        `Invalid config value for ${label}[${index}]: expected a non-empty string`,
+      );
+    }
+
+    return trimmed;
+  });
+}
+
+function normalizeAgentArgsOverride(
+  value: unknown,
+): Partial<Record<AgentName, string[]>> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidConfigError(
+      `Invalid config value for agentArgsOverride: expected an object`,
+    );
+  }
+
+  const validNames = new Set<string>(AGENT_NAMES);
+  const result: Partial<Record<AgentName, string[]>> = {};
+
+  for (const [key, rawConfig] of Object.entries(value as Record<string, unknown>)) {
+    if (!validNames.has(key)) {
+      throw new InvalidConfigError(
+        `Invalid agent name in agentArgsOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+      );
+    }
+    const args = normalizeAgentExtraArgs(
+      rawConfig,
+      `agentArgsOverride.${key}`,
+    );
+    if (args !== undefined) {
+      result[key as AgentName] = args;
+    }
+  }
+
+  return Object.keys(result).length === 0 ? undefined : result;
+}
+
 function normalizeConfig(
   config: Partial<Config>,
   configDir?: string,
@@ -107,7 +168,7 @@ function normalizeConfig(
     config,
     "preventSleep",
   );
-  const preventSleep = normalizePreventSleep(config.preventSleep);
+  const preventSleep = normalizeBooleanLike(config.preventSleep);
 
   if (preventSleep === undefined) {
     if (hasPreventSleep && config.preventSleep !== undefined) {
@@ -137,6 +198,23 @@ function normalizeConfig(
     }
   } else {
     delete normalized.agentPathOverride;
+  }
+
+  const hasAgentArgsOverride = Object.prototype.hasOwnProperty.call(
+    config,
+    "agentArgsOverride",
+  );
+  if (hasAgentArgsOverride) {
+    const agentArgsOverride = normalizeAgentArgsOverride(
+      config.agentArgsOverride,
+    );
+    if (agentArgsOverride === undefined) {
+      delete normalized.agentArgsOverride;
+    } else {
+      normalized.agentArgsOverride = agentArgsOverride;
+    }
+  } else {
+    delete normalized.agentArgsOverride;
   }
 
   return normalized;
@@ -171,9 +249,27 @@ function serializeAgentPathOverride(
     .trimEnd();
 }
 
+function serializeAgentArgsOverride(
+  agentArgsOverride?: Partial<Record<AgentName, string[]>>,
+): string {
+  if (!agentArgsOverride || Object.keys(agentArgsOverride).length === 0) {
+    return "";
+  }
+
+  return yaml
+    .dump(
+      { agentArgsOverride },
+      { lineWidth: -1, noRefs: true, sortKeys: false },
+    )
+    .trimEnd();
+}
+
 function serializeConfig(config: Config): string {
   const agentPathOverrideSection = serializeAgentPathOverride(
     config.agentPathOverride,
+  );
+  const agentArgsOverrideSection = serializeAgentArgsOverride(
+    config.agentArgsOverride,
   );
   const lines = [
     "# Agent to use by default",
@@ -186,10 +282,23 @@ function serializeConfig(config: Config): string {
     "# agentPathOverride:",
     "#   claude: /path/to/custom-claude",
     "#   codex: /path/to/custom-codex",
+    "",
+    "# Per-agent CLI arg overrides (optional)",
+    "# agentArgsOverride:",
+    "#   codex:",
+    "#     - -m",
+    "#     - gpt-5.4",
+    "#     - -c",
+    '#     - model_reasoning_effort=\"high\"',
+    "#     - --full-auto",
   ];
 
   if (agentPathOverrideSection) {
     lines.push(...agentPathOverrideSection.split("\n"));
+  }
+
+  if (agentArgsOverrideSection) {
+    lines.push(...agentArgsOverrideSection.split("\n"));
   }
 
   lines.push(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -43,7 +43,6 @@ function isReservedAgentArg(agent: AgentName, arg: string): boolean {
         arg === "-p" ||
         arg === "--print" ||
         arg === "--verbose" ||
-        arg === "--dangerously-skip-permissions" ||
         arg === "--output-format" ||
         arg.startsWith("--output-format=") ||
         arg === "--json-schema" ||

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -189,7 +189,9 @@ function normalizeAgentArgsOverride(
   const validNames = new Set<string>(AGENT_NAMES);
   const result: Partial<Record<AgentName, string[]>> = {};
 
-  for (const [key, rawConfig] of Object.entries(value as Record<string, unknown>)) {
+  for (const [key, rawConfig] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
         `Invalid agent name in agentArgsOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -39,6 +39,7 @@ const mockAppendNotes = vi.mocked(appendNotes);
 const config: Config = {
   agent: "claude",
   agentPathOverride: {},
+  agentArgsOverride: {},
   maxConsecutiveFailures: 3,
   preventSleep: true,
 };


### PR DESCRIPTION
Enterprise environments require some sandboxing for `gnhf` to run well, adding codex support for arg override, consistent with `agentPathOverride`