### PR TITLE
fix(core): harden git command inputs against shell injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,153 +2,134 @@
 
 ## [0.1.19](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.18...gnhf-v0.1.19) (2026-04-12)
 
-
 ### Bug Fixes
 
-* **orchestrator:** handle aborts and preserve successful recordings ([#66](https://github.com/kunchenguid/gnhf/issues/66)) ([7ad041d](https://github.com/kunchenguid/gnhf/commit/7ad041ddabdd70cf18e1a20e2ed917e7372bc2da))
+- **orchestrator:** handle aborts and preserve successful recordings ([#66](https://github.com/kunchenguid/gnhf/issues/66)) ([7ad041d](https://github.com/kunchenguid/gnhf/commit/7ad041ddabdd70cf18e1a20e2ed917e7372bc2da))
 
 ## [0.1.18](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.17...gnhf-v0.1.18) (2026-04-10)
 
-
 ### Features
 
-* git worktree support so that it can support multiple features to one git repository ([#63](https://github.com/kunchenguid/gnhf/issues/63)) ([bf9e3d8](https://github.com/kunchenguid/gnhf/commit/bf9e3d86899e6f3c6421605566849d110b55c1db))
+- git worktree support so that it can support multiple features to one git repository ([#63](https://github.com/kunchenguid/gnhf/issues/63)) ([bf9e3d8](https://github.com/kunchenguid/gnhf/commit/bf9e3d86899e6f3c6421605566849d110b55c1db))
 
 ## [0.1.17](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.16...gnhf-v0.1.17) (2026-04-10)
 
-
 ### Bug Fixes
 
-* **iteration-prompt:** clarify notes.md instructions ([2182240](https://github.com/kunchenguid/gnhf/commit/218224073890831d667850272b4234f6fefc68b8))
+- **iteration-prompt:** clarify notes.md instructions ([2182240](https://github.com/kunchenguid/gnhf/commit/218224073890831d667850272b4234f6fefc68b8))
 
 ## [0.1.16](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.15...gnhf-v0.1.16) (2026-04-09)
 
-
 ### Features
 
-* **codex:** allow per-agent cli arg overrides ([#58](https://github.com/kunchenguid/gnhf/issues/58)) ([4c1731e](https://github.com/kunchenguid/gnhf/commit/4c1731e0f1fc321d3ac63818bffe6dd245ed3dbe))
+- **codex:** allow per-agent cli arg overrides ([#58](https://github.com/kunchenguid/gnhf/issues/58)) ([4c1731e](https://github.com/kunchenguid/gnhf/commit/4c1731e0f1fc321d3ac63818bffe6dd245ed3dbe))
 
 ## [0.1.15](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.14...gnhf-v0.1.15) (2026-04-08)
 
-
 ### Bug Fixes
 
-* Normalize changes and learnings to avoid JSON schema non-adherence to break the notes.md file ([#59](https://github.com/kunchenguid/gnhf/issues/59)) ([3b1427b](https://github.com/kunchenguid/gnhf/commit/3b1427b8eeaac7463da95c358e4bf8a510542772))
+- Normalize changes and learnings to avoid JSON schema non-adherence to break the notes.md file ([#59](https://github.com/kunchenguid/gnhf/issues/59)) ([3b1427b](https://github.com/kunchenguid/gnhf/commit/3b1427b8eeaac7463da95c358e4bf8a510542772))
 
 ## [0.1.14](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.13...gnhf-v0.1.14) (2026-04-07)
 
-
 ### Features
 
-* **agents:** use prompt_async endpoint instead of blocking /message ([#56](https://github.com/kunchenguid/gnhf/issues/56)) ([ef5d6d3](https://github.com/kunchenguid/gnhf/commit/ef5d6d3c8c6634abccaebd28db59086cb294f8ee))
+- **agents:** use prompt_async endpoint instead of blocking /message ([#56](https://github.com/kunchenguid/gnhf/issues/56)) ([ef5d6d3](https://github.com/kunchenguid/gnhf/commit/ef5d6d3c8c6634abccaebd28db59086cb294f8ee))
 
 ## [0.1.13](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.12...gnhf-v0.1.13) (2026-04-06)
 
-
 ### Features
 
-* **core:** add detailed error logging ([#54](https://github.com/kunchenguid/gnhf/issues/54)) ([84eaa15](https://github.com/kunchenguid/gnhf/commit/84eaa15e740d35e81508a4dce91405656eb34ff3))
+- **core:** add detailed error logging ([#54](https://github.com/kunchenguid/gnhf/issues/54)) ([84eaa15](https://github.com/kunchenguid/gnhf/commit/84eaa15e740d35e81508a4dce91405656eb34ff3))
 
 ## [0.1.12](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.11...gnhf-v0.1.12) (2026-04-05)
 
-
 ### Bug Fixes
 
-* **cli:** clarify loop prompts and abort UI ([#26](https://github.com/kunchenguid/gnhf/issues/26)) ([90022c1](https://github.com/kunchenguid/gnhf/commit/90022c1df1d0456d67255c6d36dec968ffa9e943))
+- **cli:** clarify loop prompts and abort UI ([#26](https://github.com/kunchenguid/gnhf/issues/26)) ([90022c1](https://github.com/kunchenguid/gnhf/commit/90022c1df1d0456d67255c6d36dec968ffa9e943))
 
 ## [0.1.11](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.10...gnhf-v0.1.11) (2026-04-04)
 
-
 ### Features
 
-* **config:** add agent path overrides ([#24](https://github.com/kunchenguid/gnhf/issues/24)) ([c8a71c6](https://github.com/kunchenguid/gnhf/commit/c8a71c61019fd4795dabe3e5bdda4e7a44771855))
+- **config:** add agent path overrides ([#24](https://github.com/kunchenguid/gnhf/issues/24)) ([c8a71c6](https://github.com/kunchenguid/gnhf/commit/c8a71c61019fd4795dabe3e5bdda4e7a44771855))
 
 ## [0.1.10](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.9...gnhf-v0.1.10) (2026-04-03)
 
-
 ### Features
 
-* **renderer:** adapt content to viewport ([#20](https://github.com/kunchenguid/gnhf/issues/20)) ([592d80b](https://github.com/kunchenguid/gnhf/commit/592d80b6d9befb9a38f44cc19346e736c01a5220))
-* **renderer:** randomize star field seeds ([#22](https://github.com/kunchenguid/gnhf/issues/22)) ([e658f32](https://github.com/kunchenguid/gnhf/commit/e658f32004bc54b66ef3c23fec85857f1132fece))
+- **renderer:** adapt content to viewport ([#20](https://github.com/kunchenguid/gnhf/issues/20)) ([592d80b](https://github.com/kunchenguid/gnhf/commit/592d80b6d9befb9a38f44cc19346e736c01a5220))
+- **renderer:** randomize star field seeds ([#22](https://github.com/kunchenguid/gnhf/issues/22)) ([e658f32](https://github.com/kunchenguid/gnhf/commit/e658f32004bc54b66ef3c23fec85857f1132fece))
 
 ## [Unreleased]
 
 ### Features
 
-* **config:** allow per-agent binary path overrides
-* **renderer:** randomize star field seeds between runs
+- **config:** allow per-agent binary path overrides
+- **renderer:** randomize star field seeds between runs
 
 ### Bug Fixes
 
-* **agents:** support Windows cmd/bat agent wrappers and terminate overridden agent processes cleanly
-* **cli:** keep the final interactive TUI visible after aborted runs until the user exits
-* **renderer:** keep wide Unicode graphemes wrapped and aligned in the live terminal UI
+- **agents:** support Windows cmd/bat agent wrappers and terminate overridden agent processes cleanly
+- **cli:** keep the final interactive TUI visible after aborted runs until the user exits
+- **core:** harden git command execution so commit messages, branch names, and worktree paths are passed without shell interpretation
+- **renderer:** keep wide Unicode graphemes wrapped and aligned in the live terminal UI
 
 ## [0.1.9](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.8...gnhf-v0.1.9) (2026-04-03)
 
-
 ### Features
 
-* **sleep:** prevent system sleep during runs ([#17](https://github.com/kunchenguid/gnhf/issues/17)) ([091d9d3](https://github.com/kunchenguid/gnhf/commit/091d9d31b80a4c1b3c01fd7e65009ad86d864ec1))
+- **sleep:** prevent system sleep during runs ([#17](https://github.com/kunchenguid/gnhf/issues/17)) ([091d9d3](https://github.com/kunchenguid/gnhf/commit/091d9d31b80a4c1b3c01fd7e65009ad86d864ec1))
 
 ## [0.1.8](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.7...gnhf-v0.1.8) (2026-04-02)
 
-
 ### Bug Fixes
 
-* **schema:** enforce strict output schema ([#14](https://github.com/kunchenguid/gnhf/issues/14)) ([085aef7](https://github.com/kunchenguid/gnhf/commit/085aef74ba647a582aa280697213790abfa49cfa))
+- **schema:** enforce strict output schema ([#14](https://github.com/kunchenguid/gnhf/issues/14)) ([085aef7](https://github.com/kunchenguid/gnhf/commit/085aef74ba647a582aa280697213790abfa49cfa))
 
 ## [0.1.7](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.6...gnhf-v0.1.7) (2026-04-01)
 
-
 ### Features
 
-* add RovoDev agent support ([#11](https://github.com/kunchenguid/gnhf/issues/11)) ([484d989](https://github.com/kunchenguid/gnhf/commit/484d989a632aebef27b4592f96ffd7fd4f25fde0))
-* **opencode:** add OpenCode agent integration ([#13](https://github.com/kunchenguid/gnhf/issues/13)) ([aa9a2a5](https://github.com/kunchenguid/gnhf/commit/aa9a2a5cecbfe95abe6830dff40750aa03ee0423))
+- add RovoDev agent support ([#11](https://github.com/kunchenguid/gnhf/issues/11)) ([484d989](https://github.com/kunchenguid/gnhf/commit/484d989a632aebef27b4592f96ffd7fd4f25fde0))
+- **opencode:** add OpenCode agent integration ([#13](https://github.com/kunchenguid/gnhf/issues/13)) ([aa9a2a5](https://github.com/kunchenguid/gnhf/commit/aa9a2a5cecbfe95abe6830dff40750aa03ee0423))
 
 ## [0.1.6](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.5...gnhf-v0.1.6) (2026-04-01)
 
-
 ### Features
 
-* **cli:** add iteration and token caps ([#9](https://github.com/kunchenguid/gnhf/issues/9)) ([b92e9ac](https://github.com/kunchenguid/gnhf/commit/b92e9aca196647b19c854b722551e401c4ce72a7))
+- **cli:** add iteration and token caps ([#9](https://github.com/kunchenguid/gnhf/issues/9)) ([b92e9ac](https://github.com/kunchenguid/gnhf/commit/b92e9aca196647b19c854b722551e401c4ce72a7))
 
 ## [0.1.5](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.4...gnhf-v0.1.5) (2026-04-01)
 
-
 ### Bug Fixes
 
-* **cli:** show friendly non-git error ([#7](https://github.com/kunchenguid/gnhf/issues/7)) ([65acf6b](https://github.com/kunchenguid/gnhf/commit/65acf6be343b805b99a6011d1562ac54b05b6760))
+- **cli:** show friendly non-git error ([#7](https://github.com/kunchenguid/gnhf/issues/7)) ([65acf6b](https://github.com/kunchenguid/gnhf/commit/65acf6be343b805b99a6011d1562ac54b05b6760))
 
 ## [0.1.4](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.3...gnhf-v0.1.4) (2026-04-01)
 
-
 ### Features
 
-* **core:** track branch commits from run base ([#5](https://github.com/kunchenguid/gnhf/issues/5)) ([dce09e6](https://github.com/kunchenguid/gnhf/commit/dce09e6a0a47644a174428c7a29b6e19f189486b))
+- **core:** track branch commits from run base ([#5](https://github.com/kunchenguid/gnhf/issues/5)) ([dce09e6](https://github.com/kunchenguid/gnhf/commit/dce09e6a0a47644a174428c7a29b6e19f189486b))
 
 ## [0.1.3](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.2...gnhf-v0.1.3) (2026-03-31)
 
-
 ### Bug Fixes
 
-* **cli:** correct version flag ([a1203ca](https://github.com/kunchenguid/gnhf/commit/a1203caf8a6fbb794b8a954b4acdf79ebba2ebd8))
+- **cli:** correct version flag ([a1203ca](https://github.com/kunchenguid/gnhf/commit/a1203caf8a6fbb794b8a954b4acdf79ebba2ebd8))
 
 ## [0.1.2](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.1...gnhf-v0.1.2) (2026-03-31)
 
-
 ### Bug Fixes
 
-* repo field in package json ([d635f42](https://github.com/kunchenguid/gnhf/commit/d635f42286f2a2904752d3d06319e2950d992934))
+- repo field in package json ([d635f42](https://github.com/kunchenguid/gnhf/commit/d635f42286f2a2904752d3d06319e2950d992934))
 
 ## [0.1.1](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.0...gnhf-v0.1.1) (2026-03-31)
 
-
 ### Features
 
-* initial commit ([c8ae6d2](https://github.com/kunchenguid/gnhf/commit/c8ae6d21f4cf0b493386c00bdaa023b947d02451))
-
+- initial commit ([c8ae6d2](https://github.com/kunchenguid/gnhf/commit/c8ae6d21f4cf0b493386c00bdaa023b947d02451))
 
 ### Bug Fixes
 
-* update README and lower maxConsecutiveFailures to 3 ([ad8925b](https://github.com/kunchenguid/gnhf/commit/ad8925b93e80e62af615eff7fc56e8399cdee4b8))
+- update README and lower maxConsecutiveFailures to 3 ([ad8925b](https://github.com/kunchenguid/gnhf/commit/ad8925b93e80e62af615eff7fc56e8399cdee4b8))

--- a/src/core/git.injection.test.ts
+++ b/src/core/git.injection.test.ts
@@ -23,7 +23,8 @@ function makeRepo(): string {
 
 describe("git shell injection regression", () => {
   const repos: string[] = [];
-  const marker = join(tmpdir(), `gnhf-injection-marker-${process.pid}`);
+  const markerName = `gnhf-injection-marker-${process.pid}`;
+  const marker = join(tmpdir(), markerName);
 
   afterEach(() => {
     for (const dir of repos.splice(0)) {
@@ -74,11 +75,13 @@ describe("git shell injection regression", () => {
   it("createBranch treats shell metacharacters in a valid branch name as inert text", () => {
     const repo = makeRepo();
     repos.push(repo);
-    const injected = `evil\`touch\${IFS}${marker}\``;
+    const repoMarker = join(repo, markerName);
+    const injected = `evil\`touch\${IFS}${markerName}\``;
 
     createBranch(injected, repo);
 
     expect(existsSync(marker)).toBe(false);
+    expect(existsSync(repoMarker)).toBe(false);
     expect(rawGit(["branch", "--show-current"], repo)).toBe(injected);
   });
 });

--- a/src/core/git.injection.test.ts
+++ b/src/core/git.injection.test.ts
@@ -71,13 +71,14 @@ describe("git shell injection regression", () => {
     expect(subject).toBe(message);
   });
 
-  it("createBranch rejects branch names that contain shell metacharacters via git's own validation", () => {
+  it("createBranch treats shell metacharacters in a valid branch name as inert text", () => {
     const repo = makeRepo();
     repos.push(repo);
+    const injected = `evil\`touch\${IFS}${marker}\``;
 
-    expect(() =>
-      createBranch(`evil\`touch ${marker}\``, repo),
-    ).toThrow();
+    createBranch(injected, repo);
+
     expect(existsSync(marker)).toBe(false);
+    expect(rawGit(["branch", "--show-current"], repo)).toBe(injected);
   });
 });

--- a/src/core/git.injection.test.ts
+++ b/src/core/git.injection.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { commitAll, createBranch } from "./git.js";
+
+function rawGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+function makeRepo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "gnhf-injection-"));
+  rawGit(["init", "-b", "main"], cwd);
+  rawGit(["config", "user.name", "gnhf tests"], cwd);
+  rawGit(["config", "user.email", "tests@example.com"], cwd);
+  writeFileSync(join(cwd, "seed.txt"), "seed\n", "utf-8");
+  rawGit(["add", "seed.txt"], cwd);
+  rawGit(["commit", "-m", "init"], cwd);
+  return cwd;
+}
+
+describe("git shell injection regression", () => {
+  const repos: string[] = [];
+  const marker = join(tmpdir(), `gnhf-injection-marker-${process.pid}`);
+
+  afterEach(() => {
+    for (const dir of repos.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    rmSync(marker, { force: true });
+  });
+
+  it("commitAll does not evaluate backticks in the commit message", () => {
+    const repo = makeRepo();
+    repos.push(repo);
+    writeFileSync(join(repo, "work.txt"), "work\n", "utf-8");
+
+    const injected = `feat: add work \`touch ${marker}\` done`;
+    commitAll(injected, repo);
+
+    expect(existsSync(marker)).toBe(false);
+
+    const subject = rawGit(["log", "-1", "--pretty=%s"], repo);
+    expect(subject).toBe(injected);
+  });
+
+  it("commitAll does not evaluate $(...) in the commit message", () => {
+    const repo = makeRepo();
+    repos.push(repo);
+    writeFileSync(join(repo, "work.txt"), "work\n", "utf-8");
+
+    const injected = `feat: add $(touch ${marker}) thing`;
+    commitAll(injected, repo);
+
+    expect(existsSync(marker)).toBe(false);
+    const subject = rawGit(["log", "-1", "--pretty=%s"], repo);
+    expect(subject).toBe(injected);
+  });
+
+  it("commitAll preserves embedded double quotes verbatim in the commit message", () => {
+    const repo = makeRepo();
+    repos.push(repo);
+    writeFileSync(join(repo, "work.txt"), "work\n", "utf-8");
+
+    const message = 'fix "broken" test';
+    commitAll(message, repo);
+
+    const subject = rawGit(["log", "-1", "--pretty=%s"], repo);
+    expect(subject).toBe(message);
+  });
+
+  it("createBranch rejects branch names that contain shell metacharacters via git's own validation", () => {
+    const repo = makeRepo();
+    repos.push(repo);
+
+    expect(() =>
+      createBranch(`evil\`touch ${marker}\``, repo),
+    ).toThrow();
+    expect(existsSync(marker)).toBe(false);
+  });
+});

--- a/src/core/git.test.ts
+++ b/src/core/git.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   ensureCleanWorkingTree,
   createBranch,
@@ -18,45 +18,41 @@ import {
   removeWorktree,
 } from "./git.js";
 
-const mockExecSync = vi.mocked(execSync);
+const mockExecFileSync = vi.mocked(execFileSync);
+
+function argsOfCall(index: number): string[] {
+  const call = mockExecFileSync.mock.calls[index];
+  if (!call) throw new Error(`no call at index ${index}`);
+  return call[1] as string[];
+}
 
 describe("git utilities", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockExecSync.mockReturnValue("");
+    mockExecFileSync.mockReturnValue("");
   });
 
   describe("ensureCleanWorkingTree", () => {
     it("does not throw when working tree is clean", () => {
-      mockExecSync.mockReturnValue("");
+      mockExecFileSync.mockReturnValue("");
       expect(() => ensureCleanWorkingTree("/repo")).not.toThrow();
     });
 
     it("throws when working tree has changes", () => {
-      mockExecSync.mockReturnValue(" M src/index.ts");
+      mockExecFileSync.mockReturnValue(" M src/index.ts");
       expect(() => ensureCleanWorkingTree("/repo")).toThrow(
         "Working tree is not clean",
       );
     });
 
-    it("calls git status --porcelain with correct cwd", () => {
-      mockExecSync.mockReturnValue("");
+    it("invokes git status --porcelain with argv and the expected cwd", () => {
+      mockExecFileSync.mockReturnValue("");
       ensureCleanWorkingTree("/my/repo");
-      expect(mockExecSync).toHaveBeenCalledWith("git status --porcelain", {
-        cwd: "/my/repo",
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-    });
-  });
-
-  describe("createBranch", () => {
-    it("calls git checkout -b with the branch name", () => {
-      createBranch("feature/test", "/repo");
-      expect(mockExecSync).toHaveBeenCalledWith(
-        "git checkout -b feature/test",
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "git",
+        ["status", "--porcelain"],
         {
-          cwd: "/repo",
+          cwd: "/my/repo",
           encoding: "utf-8",
           stdio: "pipe",
         },
@@ -64,63 +60,65 @@ describe("git utilities", () => {
     });
   });
 
+  describe("createBranch", () => {
+    it("passes the branch name as its own argv entry so shell metacharacters are inert", () => {
+      createBranch("feature/test", "/repo");
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "git",
+        ["checkout", "-b", "feature/test"],
+        {
+          cwd: "/repo",
+          encoding: "utf-8",
+          stdio: "pipe",
+        },
+      );
+    });
+
+    it("never composes the branch name into a shell string", () => {
+      createBranch("weird`name$(ok)", "/repo");
+      expect(argsOfCall(0)).toEqual(["checkout", "-b", "weird`name$(ok)"]);
+    });
+  });
+
   describe("getCurrentBranch", () => {
     it("returns the current branch name when HEAD points to a branch", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-parse --git-dir") {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv[0] === "rev-parse" && argv[1] === "--git-dir") {
           return ".git\n";
         }
-        if (cmd === "git symbolic-ref --short HEAD") {
+        if (argv[0] === "symbolic-ref") {
           return "feature/test\n";
         }
         return "";
       });
 
       expect(getCurrentBranch("/repo")).toBe("feature/test");
-      expect(mockExecSync).toHaveBeenNthCalledWith(
-        1,
-        "git rev-parse --git-dir",
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-          env: expect.objectContaining({ LC_ALL: "C" }),
-        },
-      );
-      expect(mockExecSync).toHaveBeenNthCalledWith(
-        2,
-        "git symbolic-ref --short HEAD",
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+      expect(argsOfCall(0)).toEqual(["rev-parse", "--git-dir"]);
+      expect(argsOfCall(1)).toEqual(["symbolic-ref", "--short", "HEAD"]);
     });
 
     it("falls back to rev-parse when symbolic-ref fails, such as in detached HEAD", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-parse --git-dir") {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv[0] === "rev-parse" && argv[1] === "--git-dir") {
           return ".git\n";
         }
-        if (cmd === "git symbolic-ref --short HEAD") {
+        if (argv[0] === "symbolic-ref") {
           throw new Error("detached HEAD");
         }
-        if (cmd === "git rev-parse --abbrev-ref HEAD") {
+        if (
+          argv[0] === "rev-parse" &&
+          argv[1] === "--abbrev-ref" &&
+          argv[2] === "HEAD"
+        ) {
           return "HEAD\n";
         }
         return "";
       });
 
       expect(getCurrentBranch("/repo")).toBe("HEAD");
-      expect(mockExecSync).toHaveBeenCalledWith(
-        "git rev-parse --abbrev-ref HEAD",
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+      expect(argsOfCall(2)).toEqual(["rev-parse", "--abbrev-ref", "HEAD"]);
     });
 
     it("rewrites non-repository git errors with a friendly message", () => {
@@ -128,7 +126,7 @@ describe("git utilities", () => {
         stderr:
           "fatal: not a git repository (or any of the parent directories): .git",
       });
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw error;
       });
 
@@ -139,38 +137,22 @@ describe("git utilities", () => {
   });
 
   describe("commitAll", () => {
-    it("stages all files and commits with the message", () => {
+    it("stages all files and passes the message as its own argv entry", () => {
       commitAll("initial commit", "/repo");
-      expect(mockExecSync).toHaveBeenCalledWith("git add -A", {
-        cwd: "/repo",
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      expect(mockExecSync).toHaveBeenCalledWith(
-        'git commit -m "initial commit"',
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+      expect(argsOfCall(0)).toEqual(["add", "-A"]);
+      expect(argsOfCall(1)).toEqual(["commit", "-m", "initial commit"]);
     });
 
-    it("escapes double quotes in commit message", () => {
-      commitAll('fix "broken" test', "/repo");
-      expect(mockExecSync).toHaveBeenCalledWith(
-        'git commit -m "fix \\"broken\\" test"',
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+    it("preserves shell metacharacters in the message without any escaping", () => {
+      const injection = "feat: `touch /tmp/pwn` && $(evil) \"quoted\" 'tick'";
+      commitAll(injection, "/repo");
+      expect(argsOfCall(1)).toEqual(["commit", "-m", injection]);
     });
 
     it("does not throw when there is nothing to commit", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (typeof cmd === "string" && cmd.startsWith("git commit")) {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv[0] === "commit") {
           throw new Error("nothing to commit");
         }
         return "";
@@ -182,8 +164,12 @@ describe("git utilities", () => {
 
   describe("getBranchCommitCount", () => {
     it("counts commits on the current gnhf branch from the base commit", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-list --count --first-parent abc123..HEAD") {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (
+          argv[0] === "rev-list" &&
+          argv.includes("abc123..HEAD")
+        ) {
           return "1";
         }
         return "";
@@ -193,8 +179,9 @@ describe("git utilities", () => {
     });
 
     it("counts all branch commits after the base commit", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-list --count --first-parent base123..HEAD") {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv.includes("base123..HEAD")) {
           return "4";
         }
         return "";
@@ -204,13 +191,7 @@ describe("git utilities", () => {
     });
 
     it("returns 0 when the branch has no commits after the base commit", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-list --count --first-parent abc123..HEAD") {
-          return "0";
-        }
-        return "";
-      });
-
+      mockExecFileSync.mockReturnValue("0");
       expect(getBranchCommitCount("abc123", "/repo")).toBe(0);
     });
 
@@ -221,15 +202,16 @@ describe("git utilities", () => {
 
   describe("findLegacyRunBaseCommit", () => {
     it("derives the branch base from the initialize marker parent", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git log --first-parent --reverse --format=%H%x09%s HEAD") {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv[0] === "log") {
           return [
             "abc123\tinitial repo commit",
             "def456\tgnhf: initialize run run-abc",
             "ghi789\tgnhf #1: add tests",
           ].join("\n");
         }
-        if (cmd === "git rev-parse def456^") {
+        if (argv[0] === "rev-parse" && argv[1] === "def456^") {
           return "abc123";
         }
         return "";
@@ -239,7 +221,7 @@ describe("git utilities", () => {
     });
 
     it("returns null when no legacy marker exists", () => {
-      mockExecSync.mockReturnValue("abc123\tinitial repo commit");
+      mockExecFileSync.mockReturnValue("abc123\tinitial repo commit");
       expect(findLegacyRunBaseCommit("run-abc", "/repo")).toBeNull();
     });
   });
@@ -247,24 +229,17 @@ describe("git utilities", () => {
   describe("resetHard", () => {
     it("runs git reset --hard HEAD and git clean -fd", () => {
       resetHard("/repo");
-      expect(mockExecSync).toHaveBeenCalledWith("git reset --hard HEAD", {
-        cwd: "/repo",
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      expect(mockExecSync).toHaveBeenCalledWith("git clean -fd", {
-        cwd: "/repo",
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
+      expect(argsOfCall(0)).toEqual(["reset", "--hard", "HEAD"]);
+      expect(argsOfCall(1)).toEqual(["clean", "-fd"]);
     });
   });
 
   describe("getRepoRootDir", () => {
     it("returns the repo root directory", () => {
-      mockExecSync.mockImplementation((cmd) => {
-        if (cmd === "git rev-parse --git-dir") return ".git\n";
-        if (cmd === "git rev-parse --show-toplevel") return "/my/repo\n";
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        const argv = args as string[];
+        if (argv[1] === "--git-dir") return ".git\n";
+        if (argv[1] === "--show-toplevel") return "/my/repo\n";
         return "";
       });
       expect(getRepoRootDir("/my/repo/sub")).toBe("/my/repo");
@@ -272,30 +247,22 @@ describe("git utilities", () => {
   });
 
   describe("createWorktree", () => {
-    it("calls git worktree add with branch and path", () => {
+    it("passes the branch name and path as distinct argv entries", () => {
       createWorktree("/repo", "/tmp/wt", "gnhf/my-branch");
-      expect(mockExecSync).toHaveBeenCalledWith(
-        "git worktree add -b 'gnhf/my-branch' '/tmp/wt'",
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+      expect(argsOfCall(0)).toEqual([
+        "worktree",
+        "add",
+        "-b",
+        "gnhf/my-branch",
+        "/tmp/wt",
+      ]);
     });
   });
 
   describe("removeWorktree", () => {
-    it("calls git worktree remove --force", () => {
+    it("passes the worktree path as its own argv entry", () => {
       removeWorktree("/repo", "/tmp/wt");
-      expect(mockExecSync).toHaveBeenCalledWith(
-        "git worktree remove --force '/tmp/wt'",
-        {
-          cwd: "/repo",
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
+      expect(argsOfCall(0)).toEqual(["worktree", "remove", "--force", "/tmp/wt"]);
     });
   });
 });

--- a/src/core/git.test.ts
+++ b/src/core/git.test.ts
@@ -166,10 +166,7 @@ describe("git utilities", () => {
     it("counts commits on the current gnhf branch from the base commit", () => {
       mockExecFileSync.mockImplementation((_cmd, args) => {
         const argv = args as string[];
-        if (
-          argv[0] === "rev-list" &&
-          argv.includes("abc123..HEAD")
-        ) {
+        if (argv[0] === "rev-list" && argv.includes("abc123..HEAD")) {
           return "1";
         }
         return "";
@@ -262,7 +259,12 @@ describe("git utilities", () => {
   describe("removeWorktree", () => {
     it("passes the worktree path as its own argv entry", () => {
       removeWorktree("/repo", "/tmp/wt");
-      expect(argsOfCall(0)).toEqual(["worktree", "remove", "--force", "/tmp/wt"]);
+      expect(argsOfCall(0)).toEqual([
+        "worktree",
+        "remove",
+        "--force",
+        "/tmp/wt",
+      ]);
     });
   });
 });

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const NOT_GIT_REPOSITORY_MESSAGE =
   'This command must be run inside a Git repository. Change into a repo or run "git init" first.';
@@ -7,29 +7,32 @@ function translateGitError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function git(args: string, cwd: string): string {
+// All git invocations go through this helper, which uses execFileSync with an
+// argv array (no shell). That means caller-supplied strings such as commit
+// messages, branch names, and paths are never interpreted by a shell, so
+// characters like `, $, ", ', and ; are harmless data rather than executable
+// syntax. Do not add a code path that builds a shell command string from
+// user- or agent-provided input.
+function git(
+  args: string[],
+  cwd: string,
+  options: { env?: NodeJS.ProcessEnv } = {},
+): string {
   try {
-    return execSync(`git ${args}`, {
+    return execFileSync("git", args, {
       cwd,
       encoding: "utf-8",
       stdio: "pipe",
+      ...(options.env ? { env: options.env } : {}),
     }).trim();
   } catch (error) {
     throw translateGitError(error);
   }
 }
 
-/** Wrap a value in single quotes, escaping embedded single quotes for POSIX shells. */
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 function isGitRepository(cwd: string): boolean {
   try {
-    execSync("git rev-parse --git-dir", {
-      cwd,
-      encoding: "utf-8",
-      stdio: "pipe",
+    git(["rev-parse", "--git-dir"], cwd, {
       env: { ...process.env, LC_ALL: "C" },
     });
     return true;
@@ -47,14 +50,14 @@ function ensureGitRepository(cwd: string): void {
 export function getCurrentBranch(cwd: string): string {
   ensureGitRepository(cwd);
   try {
-    return git("symbolic-ref --short HEAD", cwd);
+    return git(["symbolic-ref", "--short", "HEAD"], cwd);
   } catch {
-    return git("rev-parse --abbrev-ref HEAD", cwd);
+    return git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
   }
 }
 
 export function ensureCleanWorkingTree(cwd: string): void {
-  const status = git("status --porcelain", cwd);
+  const status = git(["status", "--porcelain"], cwd);
   if (status) {
     throw new Error(
       "Working tree is not clean. Commit or stash changes first.",
@@ -63,11 +66,11 @@ export function ensureCleanWorkingTree(cwd: string): void {
 }
 
 export function createBranch(branchName: string, cwd: string): void {
-  git(`checkout -b ${branchName}`, cwd);
+  git(["checkout", "-b", branchName], cwd);
 }
 
 export function getHeadCommit(cwd: string): string {
-  return git("rev-parse HEAD", cwd);
+  return git(["rev-parse", "HEAD"], cwd);
 }
 
 export function findLegacyRunBaseCommit(
@@ -76,7 +79,7 @@ export function findLegacyRunBaseCommit(
 ): string | null {
   try {
     const history = git(
-      "log --first-parent --reverse --format=%H%x09%s HEAD",
+      ["log", "--first-parent", "--reverse", "--format=%H%x09%s", "HEAD"],
       cwd,
     );
     const marker = history
@@ -92,7 +95,7 @@ export function findLegacyRunBaseCommit(
       );
 
     if (!marker?.sha) return null;
-    return git(`rev-parse ${marker.sha}^`, cwd);
+    return git(["rev-parse", `${marker.sha}^`], cwd);
   } catch {
     return null;
   }
@@ -105,27 +108,30 @@ export function getBranchCommitCount(baseCommit: string, cwd: string): number {
   // commits so the number reflects "work unique to this branch" and does not
   // depend on ignored run metadata producing a commit.
   return Number.parseInt(
-    git(`rev-list --count --first-parent ${baseCommit}..HEAD`, cwd),
+    git(
+      ["rev-list", "--count", "--first-parent", `${baseCommit}..HEAD`],
+      cwd,
+    ),
     10,
   );
 }
 
 export function commitAll(message: string, cwd: string): void {
-  git("add -A", cwd);
+  git(["add", "-A"], cwd);
   try {
-    git(`commit -m "${message.replace(/"/g, '\\"')}"`, cwd);
+    git(["commit", "-m", message], cwd);
   } catch {
     // Nothing to commit (no changes) -- that's fine
   }
 }
 
 export function resetHard(cwd: string): void {
-  git("reset --hard HEAD", cwd);
-  git("clean -fd", cwd);
+  git(["reset", "--hard", "HEAD"], cwd);
+  git(["clean", "-fd"], cwd);
 }
 
 export function getRepoRootDir(cwd: string): string {
-  return git("rev-parse --show-toplevel", cwd);
+  return git(["rev-parse", "--show-toplevel"], cwd);
 }
 
 export function createWorktree(
@@ -133,12 +139,9 @@ export function createWorktree(
   worktreePath: string,
   branchName: string,
 ): void {
-  git(
-    `worktree add -b ${shellEscape(branchName)} ${shellEscape(worktreePath)}`,
-    baseCwd,
-  );
+  git(["worktree", "add", "-b", branchName, worktreePath], baseCwd);
 }
 
 export function removeWorktree(baseCwd: string, worktreePath: string): void {
-  git(`worktree remove --force ${shellEscape(worktreePath)}`, baseCwd);
+  git(["worktree", "remove", "--force", worktreePath], baseCwd);
 }

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -108,10 +108,7 @@ export function getBranchCommitCount(baseCommit: string, cwd: string): number {
   // commits so the number reflects "work unique to this branch" and does not
   // depend on ignored run metadata producing a commit.
   return Number.parseInt(
-    git(
-      ["rev-list", "--count", "--first-parent", `${baseCommit}..HEAD`],
-      cwd,
-    ),
+    git(["rev-list", "--count", "--first-parent", `${baseCommit}..HEAD`], cwd),
     10,
   );
 }


### PR DESCRIPTION
## Summary
- Harden git command execution in `src/core/git.ts` so commit messages, branch names, and worktree paths are passed safely without shell interpretation.
- Add and tighten regression coverage in `src/core/git.injection.test.ts` and `src/core/git.test.ts` to lock in the injection fix and catch refname edge cases.
- Update the changelog to call out the git shell-hardening fix as a user-visible security improvement.

## Risk Assessment

✅ Low: The change is narrowly scoped to replacing shell-based git execution with argv-based calls and adds focused regression coverage, with no material behavioral regressions evident in the reviewed diff.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/git.injection.test.ts:79` - The new `createBranch` regression test is passing for the wrong reason: ``evil`touch ${marker}`` contains a literal space, so Git rejects it as an invalid refname before the backticks matter. Use a syntactically valid refname payload such as one with `${IFS}` to verify that shell-like characters are truly inert.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `CHANGELOG.md:81` - The Unreleased bug-fix notes do not mention the new git command hardening in `src/core/git.ts`. This change prevents shell interpretation of commit messages, branch names, and worktree paths, which is a user-relevant security fix and should be called out in the changelog/release notes.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/core/git.ts:1` - Prettier check failed for this file under the repository&#39;s configured formatting rules.
- ⚠️ `src/core/git.test.ts:1` - Prettier check failed for this file under the repository&#39;s configured formatting rules.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
