### PR TITLE
fix(agents): dedupe Claude usage across repeated assistant snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 ### Bug Fixes
 
 - **agents:** support Windows cmd/bat agent wrappers and terminate overridden agent processes cleanly
+- **agents:** deduplicate repeated Claude assistant usage snapshots so live token totals and max-token enforcement stay accurate
 - **cli:** keep the final interactive TUI visible after aborted runs until the user exits
 - **core:** harden git command execution so commit messages, branch names, and worktree paths are passed without shell interpretation
 - **renderer:** keep wide Unicode graphemes wrapped and aligned in the live terminal UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.1.21](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.20...gnhf-v0.1.21) (2026-04-17)
 
-
 ### Features
 
-* add live terminal title updates ([#70](https://github.com/kunchenguid/gnhf/issues/70)) ([f8b57d6](https://github.com/kunchenguid/gnhf/commit/f8b57d6a7640cff457f3d399b4aa1b44bb37abbe))
+- add live terminal title updates ([#70](https://github.com/kunchenguid/gnhf/issues/70)) ([f8b57d6](https://github.com/kunchenguid/gnhf/commit/f8b57d6a7640cff457f3d399b4aa1b44bb37abbe))
 
 ## [0.1.20](https://github.com/kunchenguid/gnhf/compare/gnhf-v0.1.19...gnhf-v0.1.20) (2026-04-17)
 

--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -401,6 +401,95 @@ describe("ClaudeAgent", () => {
     });
   });
 
+  it("does not double count repeated assistant events without a message id", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const onUsage = vi.fn();
+
+    const promise = agent.run("prompt", "/cwd", { onUsage });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 1,
+          output_tokens: 3,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 1,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "result",
+      subtype: "success",
+      usage: {
+        input_tokens: 7,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 4,
+        output_tokens: 20,
+      },
+      structured_output: {
+        success: true,
+        summary: "done",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+    });
+
+    proc.emit("close", 0);
+    await promise;
+
+    expect(onUsage).toHaveBeenNthCalledWith(1, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(2, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(3, {
+      inputTokens: 37,
+      outputTokens: 11,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 4,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(4, {
+      inputTokens: 37,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 4,
+    });
+  });
+
   it("rejects when process exits with non-zero code", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -309,6 +309,98 @@ describe("ClaudeAgent", () => {
     await promise;
   });
 
+  it("does not double count repeated assistant events for the same message id", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const onUsage = vi.fn();
+
+    const promise = agent.run("prompt", "/cwd", { onUsage });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        id: "msg-1",
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        id: "msg-1",
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        id: "msg-2",
+        usage: {
+          input_tokens: 1,
+          output_tokens: 3,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 1,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "result",
+      subtype: "success",
+      usage: {
+        input_tokens: 7,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 4,
+        output_tokens: 20,
+      },
+      structured_output: {
+        success: true,
+        summary: "done",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+    });
+
+    proc.emit("close", 0);
+    await promise;
+
+    expect(onUsage).toHaveBeenNthCalledWith(1, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(2, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(3, {
+      inputTokens: 37,
+      outputTokens: 11,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 4,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(4, {
+      inputTokens: 37,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 4,
+    });
+  });
+
   it("rejects when process exits with non-zero code", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -490,6 +490,168 @@ describe("ClaudeAgent", () => {
     });
   });
 
+  it("does not double count evolving assistant snapshots without a message id", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const onUsage = vi.fn();
+
+    const promise = agent.run("prompt", "/cwd", { onUsage });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "hel" }],
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "hello" }],
+        usage: {
+          input_tokens: 6,
+          output_tokens: 10,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "result",
+      subtype: "success",
+      usage: {
+        input_tokens: 6,
+        cache_read_input_tokens: 10,
+        cache_creation_input_tokens: 3,
+        output_tokens: 10,
+      },
+      structured_output: {
+        success: true,
+        summary: "done",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+    });
+
+    proc.emit("close", 0);
+    await promise;
+
+    expect(onUsage).toHaveBeenNthCalledWith(1, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(2, {
+      inputTokens: 16,
+      outputTokens: 10,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(3, {
+      inputTokens: 16,
+      outputTokens: 10,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+  });
+
+  it("recovers cumulative usage for distinct anonymous turns when payloads match", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const onUsage = vi.fn();
+
+    const promise = agent.run("prompt", "/cwd", { onUsage });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 6,
+          output_tokens: 8,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 3,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "assistant",
+      message: {
+        usage: {
+          input_tokens: 12,
+          output_tokens: 16,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 6,
+        },
+      },
+    });
+
+    emitLine(proc, {
+      type: "result",
+      subtype: "success",
+      usage: {
+        input_tokens: 18,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 9,
+        output_tokens: 24,
+      },
+      structured_output: {
+        success: true,
+        summary: "done",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+    });
+
+    proc.emit("close", 0);
+    await promise;
+
+    expect(onUsage).toHaveBeenNthCalledWith(1, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(2, {
+      inputTokens: 16,
+      outputTokens: 8,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 3,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(3, {
+      inputTokens: 48,
+      outputTokens: 24,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 9,
+    });
+    expect(onUsage).toHaveBeenNthCalledWith(4, {
+      inputTokens: 48,
+      outputTokens: 24,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 9,
+    });
+  });
+
   it("rejects when process exits with non-zero code", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -137,6 +137,13 @@ function toTokenUsage(usage: {
   };
 }
 
+function getAnonymousAssistantFingerprint(message: Record<string, unknown>): string {
+  return JSON.stringify({
+    usage: message.usage,
+    content: message.content,
+  });
+}
+
 export class ClaudeAgent implements Agent {
   name = "claude";
 
@@ -185,13 +192,31 @@ export class ClaudeAgent implements Agent {
       };
       const usageByMessageId = new Map<string, TokenUsage>();
       let anonymousAssistantCount = 0;
+      let lastAnonymousAssistantFingerprint: string | null = null;
+      let lastAnonymousAssistantId: string | null = null;
 
       parseJSONLStream<ClaudeEvent>(child.stdout!, logStream, (event) => {
         if (event.type === "assistant") {
           const msg = (event as ClaudeAssistantEvent).message;
-          const messageId = msg.id ?? `assistant-${anonymousAssistantCount++}`;
+          const anonymousFingerprint = msg.id
+            ? null
+            : getAnonymousAssistantFingerprint(msg as Record<string, unknown>);
+          const messageId = msg.id
+            ? msg.id
+            : anonymousFingerprint === lastAnonymousAssistantFingerprint &&
+                lastAnonymousAssistantId
+              ? lastAnonymousAssistantId
+              : `assistant-${anonymousAssistantCount++}`;
           const nextUsage = toTokenUsage(msg.usage);
           const previousUsage = usageByMessageId.get(messageId);
+
+          if (anonymousFingerprint) {
+            lastAnonymousAssistantFingerprint = anonymousFingerprint;
+            lastAnonymousAssistantId = messageId;
+          } else {
+            lastAnonymousAssistantFingerprint = null;
+            lastAnonymousAssistantId = null;
+          }
 
           if (previousUsage) {
             cumulative.inputTokens +=

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -226,9 +226,12 @@ export class ClaudeAgent implements Agent {
           ) {
             messageId = `assistant-${anonymousAssistantCount++}`;
             previousUsage = pendingAnonymousAssistantUsage;
-            cumulative.inputTokens += pendingAnonymousAssistantUsage.inputTokens;
-            cumulative.outputTokens += pendingAnonymousAssistantUsage.outputTokens;
-            cumulative.cacheReadTokens += pendingAnonymousAssistantUsage.cacheReadTokens;
+            cumulative.inputTokens +=
+              pendingAnonymousAssistantUsage.inputTokens;
+            cumulative.outputTokens +=
+              pendingAnonymousAssistantUsage.outputTokens;
+            cumulative.cacheReadTokens +=
+              pendingAnonymousAssistantUsage.cacheReadTokens;
             cumulative.cacheCreationTokens +=
               pendingAnonymousAssistantUsage.cacheCreationTokens;
             usageByMessageId.set(messageId, pendingAnonymousAssistantUsage);

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -17,6 +17,7 @@ import {
 interface ClaudeAssistantEvent {
   type: "assistant";
   message: {
+    id?: string;
     usage: {
       input_tokens: number;
       output_tokens: number;
@@ -121,6 +122,21 @@ function buildClaudeArgs(prompt: string, extraArgs?: string[]): string[] {
   ];
 }
 
+function toTokenUsage(usage: {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}): TokenUsage {
+  return {
+    inputTokens:
+      (usage.input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0),
+    outputTokens: usage.output_tokens ?? 0,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+  };
+}
+
 export class ClaudeAgent implements Agent {
   name = "claude";
 
@@ -167,17 +183,33 @@ export class ClaudeAgent implements Agent {
         cacheReadTokens: 0,
         cacheCreationTokens: 0,
       };
+      const usageByMessageId = new Map<string, TokenUsage>();
+      let anonymousAssistantCount = 0;
 
       parseJSONLStream<ClaudeEvent>(child.stdout!, logStream, (event) => {
         if (event.type === "assistant") {
           const msg = (event as ClaudeAssistantEvent).message;
-          cumulative.inputTokens +=
-            (msg.usage.input_tokens ?? 0) +
-            (msg.usage.cache_read_input_tokens ?? 0);
-          cumulative.outputTokens += msg.usage.output_tokens ?? 0;
-          cumulative.cacheReadTokens += msg.usage.cache_read_input_tokens ?? 0;
-          cumulative.cacheCreationTokens +=
-            msg.usage.cache_creation_input_tokens ?? 0;
+          const messageId = msg.id ?? `assistant-${anonymousAssistantCount++}`;
+          const nextUsage = toTokenUsage(msg.usage);
+          const previousUsage = usageByMessageId.get(messageId);
+
+          if (previousUsage) {
+            cumulative.inputTokens +=
+              nextUsage.inputTokens - previousUsage.inputTokens;
+            cumulative.outputTokens +=
+              nextUsage.outputTokens - previousUsage.outputTokens;
+            cumulative.cacheReadTokens +=
+              nextUsage.cacheReadTokens - previousUsage.cacheReadTokens;
+            cumulative.cacheCreationTokens +=
+              nextUsage.cacheCreationTokens - previousUsage.cacheCreationTokens;
+          } else {
+            cumulative.inputTokens += nextUsage.inputTokens;
+            cumulative.outputTokens += nextUsage.outputTokens;
+            cumulative.cacheReadTokens += nextUsage.cacheReadTokens;
+            cumulative.cacheCreationTokens += nextUsage.cacheCreationTokens;
+          }
+
+          usageByMessageId.set(messageId, nextUsage);
           onUsage?.({ ...cumulative });
 
           if (onMessage) {
@@ -220,15 +252,7 @@ export class ClaudeAgent implements Agent {
         }
 
         const output: AgentOutput = resultEvent.structured_output;
-        const usage: TokenUsage = {
-          inputTokens:
-            (resultEvent.usage.input_tokens ?? 0) +
-            (resultEvent.usage.cache_read_input_tokens ?? 0),
-          outputTokens: resultEvent.usage.output_tokens ?? 0,
-          cacheReadTokens: resultEvent.usage.cache_read_input_tokens ?? 0,
-          cacheCreationTokens:
-            resultEvent.usage.cache_creation_input_tokens ?? 0,
-        };
+        const usage = toTokenUsage(resultEvent.usage);
 
         onUsage?.(usage);
         resolve({ output, usage });

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -137,11 +137,23 @@ function toTokenUsage(usage: {
   };
 }
 
-function getAnonymousAssistantFingerprint(message: Record<string, unknown>): string {
-  return JSON.stringify({
-    usage: message.usage,
-    content: message.content,
-  });
+function isSameUsage(a: TokenUsage, b: TokenUsage): boolean {
+  return (
+    a.inputTokens === b.inputTokens &&
+    a.outputTokens === b.outputTokens &&
+    a.cacheReadTokens === b.cacheReadTokens &&
+    a.cacheCreationTokens === b.cacheCreationTokens
+  );
+}
+
+function extendsUsage(next: TokenUsage, previous: TokenUsage): boolean {
+  return (
+    next.inputTokens >= previous.inputTokens &&
+    next.outputTokens >= previous.outputTokens &&
+    next.cacheReadTokens >= previous.cacheReadTokens &&
+    next.cacheCreationTokens >= previous.cacheCreationTokens &&
+    !isSameUsage(next, previous)
+  );
 }
 
 export class ClaudeAgent implements Agent {
@@ -192,30 +204,59 @@ export class ClaudeAgent implements Agent {
       };
       const usageByMessageId = new Map<string, TokenUsage>();
       let anonymousAssistantCount = 0;
-      let lastAnonymousAssistantFingerprint: string | null = null;
       let lastAnonymousAssistantId: string | null = null;
+      let lastAnonymousAssistantUsage: TokenUsage | null = null;
+      let pendingAnonymousAssistantUsage: TokenUsage | null = null;
 
       parseJSONLStream<ClaudeEvent>(child.stdout!, logStream, (event) => {
         if (event.type === "assistant") {
           const msg = (event as ClaudeAssistantEvent).message;
-          const anonymousFingerprint = msg.id
-            ? null
-            : getAnonymousAssistantFingerprint(msg as Record<string, unknown>);
-          const messageId = msg.id
-            ? msg.id
-            : anonymousFingerprint === lastAnonymousAssistantFingerprint &&
-                lastAnonymousAssistantId
-              ? lastAnonymousAssistantId
-              : `assistant-${anonymousAssistantCount++}`;
           const nextUsage = toTokenUsage(msg.usage);
-          const previousUsage = usageByMessageId.get(messageId);
+          let messageId = msg.id;
+          let previousUsage: TokenUsage | undefined;
 
-          if (anonymousFingerprint) {
-            lastAnonymousAssistantFingerprint = anonymousFingerprint;
-            lastAnonymousAssistantId = messageId;
-          } else {
-            lastAnonymousAssistantFingerprint = null;
+          if (messageId) {
+            previousUsage = usageByMessageId.get(messageId);
             lastAnonymousAssistantId = null;
+            lastAnonymousAssistantUsage = null;
+            pendingAnonymousAssistantUsage = null;
+          } else if (
+            pendingAnonymousAssistantUsage &&
+            extendsUsage(nextUsage, pendingAnonymousAssistantUsage)
+          ) {
+            messageId = `assistant-${anonymousAssistantCount++}`;
+            previousUsage = pendingAnonymousAssistantUsage;
+            cumulative.inputTokens += pendingAnonymousAssistantUsage.inputTokens;
+            cumulative.outputTokens += pendingAnonymousAssistantUsage.outputTokens;
+            cumulative.cacheReadTokens += pendingAnonymousAssistantUsage.cacheReadTokens;
+            cumulative.cacheCreationTokens +=
+              pendingAnonymousAssistantUsage.cacheCreationTokens;
+            usageByMessageId.set(messageId, pendingAnonymousAssistantUsage);
+            pendingAnonymousAssistantUsage = null;
+            lastAnonymousAssistantId = messageId;
+            lastAnonymousAssistantUsage = nextUsage;
+          } else if (
+            lastAnonymousAssistantId &&
+            lastAnonymousAssistantUsage &&
+            extendsUsage(nextUsage, lastAnonymousAssistantUsage)
+          ) {
+            messageId = lastAnonymousAssistantId;
+            previousUsage = usageByMessageId.get(messageId);
+            pendingAnonymousAssistantUsage = null;
+            lastAnonymousAssistantUsage = nextUsage;
+          } else if (
+            lastAnonymousAssistantId &&
+            lastAnonymousAssistantUsage &&
+            isSameUsage(nextUsage, lastAnonymousAssistantUsage)
+          ) {
+            messageId = lastAnonymousAssistantId;
+            previousUsage = usageByMessageId.get(messageId);
+            pendingAnonymousAssistantUsage ??= nextUsage;
+          } else {
+            messageId = `assistant-${anonymousAssistantCount++}`;
+            pendingAnonymousAssistantUsage = null;
+            lastAnonymousAssistantId = messageId;
+            lastAnonymousAssistantUsage = nextUsage;
           }
 
           if (previousUsage) {


### PR DESCRIPTION
## Summary
- Fix Claude usage accounting for streamed assistant events so repeated or evolving snapshots, especially anonymous no-id turns, do not get double-counted in live token totals.
- Add targeted `src/core/agents/claude.test.ts` coverage for the snapshot deduplication edge cases that drove the fix.
- Document the user-visible change in `CHANGELOG.md` because corrected live usage totals can affect reported tokens and `--max-tokens` enforcement.

## Risk Assessment

⚠️ Medium: The change is narrowly scoped, but the new anonymous-snapshot heuristics still misattribute usage in plausible stream shapes, so it is mergeable only if inaccurate live usage reporting is acceptable for now.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 warnings</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/agents/claude.ts:192` - Anonymous assistant events are given a fresh synthetic ID on every emission, so repeated snapshots without `message.id` are still treated as new messages and double-counted. This branch&#39;s own tests already model assistant events without IDs, so live `onUsage` can still over-report tokens whenever Claude omits or delays the ID.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `src/core/agents/claude.ts:204` - Anonymous assistant events are keyed only by the previous event&#39;s serialized `usage` and `content`, so two back-to-back anonymous turns with the same payload reuse the same synthetic ID and the later turn&#39;s tokens are dropped from cumulative usage.
- ⚠️ `src/core/agents/claude.ts:140` - The anonymous fallback fingerprint includes `content`, so a no-id assistant message that is re-emitted with updated text gets a fresh synthetic ID and is counted again even though it is still the same turn; this fix only dedupes byte-identical snapshots.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `src/core/agents/claude.ts:224` - Once an anonymous assistant snapshot has been seen twice, the next larger snapshot is always promoted to a new synthetic message. If Claude replays the same no-id snapshot multiple times before continuing the same turn, that later update is counted as a second turn and `onUsage` over-reports by one full snapshot.
- ⚠️ `src/core/agents/claude.ts:238` - A larger anonymous snapshot is otherwise always treated as an update to the previous anonymous message. Two consecutive no-id assistant turns whose usage simply increases across turns, but never emits an exact duplicate boundary snapshot, will be merged and the earlier turn&#39;s tokens are dropped from cumulative `onUsage`.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `CHANGELOG.md:85` - The changelog does not mention this Claude-specific bug fix: token usage is now deduplicated across repeated or evolving assistant stream events, which changes the reported live token totals and can affect `--max-tokens` enforcement. Add an Unreleased bug-fix entry so the user-visible behavior change is documented.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/core/agents/claude.ts:229` - Prettier formatting check failed. This block needs line wrapping to match the repository&#39;s configured print width and formatting rules.
- ⚠️ `CHANGELOG.md:5` - Prettier formatting check failed. The file has markdown style issues at the top of the changelog, including an extra blank line and list marker formatting that do not match the repository&#39;s configured style.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
