### PR TITLE
fix(orchestrator): handle aborts and preserve successful recordings

### DIFF
--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -565,7 +565,7 @@ describe("Orchestrator crash resilience", () => {
     expect(abort).not.toHaveBeenCalled();
   });
 
-  it("resets the worktree and rethrows when success recording fails", async () => {
+  it("rethrows success recording failures without resetting the worktree", async () => {
     mockAppendNotes.mockImplementation(() => {
       throw new Error("ENOSPC: no space left on device");
     });
@@ -590,7 +590,7 @@ describe("Orchestrator crash resilience", () => {
       "ENOSPC: no space left on device",
     );
 
-    expect(mockResetHard).toHaveBeenCalledWith("/repo");
+    expect(mockResetHard).not.toHaveBeenCalled();
     expect(orchestrator.getState().status).not.toBe("aborted");
     expect(abort).not.toHaveBeenCalled();
   });

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -525,7 +525,7 @@ describe("Orchestrator crash resilience", () => {
     mockAppendNotes.mockImplementation(() => {});
   });
 
-  it("aborts gracefully when git reset fails during failure recording", async () => {
+  it("rethrows when git reset fails during failure recording", async () => {
     mockResetHard.mockImplementation(() => {
       throw new Error("not a git repository");
     });
@@ -559,14 +559,13 @@ describe("Orchestrator crash resilience", () => {
     const abort = vi.fn();
     orchestrator.on("abort", abort);
 
-    await orchestrator.start();
+    await expect(orchestrator.start()).rejects.toThrow("not a git repository");
 
-    expect(orchestrator.getState().status).toBe("aborted");
-    expect(abort).toHaveBeenCalled();
-    expect(abort.mock.calls[0][0]).toContain("not a git repository");
+    expect(orchestrator.getState().status).not.toBe("aborted");
+    expect(abort).not.toHaveBeenCalled();
   });
 
-  it("aborts gracefully when file write fails during success recording", async () => {
+  it("resets the worktree and rethrows when success recording fails", async () => {
     mockAppendNotes.mockImplementation(() => {
       throw new Error("ENOSPC: no space left on device");
     });
@@ -587,10 +586,12 @@ describe("Orchestrator crash resilience", () => {
     const abort = vi.fn();
     orchestrator.on("abort", abort);
 
-    await orchestrator.start();
+    await expect(orchestrator.start()).rejects.toThrow(
+      "ENOSPC: no space left on device",
+    );
 
-    expect(orchestrator.getState().status).toBe("aborted");
-    expect(abort).toHaveBeenCalled();
-    expect(abort.mock.calls[0][0]).toContain("ENOSPC");
+    expect(mockResetHard).toHaveBeenCalledWith("/repo");
+    expect(orchestrator.getState().status).not.toBe("aborted");
+    expect(abort).not.toHaveBeenCalled();
   });
 });

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -594,4 +594,29 @@ describe("Orchestrator crash resilience", () => {
     expect(orchestrator.getState().status).not.toBe("aborted");
     expect(abort).not.toHaveBeenCalled();
   });
+
+  it("rethrows observer errors without resetting the worktree", async () => {
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => createSuccessResult()),
+    };
+
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+    );
+
+    orchestrator.on("iteration:end", () => {
+      throw new Error("listener failed");
+    });
+
+    await expect(orchestrator.start()).rejects.toThrow("listener failed");
+
+    expect(mockAppendNotes).toHaveBeenCalledTimes(1);
+    expect(mockCommitAll).toHaveBeenCalledTimes(1);
+    expect(mockResetHard).not.toHaveBeenCalled();
+  });
 });

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("./git.js", () => ({
   commitAll: vi.fn(),
@@ -30,7 +30,7 @@ vi.mock("../templates/iteration-prompt.js", () => ({
   buildIterationPrompt: vi.fn(() => "iteration prompt"),
 }));
 
-import { commitAll } from "./git.js";
+import { commitAll, resetHard } from "./git.js";
 import { appendNotes } from "./run.js";
 import { Orchestrator } from "./orchestrator.js";
 import type { Agent, AgentResult } from "./agents/types.js";
@@ -39,6 +39,7 @@ import type { RunInfo } from "./run.js";
 
 const mockCommitAll = vi.mocked(commitAll);
 const mockAppendNotes = vi.mocked(appendNotes);
+const mockResetHard = vi.mocked(resetHard);
 
 const config: Config = {
   agent: "claude",
@@ -510,5 +511,86 @@ describe("Orchestrator stop limits", () => {
     expect(orchestrator.getState().iterations).toEqual([]);
     expect(orchestrator.getState().status).toBe("stopped");
     expect(close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Orchestrator crash resilience", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    mockResetHard.mockImplementation(() => {});
+    mockAppendNotes.mockImplementation(() => {});
+  });
+
+  it("aborts gracefully when git reset fails during failure recording", async () => {
+    mockResetHard.mockImplementation(() => {
+      throw new Error("not a git repository");
+    });
+
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => ({
+        output: {
+          success: false,
+          summary: "iteration failed",
+          key_changes_made: [],
+          key_learnings: [],
+        },
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      })),
+    };
+
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+    );
+
+    const abort = vi.fn();
+    orchestrator.on("abort", abort);
+
+    await orchestrator.start();
+
+    expect(orchestrator.getState().status).toBe("aborted");
+    expect(abort).toHaveBeenCalled();
+    expect(abort.mock.calls[0][0]).toContain("not a git repository");
+  });
+
+  it("aborts gracefully when file write fails during success recording", async () => {
+    mockAppendNotes.mockImplementation(() => {
+      throw new Error("ENOSPC: no space left on device");
+    });
+
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => createSuccessResult()),
+    };
+
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+    );
+
+    const abort = vi.fn();
+    orchestrator.on("abort", abort);
+
+    await orchestrator.start();
+
+    expect(orchestrator.getState().status).toBe("aborted");
+    expect(abort).toHaveBeenCalled();
+    expect(abort.mock.calls[0][0]).toContain("ENOSPC");
   });
 });

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -291,7 +291,6 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
         iteration: this.state.currentIteration,
         error: serializeError(err),
       });
