### PR TITLE
feat: add live terminal title updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 - **config:** allow per-agent binary path overrides
 - **renderer:** randomize star field seeds between runs
+- **renderer:** update the terminal title with live run status and restore it on exit
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.1.20](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.19...gnhf-v0.1.20) (2026-04-17)
 
-
 ### Bug Fixes
 
-* **core:** harden git command inputs against shell injection ([#68](https://github.com/kunchenguid/gnhf/issues/68)) ([b19d778](https://github.com/kunchenguid/gnhf/commit/b19d778a1322d636e1179aa29b5fe606e7c8b0cc))
+- **core:** harden git command inputs against shell injection ([#68](https://github.com/kunchenguid/gnhf/issues/68)) ([b19d778](https://github.com/kunchenguid/gnhf/commit/b19d778a1322d636e1179aa29b5fe606e7c8b0cc))
 
 ## [0.1.19](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.18...gnhf-v0.1.19) (2026-04-12)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 
 - **Dead simple** — one command starts an autonomous loop that runs until you Ctrl+C or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries and exponential backoff
+- **Live terminal title** — interactive runs keep your terminal title updated with live status, token totals, and commit count, then restore the previous title on exit
 - **Agent-agnostic** — works with Claude Code, Codex, Rovo Dev, or OpenCode out of the box
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -167,14 +167,14 @@ Pass `--worktree` to run each agent in an isolated [git worktree](https://git-sc
 
 ### Flags
 
-| Flag                     | Description                                                        | Default                |
-| ------------------------ | ------------------------------------------------------------------ | ---------------------- |
-| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)         | config file (`claude`) |
-| `--max-iterations <n>`   | Abort after `n` total iterations                                   | unlimited              |
-| `--max-tokens <n>`       | Abort after `n` total input+output tokens                          | unlimited              |
-| `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`) | config file (`on`)     |
-| `--worktree`             | Run in a separate git worktree (enables multiple agents concurrently) | `false`             |
-| `--version`              | Show version                                                       |                        |
+| Flag                     | Description                                                           | Default                |
+| ------------------------ | --------------------------------------------------------------------- | ---------------------- |
+| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)            | config file (`claude`) |
+| `--max-iterations <n>`   | Abort after `n` total iterations                                      | unlimited              |
+| `--max-tokens <n>`       | Abort after `n` total input+output tokens                             | unlimited              |
+| `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`)    | config file (`on`)     |
+| `--worktree`             | Run in a separate git worktree (enables multiple agents concurrently) | `false`                |
+| `--version`              | Show version                                                          |                        |
 
 ## Configuration
 

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -708,7 +708,7 @@ describe("Renderer terminal title", () => {
     return output
       .split(titlePrefix)
       .slice(1)
-      .map((segment) => segment.split(bell, 1)[0] ?? "");
+      .map((segment: string) => segment.split(bell, 1)[0] ?? "");
   }
 
   function extractTitleStackOps(
@@ -720,8 +720,8 @@ describe("Renderer terminal title", () => {
     return output
       .split(titleStackPrefix)
       .slice(1)
-      .map((segment) => segment.split(titleStackSuffix, 1)[0] ?? "")
-      .filter((segment) => segment === "22" || segment === "23");
+      .map((segment: string) => segment.split(titleStackSuffix, 1)[0] ?? "")
+      .filter((segment: string) => segment === "22" || segment === "23");
   }
 
   const baseState: OrchestratorState = {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -675,3 +675,112 @@ describe("Renderer ctrl+c", () => {
     }
   });
 });
+
+describe("Renderer terminal title", () => {
+  function extractTerminalTitles(
+    stdoutWrite: ReturnType<typeof vi.spyOn>,
+  ): string[] {
+    const output = stdoutWrite.mock.calls
+      .map((args: unknown[]) => String(args[0]))
+      .join("");
+    return Array.from(
+      output.matchAll(/\x1b\]2;([^\x07]*)\x07/g) as Iterable<RegExpMatchArray>,
+      (match) => match[1] ?? "",
+    );
+  }
+
+  const baseState: OrchestratorState = {
+    status: "running",
+    currentIteration: 1,
+    totalInputTokens: 12_400,
+    totalOutputTokens: 8_200,
+    commitCount: 12,
+    iterations: [createIteration()],
+    successCount: 1,
+    failCount: 0,
+    consecutiveFailures: 0,
+    startTime: new Date("2026-01-01T00:00:00Z"),
+    waitingUntil: null,
+    lastMessage: "reading files",
+  };
+
+  it("writes a running title with the active moon and counters", () => {
+    const state = { ...baseState, iterations: [...baseState.iterations] };
+    const orchestrator = Object.assign(new EventEmitter(), {
+      getState: vi.fn(() => state),
+      stop: vi.fn(),
+    }) as unknown as Orchestrator;
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const renderer = new Renderer(orchestrator, "ship it", "claude");
+      renderer.start();
+
+      const titles = extractTerminalTitles(stdoutWrite);
+      expect(titles.at(-1)).toMatch(
+        /^gnhf [🌑🌒🌓🌔🌕🌖🌗🌘] · 12K in · 8K out · 12 commits$/u,
+      );
+
+      renderer.stop();
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      }
+      stdoutWrite.mockRestore();
+    }
+  });
+
+  it("updates the title when the run stops", async () => {
+    const state = { ...baseState, iterations: [...baseState.iterations] };
+    const orchestrator = Object.assign(new EventEmitter(), {
+      getState: vi.fn(() => state),
+      stop: vi.fn(),
+    }) as unknown as Orchestrator;
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const renderer = new Renderer(orchestrator, "ship it", "claude");
+      renderer.start();
+      stdoutWrite.mockClear();
+
+      state.status = "stopped";
+      orchestrator.emit("state", {
+        ...state,
+        iterations: [...state.iterations],
+      });
+      orchestrator.emit("stopped");
+
+      await expect(renderer.waitUntilExit()).resolves.toBe("stopped");
+
+      const titles = extractTerminalTitles(stdoutWrite);
+      expect(titles.at(-1)).toBe("gnhf stopped · 12K in · 8K out · 12 commits");
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      }
+      stdoutWrite.mockRestore();
+    }
+  });
+});

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -677,6 +677,19 @@ describe("Renderer ctrl+c", () => {
 });
 
 describe("Renderer terminal title", () => {
+  function setTty(target: NodeJS.WriteStream | NodeJS.ReadStream, value: boolean) {
+    const original = Object.getOwnPropertyDescriptor(target, "isTTY");
+    Object.defineProperty(target, "isTTY", {
+      configurable: true,
+      value,
+    });
+    return () => {
+      if (original) {
+        Object.defineProperty(target, "isTTY", original);
+      }
+    };
+  }
+
   function extractTerminalTitles(
     stdoutWrite: ReturnType<typeof vi.spyOn>,
   ): string[] {
@@ -725,15 +738,8 @@ describe("Renderer terminal title", () => {
     const stdoutWrite = vi
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
-    const originalIsTTY = Object.getOwnPropertyDescriptor(
-      process.stdin,
-      "isTTY",
-    );
-
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: false,
-    });
+    const restoreStdinTty = setTty(process.stdin, false);
+    const restoreStdoutTty = setTty(process.stdout, true);
 
     try {
       const renderer = new Renderer(orchestrator, "ship it", "claude");
@@ -746,9 +752,34 @@ describe("Renderer terminal title", () => {
 
       renderer.stop();
     } finally {
-      if (originalIsTTY) {
-        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
-      }
+      restoreStdoutTty();
+      restoreStdinTty();
+      stdoutWrite.mockRestore();
+    }
+  });
+
+  it("does not emit title control codes when stdout is not a tty", () => {
+    const state = { ...baseState, iterations: [...baseState.iterations] };
+    const orchestrator = Object.assign(new EventEmitter(), {
+      getState: vi.fn(() => state),
+      stop: vi.fn(),
+    }) as unknown as Orchestrator;
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const restoreStdinTty = setTty(process.stdin, false);
+    const restoreStdoutTty = setTty(process.stdout, false);
+
+    try {
+      const renderer = new Renderer(orchestrator, "ship it", "claude");
+      renderer.start();
+      renderer.stop();
+
+      expect(extractTerminalTitles(stdoutWrite)).toEqual([]);
+      expect(extractTitleStackOps(stdoutWrite)).toEqual([]);
+    } finally {
+      restoreStdoutTty();
+      restoreStdinTty();
       stdoutWrite.mockRestore();
     }
   });
@@ -762,15 +793,8 @@ describe("Renderer terminal title", () => {
     const stdoutWrite = vi
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
-    const originalIsTTY = Object.getOwnPropertyDescriptor(
-      process.stdin,
-      "isTTY",
-    );
-
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: false,
-    });
+    const restoreStdinTty = setTty(process.stdin, false);
+    const restoreStdoutTty = setTty(process.stdout, true);
 
     try {
       const renderer = new Renderer(orchestrator, "ship it", "claude");
@@ -789,9 +813,8 @@ describe("Renderer terminal title", () => {
       const titles = extractTerminalTitles(stdoutWrite);
       expect(titles.at(-1)).toBe("gnhf stopped · 12K in · 8K out · 12 commits");
     } finally {
-      if (originalIsTTY) {
-        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
-      }
+      restoreStdoutTty();
+      restoreStdinTty();
       stdoutWrite.mockRestore();
     }
   });
@@ -805,15 +828,8 @@ describe("Renderer terminal title", () => {
     const stdoutWrite = vi
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
-    const originalIsTTY = Object.getOwnPropertyDescriptor(
-      process.stdin,
-      "isTTY",
-    );
-
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: false,
-    });
+    const restoreStdinTty = setTty(process.stdin, false);
+    const restoreStdoutTty = setTty(process.stdout, true);
 
     try {
       const renderer = new Renderer(orchestrator, "ship it", "claude");
@@ -829,9 +845,8 @@ describe("Renderer terminal title", () => {
 
       expect(stdoutWrite).not.toHaveBeenCalled();
     } finally {
-      if (originalIsTTY) {
-        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
-      }
+      restoreStdoutTty();
+      restoreStdinTty();
       stdoutWrite.mockRestore();
     }
   });
@@ -845,15 +860,8 @@ describe("Renderer terminal title", () => {
     const stdoutWrite = vi
       .spyOn(process.stdout, "write")
       .mockImplementation(() => true);
-    const originalIsTTY = Object.getOwnPropertyDescriptor(
-      process.stdin,
-      "isTTY",
-    );
-
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: false,
-    });
+    const restoreStdinTty = setTty(process.stdin, false);
+    const restoreStdoutTty = setTty(process.stdout, true);
 
     try {
       const renderer = new Renderer(orchestrator, "ship it", "claude");
@@ -862,9 +870,8 @@ describe("Renderer terminal title", () => {
 
       expect(extractTitleStackOps(stdoutWrite)).toEqual(["22", "23"]);
     } finally {
-      if (originalIsTTY) {
-        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
-      }
+      restoreStdoutTty();
+      restoreStdinTty();
       stdoutWrite.mockRestore();
     }
   });

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -677,7 +677,16 @@ describe("Renderer ctrl+c", () => {
 });
 
 describe("Renderer terminal title", () => {
-  function setTty(target: NodeJS.WriteStream | NodeJS.ReadStream, value: boolean) {
+  const escape = String.fromCharCode(27);
+  const bell = String.fromCharCode(7);
+  const titlePrefix = `${escape}]2;`;
+  const titleStackPrefix = `${escape}[`;
+  const titleStackSuffix = ";0t";
+
+  function setTty(
+    target: NodeJS.WriteStream | NodeJS.ReadStream,
+    value: boolean,
+  ) {
     const original = Object.getOwnPropertyDescriptor(target, "isTTY");
     Object.defineProperty(target, "isTTY", {
       configurable: true,
@@ -696,10 +705,10 @@ describe("Renderer terminal title", () => {
     const output = stdoutWrite.mock.calls
       .map((args: unknown[]) => String(args[0]))
       .join("");
-    return Array.from(
-      output.matchAll(/\x1b\]2;([^\x07]*)\x07/g) as Iterable<RegExpMatchArray>,
-      (match) => match[1] ?? "",
-    );
+    return output
+      .split(titlePrefix)
+      .slice(1)
+      .map((segment) => segment.split(bell, 1)[0] ?? "");
   }
 
   function extractTitleStackOps(
@@ -708,10 +717,11 @@ describe("Renderer terminal title", () => {
     const output = stdoutWrite.mock.calls
       .map((args: unknown[]) => String(args[0]))
       .join("");
-    return Array.from(
-      output.matchAll(/\x1b\[(22|23);0t/g) as Iterable<RegExpMatchArray>,
-      (match) => match[1] ?? "",
-    );
+    return output
+      .split(titleStackPrefix)
+      .slice(1)
+      .map((segment) => segment.split(titleStackSuffix, 1)[0] ?? "")
+      .filter((segment) => segment === "22" || segment === "23");
   }
 
   const baseState: OrchestratorState = {

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -689,6 +689,18 @@ describe("Renderer terminal title", () => {
     );
   }
 
+  function extractTitleStackOps(
+    stdoutWrite: ReturnType<typeof vi.spyOn>,
+  ): string[] {
+    const output = stdoutWrite.mock.calls
+      .map((args: unknown[]) => String(args[0]))
+      .join("");
+    return Array.from(
+      output.matchAll(/\x1b\[(22|23);0t/g) as Iterable<RegExpMatchArray>,
+      (match) => match[1] ?? "",
+    );
+  }
+
   const baseState: OrchestratorState = {
     status: "running",
     currentIteration: 1,
@@ -776,6 +788,79 @@ describe("Renderer terminal title", () => {
 
       const titles = extractTerminalTitles(stdoutWrite);
       expect(titles.at(-1)).toBe("gnhf stopped · 12K in · 8K out · 12 commits");
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      }
+      stdoutWrite.mockRestore();
+    }
+  });
+
+  it("stops updating the title after the renderer exits", () => {
+    const state = { ...baseState, iterations: [...baseState.iterations] };
+    const orchestrator = Object.assign(new EventEmitter(), {
+      getState: vi.fn(() => state),
+      stop: vi.fn(),
+    }) as unknown as Orchestrator;
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const renderer = new Renderer(orchestrator, "ship it", "claude");
+      renderer.start();
+      renderer.stop("interrupted");
+      stdoutWrite.mockClear();
+
+      state.status = "stopped";
+      orchestrator.emit("state", {
+        ...state,
+        iterations: [...state.iterations],
+      });
+
+      expect(stdoutWrite).not.toHaveBeenCalled();
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+      }
+      stdoutWrite.mockRestore();
+    }
+  });
+
+  it("restores the previous terminal title when the renderer exits", () => {
+    const state = { ...baseState, iterations: [...baseState.iterations] };
+    const orchestrator = Object.assign(new EventEmitter(), {
+      getState: vi.fn(() => state),
+      stop: vi.fn(),
+    }) as unknown as Orchestrator;
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "isTTY",
+    );
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const renderer = new Renderer(orchestrator, "ship it", "claude");
+      renderer.start();
+      renderer.stop();
+
+      expect(extractTitleStackOps(stdoutWrite)).toEqual(["22", "23"]);
     } finally {
       if (originalIsTTY) {
         Object.defineProperty(process.stdin, "isTTY", originalIsTTY);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -44,17 +44,25 @@ function spacedLabel(text: string): string {
   return text.split("").join(" ");
 }
 
+function formatTokenCount(tokens: number, direction: "in" | "out"): string {
+  return `${formatTokens(tokens)} ${direction}`;
+}
+
+function formatCommitCount(commitCount: number): string {
+  const commitLabel = commitCount === 1 ? "commit" : "commits";
+  return `${commitCount} ${commitLabel}`;
+}
+
 function buildTerminalTitle(state: OrchestratorState, now: number): string {
-  const commitLabel = state.commitCount === 1 ? "commit" : "commits";
   const lead =
     state.status === "running" || state.status === "waiting"
       ? getMoonPhase("active", now, MOON_PHASE_PERIOD)
       : state.status;
   return (
     `gnhf ${lead}` +
-    ` · ${formatTokens(state.totalInputTokens)} in` +
-    ` · ${formatTokens(state.totalOutputTokens)} out` +
-    ` · ${state.commitCount} ${commitLabel}`
+    ` · ${formatTokenCount(state.totalInputTokens, "in")}` +
+    ` · ${formatTokenCount(state.totalOutputTokens, "out")}` +
+    ` · ${formatCommitCount(state.commitCount)}`
   );
 }
 
@@ -107,21 +115,20 @@ export function renderStatsCells(
   outputTokens: number,
   commitCount: number,
 ): Cell[] {
-  const commitLabel = commitCount === 1 ? "commit" : "commits";
   return [
     ...textToCells(elapsed, "bold"),
     ...textToCells("  ", "normal"),
     ...textToCells("\u00b7", "dim"),
     ...textToCells("  ", "normal"),
-    ...textToCells(`${formatTokens(inputTokens)} in`, "normal"),
+    ...textToCells(formatTokenCount(inputTokens, "in"), "normal"),
     ...textToCells("  ", "normal"),
     ...textToCells("\u00b7", "dim"),
     ...textToCells("  ", "normal"),
-    ...textToCells(`${formatTokens(outputTokens)} out`, "normal"),
+    ...textToCells(formatTokenCount(outputTokens, "out"), "normal"),
     ...textToCells("  ", "normal"),
     ...textToCells("\u00b7", "dim"),
     ...textToCells("  ", "normal"),
-    ...textToCells(`${commitCount} ${commitLabel}`, "normal"),
+    ...textToCells(formatCommitCount(commitCount), "normal"),
   ];
 }
 
@@ -675,6 +682,9 @@ export class Renderer {
   }
 
   private updateTerminalTitle(now = Date.now()): void {
+    if (!process.stdout.isTTY) {
+      return;
+    }
     const nextTitle = buildTerminalTitle(this.state, now);
     if (!this.titleSaved) {
       process.stdout.write(saveTerminalTitle());

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -62,6 +62,14 @@ function emitTerminalTitle(title: string): string {
   return `\x1b]2;${title}\x07`;
 }
 
+function saveTerminalTitle(): string {
+  return "\x1b[22;0t";
+}
+
+function restoreTerminalTitle(): string {
+  return "\x1b[23;0t";
+}
+
 export function renderTitleCells(agentName?: string): Cell[][] {
   const eyebrow: Cell[] = [
     ...textToCells(spacedLabel("gnhf"), "dim"),
@@ -527,10 +535,18 @@ export class Renderer {
   private cachedHeight = 0;
   private prevCells: Cell[][] = [];
   private prevTitle: string | null = null;
+  private titleSaved = false;
   private isFirstFrame = true;
   private seedTop: number;
   private seedBottom: number;
   private seedSide: number;
+  private readonly handleState = (newState: OrchestratorState) => {
+    this.state = { ...newState, iterations: [...newState.iterations] };
+    this.updateTerminalTitle();
+  };
+  private readonly handleStopped = () => {
+    this.stop("stopped");
+  };
 
   constructor(orchestrator: Orchestrator, prompt: string, agentName: string) {
     this.orchestrator = orchestrator;
@@ -546,14 +562,9 @@ export class Renderer {
   }
 
   start(): void {
-    this.orchestrator.on("state", (newState) => {
-      this.state = { ...newState, iterations: [...newState.iterations] };
-      this.updateTerminalTitle();
-    });
+    this.orchestrator.on("state", this.handleState);
 
-    this.orchestrator.on("stopped", () => {
-      this.stop("stopped");
-    });
+    this.orchestrator.on("stopped", this.handleStopped);
 
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(true);
@@ -575,10 +586,17 @@ export class Renderer {
       clearInterval(this.interval);
       this.interval = null;
     }
+    this.orchestrator.off("state", this.handleState);
+    this.orchestrator.off("stopped", this.handleStopped);
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(false);
       process.stdin.pause();
       process.stdin.removeAllListeners("data");
+    }
+    if (this.titleSaved) {
+      process.stdout.write(restoreTerminalTitle());
+      this.titleSaved = false;
+      this.prevTitle = null;
     }
     this.exitResolve(reason);
   }
@@ -658,6 +676,10 @@ export class Renderer {
 
   private updateTerminalTitle(now = Date.now()): void {
     const nextTitle = buildTerminalTitle(this.state, now);
+    if (!this.titleSaved) {
+      process.stdout.write(saveTerminalTitle());
+      this.titleSaved = true;
+    }
     if (nextTitle === this.prevTitle) {
       return;
     }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -44,6 +44,24 @@ function spacedLabel(text: string): string {
   return text.split("").join(" ");
 }
 
+function buildTerminalTitle(state: OrchestratorState, now: number): string {
+  const commitLabel = state.commitCount === 1 ? "commit" : "commits";
+  const lead =
+    state.status === "running" || state.status === "waiting"
+      ? getMoonPhase("active", now, MOON_PHASE_PERIOD)
+      : state.status;
+  return (
+    `gnhf ${lead}` +
+    ` · ${formatTokens(state.totalInputTokens)} in` +
+    ` · ${formatTokens(state.totalOutputTokens)} out` +
+    ` · ${state.commitCount} ${commitLabel}`
+  );
+}
+
+function emitTerminalTitle(title: string): string {
+  return `\x1b]2;${title}\x07`;
+}
+
 export function renderTitleCells(agentName?: string): Cell[][] {
   const eyebrow: Cell[] = [
     ...textToCells(spacedLabel("gnhf"), "dim"),
@@ -508,6 +526,7 @@ export class Renderer {
   private cachedWidth = 0;
   private cachedHeight = 0;
   private prevCells: Cell[][] = [];
+  private prevTitle: string | null = null;
   private isFirstFrame = true;
   private seedTop: number;
   private seedBottom: number;
@@ -529,6 +548,7 @@ export class Renderer {
   start(): void {
     this.orchestrator.on("state", (newState) => {
       this.state = { ...newState, iterations: [...newState.iterations] };
+      this.updateTerminalTitle();
     });
 
     this.orchestrator.on("stopped", () => {
@@ -609,6 +629,8 @@ export class Renderer {
     const h = process.stdout.rows || 24;
     const resized = this.ensureStarFields(w, h);
 
+    this.updateTerminalTitle(now);
+
     const nextCells = buildFrameCells(
       this.prompt,
       this.agentName,
@@ -632,5 +654,14 @@ export class Renderer {
     }
 
     this.prevCells = nextCells;
+  }
+
+  private updateTerminalTitle(now = Date.now()): void {
+    const nextTitle = buildTerminalTitle(this.state, now);
+    if (nextTitle === this.prevTitle) {
+      return;
+    }
+    process.stdout.write(emitTerminalTitle(nextTitle));
+    this.prevTitle = nextTitle;
   }
 }


### PR DESCRIPTION
## Summary
- Add renderer support for updating the terminal window title during interactive runs so status, token totals, and commit count stay visible outside the TUI.
- Restore the previous title on shutdown and gate title escape sequences to TTY output to avoid leaked control bytes and post-exit side effects.
- Cover the new terminal-title behavior with renderer tests and document the feature in the README and changelog.

## Risk Assessment

✅ Low: The change is narrowly scoped to renderer terminal-title behavior, includes targeted lifecycle coverage, and I did not find any material correctness or merge-blocking risks in the changed code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/renderer.ts:549` - `start()` registers anonymous `state`/`stopped` listeners, but `stop()` never unregisters them. If the renderer is stopped before the orchestrator finishes (for example the SIGINT/SIGTERM path in `cli.ts`), a later `state` event can still call `updateTerminalTitle()` and emit OSC title bytes after the TUI has already exited.
- ⚠️ `src/renderer.ts:664` - The new title is only ever set, never restored. After the process exits, the user&#39;s terminal/tab title stays stuck on the last `gnhf ...` value, which is a persistent user-visible side effect worth confirming before merge.

**Round 2** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `src/renderer.ts:677` - `updateTerminalTitle()` emits save/title/restore escape sequences unconditionally, so non-interactive runs that pipe or redirect stdout will get raw `OSC 2` / `CSI 22;0t` bytes in their output. Gate the title feature on `process.stdout.isTTY` before writing any title control codes.
- ℹ️ `src/renderer.ts:47` - `buildTerminalTitle()` reimplements the token and commit label formatting already used by the stats row, which creates an easy drift point if either display is updated later. Extracting a small shared formatter would simplify the code and keep the title and in-screen stats consistent.

**Round 3** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `README.md:47` - The README&#39;s user-facing feature overview does not mention the new renderer behavior that updates the terminal window title with live run status, token totals, and commit count, then restores the previous title on exit. Since this is a visible runtime feature change, the main usage docs should mention it.
- ⚠️ `CHANGELOG.md:73` - The Unreleased changelog is missing an entry for the renderer change that sets and restores the terminal title during interactive runs. This branch adds a user-visible feature/behavior change, so it should be recorded in the changelog.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>🔧 **Lint** - 5 issues found → auto-fixed (2)</summary>

**Round 1** - found 5 issues (2 errors, 3 warnings)
- ⚠️ `CHANGELOG.md:77` - Prettier check failed for this changed Markdown file.
- ⚠️ `README.md:49` - Prettier check failed for this changed Markdown file.
- ⚠️ `src/renderer.test.ts:678` - Prettier check failed for this changed test file.
- 🚨 `src/renderer.test.ts:700` - ESLint `no-control-regex` failed: the regular expression contains control characters in the terminal-title matcher.
- 🚨 `src/renderer.test.ts:712` - ESLint `no-control-regex` failed: the regular expression contains a control character in the terminal-title stack-operation matcher.

**Round 2** (auto-fix) - found 3 errors
- 🚨 `src/renderer.test.ts:711` - TypeScript typecheck failed: parameter `segment` implicitly has an `any` type in `extractTerminalTitles`.
- 🚨 `src/renderer.test.ts:723` - TypeScript typecheck failed: parameter `segment` implicitly has an `any` type in `extractTitleStackOps`.
- 🚨 `src/renderer.test.ts:724` - TypeScript typecheck failed: parameter `segment` implicitly has an `any` type in `extractTitleStackOps` filter callback.

**Round 3** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