-      resetHard(this.cwd);
       throw err;
     } finally {
       this.activeIterationPromise = null;
@@ -433,31 +432,36 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
   }
 
   private recordSuccess(output: AgentOutput): IterationRecord {
-    appendNotes(
-      this.runInfo.notesPath,
-      this.state.currentIteration,
-      output.summary,
-      toStringArray(output.key_changes_made),
-      toStringArray(output.key_learnings),
-    );
-    commitAll(
-      `gnhf #${this.state.currentIteration}: ${output.summary}`,
-      this.cwd,
-    );
-    this.state.commitCount = getBranchCommitCount(
-      this.runInfo.baseCommit,
-      this.cwd,
-    );
-    this.state.successCount++;
-    this.state.consecutiveFailures = 0;
-    return {
-      number: this.state.currentIteration,
-      success: true,
-      summary: output.summary,
-      keyChanges: toStringArray(output.key_changes_made),
-      keyLearnings: toStringArray(output.key_learnings),
-      timestamp: new Date(),
-    };
+    try {
+      appendNotes(
+        this.runInfo.notesPath,
+        this.state.currentIteration,
+        output.summary,
+        toStringArray(output.key_changes_made),
+        toStringArray(output.key_learnings),
+      );
+      commitAll(
+        `gnhf #${this.state.currentIteration}: ${output.summary}`,
+        this.cwd,
+      );
+      this.state.commitCount = getBranchCommitCount(
+        this.runInfo.baseCommit,
+        this.cwd,
+      );
+      this.state.successCount++;
+      this.state.consecutiveFailures = 0;
+      return {
+        number: this.state.currentIteration,
+        success: true,
+        summary: output.summary,
+        keyChanges: toStringArray(output.key_changes_made),
+        keyLearnings: toStringArray(output.key_learnings),
+        timestamp: new Date(),
+      };
+    } catch (err) {
+      resetHard(this.cwd);
+      throw err;
+    }
   }
 
   private recordFailure(

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -177,113 +177,122 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
 
     try {
       while (!this.stopRequested) {
-        const preIterationAbortReason = this.getPreIterationAbortReason();
-        if (preIterationAbortReason) {
-          this.abort(preIterationAbortReason);
-          break;
-        }
+        try {
+          const preIterationAbortReason = this.getPreIterationAbortReason();
+          if (preIterationAbortReason) {
+            this.abort(preIterationAbortReason);
+            break;
+          }
 
-        this.state.currentIteration++;
-        this.state.status = "running";
-        this.emit("iteration:start", this.state.currentIteration);
-        this.emit("state", this.getState());
-
-        const iterationPrompt = buildIterationPrompt({
-          n: this.state.currentIteration,
-          runId: this.runInfo.runId,
-          prompt: this.prompt,
-        });
-
-        appendDebugLog("iteration:start", {
-          iteration: this.state.currentIteration,
-          promptLength: iterationPrompt.length,
-          consecutiveFailures: this.state.consecutiveFailures,
-          totalInputTokens: this.state.totalInputTokens,
-          totalOutputTokens: this.state.totalOutputTokens,
-          git: this.snapshotGitState(),
-        });
-
-        const iterationStartedAt = Date.now();
-        this.activeIterationPromise = this.runIteration(iterationPrompt);
-        const result = await this.activeIterationPromise;
-        this.activeIterationPromise = null;
-        const iterationElapsedMs = Date.now() - iterationStartedAt;
-
-        if (result.type === "stopped") {
-          appendDebugLog("iteration:stopped", {
-            iteration: this.state.currentIteration,
-            elapsedMs: iterationElapsedMs,
-          });
-          break;
-        }
-        if (result.type === "aborted") {
-          appendDebugLog("iteration:aborted", {
-            iteration: this.state.currentIteration,
-            elapsedMs: iterationElapsedMs,
-            reason: result.reason,
-          });
-          this.abort(result.reason);
-          break;
-        }
-
-        const { record } = result;
-        this.state.iterations.push(record);
-        this.emit("iteration:end", record);
-        this.emit("state", this.getState());
-
-        appendDebugLog("iteration:end", {
-          iteration: record.number,
-          elapsedMs: iterationElapsedMs,
-          success: record.success,
-          summary: record.summary,
-          keyChanges: record.keyChanges.length,
-          keyLearnings: record.keyLearnings.length,
-          consecutiveFailures: this.state.consecutiveFailures,
-          totalInputTokens: this.state.totalInputTokens,
-          totalOutputTokens: this.state.totalOutputTokens,
-          commitCount: this.state.commitCount,
-        });
-
-        const postIterationAbortReason = this.getPostIterationAbortReason();
-        if (postIterationAbortReason) {
-          this.abort(postIterationAbortReason);
-          break;
-        }
-
-        if (
-          this.state.consecutiveFailures >= this.config.maxConsecutiveFailures
-        ) {
-          this.abort(
-            `${this.config.maxConsecutiveFailures} consecutive failures`,
-          );
-          break;
-        }
-
-        if (this.state.consecutiveFailures > 0 && !this.stopRequested) {
-          const backoffMs =
-            60_000 * Math.pow(2, this.state.consecutiveFailures - 1);
-          this.state.status = "waiting";
-          this.state.waitingUntil = new Date(Date.now() + backoffMs);
+          this.state.currentIteration++;
+          this.state.status = "running";
+          this.emit("iteration:start", this.state.currentIteration);
           this.emit("state", this.getState());
 
-          appendDebugLog("backoff:start", {
+          const iterationPrompt = buildIterationPrompt({
+            n: this.state.currentIteration,
+            runId: this.runInfo.runId,
+            prompt: this.prompt,
+          });
+
+          appendDebugLog("iteration:start", {
             iteration: this.state.currentIteration,
+            promptLength: iterationPrompt.length,
             consecutiveFailures: this.state.consecutiveFailures,
-            backoffMs,
+            totalInputTokens: this.state.totalInputTokens,
+            totalOutputTokens: this.state.totalOutputTokens,
+            git: this.snapshotGitState(),
           });
 
-          await this.interruptibleSleep(backoffMs);
+          const iterationStartedAt = Date.now();
+          this.activeIterationPromise = this.runIteration(iterationPrompt);
+          const result = await this.activeIterationPromise;
+          this.activeIterationPromise = null;
+          const iterationElapsedMs = Date.now() - iterationStartedAt;
 
-          appendDebugLog("backoff:end", {
-            iteration: this.state.currentIteration,
-            stopRequested: this.stopRequested,
-          });
-
-          this.state.waitingUntil = null;
-          if (!this.stopRequested) {
-            this.state.status = "running";
-            this.emit("state", this.getState());
+          if (result.type === "stopped") {
+            appendDebugLog("iteration:stopped", {
+              iteration: this.state.currentIteration,
+              elapsedMs: iterationElapsedMs,
+            });
+            break;
           }
+          if (result.type === "aborted") {
+            appendDebugLog("iteration:aborted", {
+              iteration: this.state.currentIteration,
+              elapsedMs: iterationElapsedMs,
+              reason: result.reason,
+            });
+            this.abort(result.reason);
+            break;
+          }
+
+          const { record } = result;
+          this.state.iterations.push(record);
+          this.emit("iteration:end", record);
+          this.emit("state", this.getState());
+
+          appendDebugLog("iteration:end", {
+            iteration: record.number,
+            elapsedMs: iterationElapsedMs,
+            success: record.success,
+            summary: record.summary,
+            keyChanges: record.keyChanges.length,
+            keyLearnings: record.keyLearnings.length,
+            consecutiveFailures: this.state.consecutiveFailures,
+            totalInputTokens: this.state.totalInputTokens,
+            totalOutputTokens: this.state.totalOutputTokens,
+            commitCount: this.state.commitCount,
+          });
+
+          const postIterationAbortReason = this.getPostIterationAbortReason();
+          if (postIterationAbortReason) {
+            this.abort(postIterationAbortReason);
+            break;
+          }
+
+          if (
+            this.state.consecutiveFailures >= this.config.maxConsecutiveFailures
+          ) {
+            this.abort(
+              `${this.config.maxConsecutiveFailures} consecutive failures`,
+            );
+            break;
+          }
+
+          if (this.state.consecutiveFailures > 0 && !this.stopRequested) {
+            const backoffMs =
+              60_000 * Math.pow(2, this.state.consecutiveFailures - 1);
+            this.state.status = "waiting";
+            this.state.waitingUntil = new Date(Date.now() + backoffMs);
+            this.emit("state", this.getState());
+
+            appendDebugLog("backoff:start", {
+              iteration: this.state.currentIteration,
+              consecutiveFailures: this.state.consecutiveFailures,
+              backoffMs,
+            });
+
+            await this.interruptibleSleep(backoffMs);
+
+            appendDebugLog("backoff:end", {
+              iteration: this.state.currentIteration,
+              stopRequested: this.stopRequested,
+            });
+
+            this.state.waitingUntil = null;
+            if (!this.stopRequested) {
+              this.state.status = "running";
+              this.emit("state", this.getState());
+            }
+          }
+        } catch (err) {
+          appendDebugLog("orchestrator:loop-error", {
+            iteration: this.state.currentIteration,
+            error: serializeError(err),
+          });
+          this.abort(err instanceof Error ? err.message : String(err));
+          break;
         }
       }
     } finally {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -177,124 +177,122 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
 
     try {
       while (!this.stopRequested) {
-        try {
-          const preIterationAbortReason = this.getPreIterationAbortReason();
-          if (preIterationAbortReason) {
-            this.abort(preIterationAbortReason);
-            break;
-          }
-
-          this.state.currentIteration++;
-          this.state.status = "running";
-          this.emit("iteration:start", this.state.currentIteration);
-          this.emit("state", this.getState());
-
-          const iterationPrompt = buildIterationPrompt({
-            n: this.state.currentIteration,
-            runId: this.runInfo.runId,
-            prompt: this.prompt,
-          });
-
-          appendDebugLog("iteration:start", {
-            iteration: this.state.currentIteration,
-            promptLength: iterationPrompt.length,
-            consecutiveFailures: this.state.consecutiveFailures,
-            totalInputTokens: this.state.totalInputTokens,
-            totalOutputTokens: this.state.totalOutputTokens,
-            git: this.snapshotGitState(),
-          });
-
-          const iterationStartedAt = Date.now();
-          this.activeIterationPromise = this.runIteration(iterationPrompt);
-          const result = await this.activeIterationPromise;
-          this.activeIterationPromise = null;
-          const iterationElapsedMs = Date.now() - iterationStartedAt;
-
-          if (result.type === "stopped") {
-            appendDebugLog("iteration:stopped", {
-              iteration: this.state.currentIteration,
-              elapsedMs: iterationElapsedMs,
-            });
-            break;
-          }
-          if (result.type === "aborted") {
-            appendDebugLog("iteration:aborted", {
-              iteration: this.state.currentIteration,
-              elapsedMs: iterationElapsedMs,
-              reason: result.reason,
-            });
-            this.abort(result.reason);
-            break;
-          }
-
-          const { record } = result;
-          this.state.iterations.push(record);
-          this.emit("iteration:end", record);
-          this.emit("state", this.getState());
-
-          appendDebugLog("iteration:end", {
-            iteration: record.number,
-            elapsedMs: iterationElapsedMs,
-            success: record.success,
-            summary: record.summary,
-            keyChanges: record.keyChanges.length,
-            keyLearnings: record.keyLearnings.length,
-            consecutiveFailures: this.state.consecutiveFailures,
-            totalInputTokens: this.state.totalInputTokens,
-            totalOutputTokens: this.state.totalOutputTokens,
-            commitCount: this.state.commitCount,
-          });
-
-          const postIterationAbortReason = this.getPostIterationAbortReason();
-          if (postIterationAbortReason) {
-            this.abort(postIterationAbortReason);
-            break;
-          }
-
-          if (
-            this.state.consecutiveFailures >= this.config.maxConsecutiveFailures
-          ) {
-            this.abort(
-              `${this.config.maxConsecutiveFailures} consecutive failures`,
-            );
-            break;
-          }
-
-          if (this.state.consecutiveFailures > 0 && !this.stopRequested) {
-            const backoffMs =
-              60_000 * Math.pow(2, this.state.consecutiveFailures - 1);
-            this.state.status = "waiting";
-            this.state.waitingUntil = new Date(Date.now() + backoffMs);
-            this.emit("state", this.getState());
-
-            appendDebugLog("backoff:start", {
-              iteration: this.state.currentIteration,
-              consecutiveFailures: this.state.consecutiveFailures,
-              backoffMs,
-            });
-
-            await this.interruptibleSleep(backoffMs);
-
-            appendDebugLog("backoff:end", {
-              iteration: this.state.currentIteration,
-              stopRequested: this.stopRequested,
-            });
-
-            this.state.waitingUntil = null;
-            if (!this.stopRequested) {
-              this.state.status = "running";
-              this.emit("state", this.getState());
-            }
-          }
-        } catch (err) {
-          appendDebugLog("orchestrator:loop-error", {
-            iteration: this.state.currentIteration,
-            error: serializeError(err),
-          });
-          this.abort(err instanceof Error ? err.message : String(err));
+        const preIterationAbortReason = this.getPreIterationAbortReason();
+        if (preIterationAbortReason) {
+          this.abort(preIterationAbortReason);
           break;
         }
+
+        this.state.currentIteration++;
+        this.state.status = "running";
+        this.emit("iteration:start", this.state.currentIteration);
+        this.emit("state", this.getState());
+
+        const iterationPrompt = buildIterationPrompt({
+          n: this.state.currentIteration,
+          runId: this.runInfo.runId,
+          prompt: this.prompt,
+        });
+
+        appendDebugLog("iteration:start", {
+          iteration: this.state.currentIteration,
+          promptLength: iterationPrompt.length,
+          consecutiveFailures: this.state.consecutiveFailures,
+          totalInputTokens: this.state.totalInputTokens,
+          totalOutputTokens: this.state.totalOutputTokens,
+          git: this.snapshotGitState(),
+        });
+
+        const iterationStartedAt = Date.now();
+        this.activeIterationPromise = this.runIteration(iterationPrompt);
+        const result = await this.activeIterationPromise;
+        this.activeIterationPromise = null;
+        const iterationElapsedMs = Date.now() - iterationStartedAt;
+
+        if (result.type === "stopped") {
+          appendDebugLog("iteration:stopped", {
+            iteration: this.state.currentIteration,
+            elapsedMs: iterationElapsedMs,
+          });
+          break;
+        }
+        if (result.type === "aborted") {
+          appendDebugLog("iteration:aborted", {
+            iteration: this.state.currentIteration,
+            elapsedMs: iterationElapsedMs,
+            reason: result.reason,
+          });
+          this.abort(result.reason);
+          break;
+        }
+
+        const { record } = result;
+        this.state.iterations.push(record);
+        this.emit("iteration:end", record);
+        this.emit("state", this.getState());
+
+        appendDebugLog("iteration:end", {
+          iteration: record.number,
+          elapsedMs: iterationElapsedMs,
+          success: record.success,
+          summary: record.summary,
+          keyChanges: record.keyChanges.length,
+          keyLearnings: record.keyLearnings.length,
+          consecutiveFailures: this.state.consecutiveFailures,
+          totalInputTokens: this.state.totalInputTokens,
+          totalOutputTokens: this.state.totalOutputTokens,
+          commitCount: this.state.commitCount,
+        });
+
+        const postIterationAbortReason = this.getPostIterationAbortReason();
+        if (postIterationAbortReason) {
+          this.abort(postIterationAbortReason);
+          break;
+        }
+
+        if (
+          this.state.consecutiveFailures >= this.config.maxConsecutiveFailures
+        ) {
+          this.abort(
+            `${this.config.maxConsecutiveFailures} consecutive failures`,
+          );
+          break;
+        }
+
+        if (this.state.consecutiveFailures > 0 && !this.stopRequested) {
+          const backoffMs =
+            60_000 * Math.pow(2, this.state.consecutiveFailures - 1);
+          this.state.status = "waiting";
+          this.state.waitingUntil = new Date(Date.now() + backoffMs);
+          this.emit("state", this.getState());
+
+          appendDebugLog("backoff:start", {
+            iteration: this.state.currentIteration,
+            consecutiveFailures: this.state.consecutiveFailures,
+            backoffMs,
+          });
+
+          await this.interruptibleSleep(backoffMs);
+
+          appendDebugLog("backoff:end", {
+            iteration: this.state.currentIteration,
+            stopRequested: this.stopRequested,
+          });
+
+          this.state.waitingUntil = null;
+          if (!this.stopRequested) {
+            this.state.status = "running";
+            this.emit("state", this.getState());
+          }
+        }
       }
+    } catch (err) {
+      appendDebugLog("orchestrator:loop-error", {
+        iteration: this.state.currentIteration,
+        error: serializeError(err),
+      });
+      resetHard(this.cwd);
+      throw err;
     } finally {
       this.activeIterationPromise = null;
       if (this.stopPromise) {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -432,36 +432,31 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
   }
 
   private recordSuccess(output: AgentOutput): IterationRecord {
-    try {
-      appendNotes(
-        this.runInfo.notesPath,
-        this.state.currentIteration,
-        output.summary,
-        toStringArray(output.key_changes_made),
-        toStringArray(output.key_learnings),
-      );
-      commitAll(
-        `gnhf #${this.state.currentIteration}: ${output.summary}`,
-        this.cwd,
-      );
-      this.state.commitCount = getBranchCommitCount(
-        this.runInfo.baseCommit,
-        this.cwd,
-      );
-      this.state.successCount++;
-      this.state.consecutiveFailures = 0;
-      return {
-        number: this.state.currentIteration,
-        success: true,
-        summary: output.summary,
-        keyChanges: toStringArray(output.key_changes_made),
-        keyLearnings: toStringArray(output.key_learnings),
-        timestamp: new Date(),
-      };
-    } catch (err) {
-      resetHard(this.cwd);
-      throw err;
-    }
+    appendNotes(
+      this.runInfo.notesPath,
+      this.state.currentIteration,
+      output.summary,
+      toStringArray(output.key_changes_made),
+      toStringArray(output.key_learnings),
+    );
+    commitAll(
+      `gnhf #${this.state.currentIteration}: ${output.summary}`,
+      this.cwd,
+    );
+    this.state.commitCount = getBranchCommitCount(
+      this.runInfo.baseCommit,
+      this.cwd,
+    );
+    this.state.successCount++;
+    this.state.consecutiveFailures = 0;
+    return {
+      number: this.state.currentIteration,
+      success: true,
+      summary: output.summary,
+      keyChanges: toStringArray(output.key_changes_made),
+      keyLearnings: toStringArray(output.key_learnings),
+      timestamp: new Date(),
+    };
   }
 
   private recordFailure(


### PR DESCRIPTION
## Summary
- add abort handling and backoff improvements in the orchestrator
- rethrow fatal orchestrator errors instead of swallowing them
- limit worktree resets to recording failures so successful runs are not reset

## Testing
- Updated `src/core/orchestrator.test.ts`