### PR TITLE
feat(orchestrator): add --stop-when condition to end loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Entry point is `src/cli.ts`. It parses flags with commander, resolves config, ha
 ### Run lifecycle (the critical flow)
 
 1. `cli.ts` decides one of three modes: new branch, resume an existing `gnhf/<slug>` branch, or `--worktree` (creates a sibling `<repo>-gnhf-worktrees/<slug>/` checkout). `setupRun`/`resumeRun` in `src/core/run.ts` create `.gnhf/runs/<runId>/` with `prompt.md`, `notes.md`, `output-schema.json`, `base-commit`, and `gnhf.log`, and add `.gnhf/runs/` to `.git/info/exclude` so run metadata stays local.
-2. `Orchestrator` (`src/core/orchestrator.ts`) is an `EventEmitter` loop. Each iteration: build prompt via `src/templates/iteration-prompt.ts` (injects current `notes.md`), call `agent.run(...)`, then on success `commitAll` + append to `notes.md`; on failure `resetHard` and back off. Three consecutive failures abort. The `RunLimits` object enforces `--max-iterations` (between iterations) and `--max-tokens` (mid-iteration via AbortController).
+2. `Orchestrator` (`src/core/orchestrator.ts`) is an `EventEmitter` loop. Each iteration: build prompt via `src/templates/iteration-prompt.ts` (injects current `notes.md`), call `agent.run(...)`, then on success `commitAll` + append to `notes.md`; on failure `resetHard` and back off. Three consecutive failures abort. The `RunLimits` object enforces `--max-iterations` (between iterations), `--max-tokens` (mid-iteration via AbortController), and `--stop-when` (post-iteration, honored on both successful and failed iterations when the agent sets `should_fully_stop` in its output).
 3. `Renderer` (`src/renderer.ts` + `src/renderer-diff.ts`) is a cell-based TUI using the alt screen buffer. `cli.ts` enters/exits alt screen around it. The renderer subscribes to orchestrator events, diffs frames to minimize writes, and updates the terminal title live. `MockOrchestrator` (`src/mock-orchestrator.ts`) drives the renderer offline via `--mock` for demos/testing.
 4. Shutdown path: SIGINT/SIGTERM → `orchestrator.stop()` (aborts the active iteration, rolls back uncommitted work) → renderer exits → 5s force-exit timeout. If it's a `--worktree` run with zero commits, the worktree is removed; otherwise it's preserved and the path is printed.
 
@@ -46,7 +46,7 @@ Reserved args managed by gnhf are rejected in `config.ts` via `isReservedAgentAr
 
 ### Config (`src/core/config.ts`)
 
-Loads `~/.gnhf/config.yml` (bootstrapped on first run). CLI flags override config; runtime-only flags (`--max-iterations`, `--max-tokens`) are never persisted. `agentPathOverride` and `agentArgsOverride` are per-agent; paths resolve relative to `~/.gnhf/` and support `~` expansion.
+Loads `~/.gnhf/config.yml` (bootstrapped on first run). CLI flags override config; runtime-only flags (`--max-iterations`, `--max-tokens`, `--stop-when`) are never persisted. `agentPathOverride` and `agentArgsOverride` are per-agent; paths resolve relative to `~/.gnhf/` and support `~` expansion.
 
 ### Git helpers (`src/core/git.ts`)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ npm link
 ```
 
 - **Incremental commits** — each successful iteration is a separate git commit, so you can cherry-pick or revert individual changes
-- **Runtime caps** — `--max-iterations` stops before the next iteration begins, while `--max-tokens` can abort mid-iteration once reported usage reaches the cap; uncommitted work is rolled back in either case, and in the interactive TUI the final state remains visible until you press Ctrl+C to exit
+- **Runtime caps** - `--max-iterations` stops before the next iteration begins, `--max-tokens` can abort mid-iteration once reported usage reaches the cap, and `--stop-when` ends the loop after an iteration whose agent output reports the natural-language condition is met; uncommitted work is rolled back in either case, and in the interactive TUI the final state remains visible until you press Ctrl+C to exit
 - **Shared memory** — the agent reads `notes.md` (built up from prior iterations) to communicate across iterations
 - **Local run metadata** — gnhf stores prompt, notes, and resume metadata under `.gnhf/runs/` and ignores it locally, so your branch only contains intentional work
 - **Resume support** — run `gnhf` while on an existing `gnhf/` branch to pick up where a previous run left off
@@ -172,6 +172,7 @@ Pass `--worktree` to run each agent in an isolated [git worktree](https://git-sc
 | `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)            | config file (`claude`) |
 | `--max-iterations <n>`   | Abort after `n` total iterations                                      | unlimited              |
 | `--max-tokens <n>`       | Abort after `n` total input+output tokens                             | unlimited              |
+| `--stop-when <cond>`     | End the loop when the agent reports this natural-language condition is met | unlimited         |
 | `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`)    | config file (`on`)     |
 | `--worktree`             | Run in a separate git worktree (enables multiple agents concurrently) | `false`                |
 | `--version`              | Show version                                                          |                        |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,6 +210,10 @@ program
     parseNonNegativeInteger,
   )
   .option(
+    "--stop-when <condition>",
+    "End the loop when the agent reports this natural-language condition is met",
+  )
+  .option(
     "--prevent-sleep <mode>",
     'Prevent system sleep during the run ("on" or "off")',
     parseOnOffBoolean,
@@ -227,6 +231,7 @@ program
         agent?: string;
         maxIterations?: number;
         maxTokens?: number;
+        stopWhen?: string;
         preventSleep?: boolean;
         worktree: boolean;
         mock: boolean;
@@ -427,6 +432,7 @@ program
         startIteration,
         maxIterations: options.maxIterations,
         maxTokens: options.maxTokens,
+        stopWhen: options.stopWhen,
         preventSleep: config.preventSleep,
         agentArgsOverride: config.agentArgsOverride?.[config.agent],
         worktree: options.worktree,
@@ -452,6 +458,7 @@ program
         {
           maxIterations: options.maxIterations,
           maxTokens: options.maxTokens,
+          stopWhen: options.stopWhen,
         },
       );
       let shutdownSignal: NodeJS.Signals | null = null;

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -3,6 +3,7 @@ export interface AgentOutput {
   summary: string;
   key_changes_made: unknown;
   key_learnings: unknown;
+  should_fully_stop?: boolean;
 }
 
 export const AGENT_OUTPUT_SCHEMA = {
@@ -13,6 +14,7 @@ export const AGENT_OUTPUT_SCHEMA = {
     summary: { type: "string" },
     key_changes_made: { type: "array", items: { type: "string" } },
     key_learnings: { type: "array", items: { type: "string" } },
+    should_fully_stop: { type: "boolean" },
   },
   required: ["success", "summary", "key_changes_made", "key_learnings"],
 } as const;

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -316,6 +316,46 @@ describe("Orchestrator stop limits", () => {
     expect(orchestrator.getState().status).toBe("aborted");
   });
 
+  it("aborts when the agent reports should_fully_stop with success=false and stopWhen is set", async () => {
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => ({
+        output: {
+          success: false,
+          summary: "nothing left to do",
+          key_changes_made: [],
+          key_learnings: [],
+          should_fully_stop: true,
+        },
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      })),
+    };
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { stopWhen: "all tasks done", maxIterations: 5 },
+    );
+
+    const abort = vi.fn();
+    orchestrator.on("abort", abort);
+
+    await orchestrator.start();
+
+    expect(agent.run).toHaveBeenCalledTimes(1);
+    expect(mockCommitAll).not.toHaveBeenCalled();
+    expect(abort).toHaveBeenCalledWith("stop condition met");
+    expect(orchestrator.getState().status).toBe("aborted");
+  });
+
   it("ignores should_fully_stop when stopWhen is not set", async () => {
     let callCount = 0;
     const agent: Agent = {

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -276,6 +276,85 @@ describe("Orchestrator stop limits", () => {
     expect(orchestrator.getState().status).toBe("aborted");
   });
 
+  it("aborts after the iteration when the agent reports should_fully_stop and stopWhen is set", async () => {
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => ({
+        output: {
+          success: true,
+          summary: "all tasks done",
+          key_changes_made: ["file.ts"],
+          key_learnings: [],
+          should_fully_stop: true,
+        },
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      })),
+    };
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { stopWhen: "all tasks done", maxIterations: 5 },
+    );
+
+    const abort = vi.fn();
+    orchestrator.on("abort", abort);
+
+    await orchestrator.start();
+
+    expect(agent.run).toHaveBeenCalledTimes(1);
+    expect(mockCommitAll).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledWith("stop condition met");
+    expect(orchestrator.getState().status).toBe("aborted");
+  });
+
+  it("ignores should_fully_stop when stopWhen is not set", async () => {
+    let callCount = 0;
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => {
+        callCount++;
+        return {
+          output: {
+            success: true,
+            summary: `iter ${callCount}`,
+            key_changes_made: [],
+            key_learnings: [],
+            should_fully_stop: true,
+          },
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+          },
+        };
+      }),
+    };
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { maxIterations: 2 },
+    );
+
+    await orchestrator.start();
+
+    expect(agent.run).toHaveBeenCalledTimes(2);
+    expect(orchestrator.getState().status).toBe("aborted");
+  });
+
   it("aborts when reported token usage reaches the configured cap", async () => {
     const agent: Agent = {
       name: "claude",

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -49,12 +49,13 @@ export interface OrchestratorEvents {
 export interface RunLimits {
   maxIterations?: number;
   maxTokens?: number;
+  stopWhen?: string;
 }
 
 const STOP_CLOSE_AGENT_GRACE_MS = 250;
 
 type RunIterationResult =
-  | { type: "completed"; record: IterationRecord }
+  | { type: "completed"; record: IterationRecord; shouldFullyStop: boolean }
   | { type: "stopped" }
   | { type: "aborted"; reason: string };
 
@@ -192,6 +193,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           n: this.state.currentIteration,
           runId: this.runInfo.runId,
           prompt: this.prompt,
+          stopWhen: this.limits.stopWhen,
         });
 
         appendDebugLog("iteration:start", {
@@ -243,6 +245,15 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           totalOutputTokens: this.state.totalOutputTokens,
           commitCount: this.state.commitCount,
         });
+
+        if (
+          this.limits.stopWhen !== undefined &&
+          record.success &&
+          result.shouldFullyStop
+        ) {
+          this.abort("stop condition met");
+          break;
+        }
 
         const postIterationAbortReason = this.getPostIterationAbortReason();
         if (postIterationAbortReason) {
@@ -374,8 +385,14 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
         return { type: "stopped" };
       }
 
+      const shouldFullyStop = result.output.should_fully_stop === true;
+
       if (result.output.success) {
-        return { type: "completed", record: this.recordSuccess(result.output) };
+        return {
+          type: "completed",
+          record: this.recordSuccess(result.output),
+          shouldFullyStop,
+        };
       }
       return {
         type: "completed",
@@ -384,6 +401,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           result.output.summary,
           toStringArray(result.output.key_learnings),
         ),
+        shouldFullyStop,
       };
     } catch (err) {
       const elapsedMs = Date.now() - agentStartedAt;
@@ -424,6 +442,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
       return {
         type: "completed",
         record: this.recordFailure(`[ERROR] ${summary}`, summary, []),
+        shouldFullyStop: false,
       };
     } finally {
       this.activeAbortController = null;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -246,11 +246,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           commitCount: this.state.commitCount,
         });
 
-        if (
-          this.limits.stopWhen !== undefined &&
-          record.success &&
-          result.shouldFullyStop
-        ) {
+        if (this.limits.stopWhen !== undefined && result.shouldFullyStop) {
           this.abort("stop condition met");
           break;
         }

--- a/src/templates/iteration-prompt.test.ts
+++ b/src/templates/iteration-prompt.test.ts
@@ -40,4 +40,33 @@ describe("buildIterationPrompt", () => {
     expect(result).toContain("Read .gnhf/runs/");
     expect(result).toContain("smallest logical unit");
   });
+
+  it("produces a prompt identical to the default when stopWhen is not set", () => {
+    const baseline = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "do stuff",
+    });
+    const withUndefined = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "do stuff",
+      stopWhen: undefined,
+    });
+    expect(withUndefined).toBe(baseline);
+    expect(baseline).not.toContain("should_fully_stop");
+    expect(baseline).not.toContain("Stop Condition");
+  });
+
+  it("injects a stop condition section and should_fully_stop output field when stopWhen is set", () => {
+    const result = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "do stuff",
+      stopWhen: "all tasks are done",
+    });
+    expect(result).toContain("Stop Condition");
+    expect(result).toContain("all tasks are done");
+    expect(result).toContain("should_fully_stop");
+  });
 });

--- a/src/templates/iteration-prompt.ts
+++ b/src/templates/iteration-prompt.ts
@@ -2,7 +2,26 @@ export function buildIterationPrompt(params: {
   n: number;
   runId: string;
   prompt: string;
+  stopWhen?: string;
 }): string {
+  const outputFields = [
+    "- success: whether you were able to make a meaningful contribution that got us closer towards the objective. setting this to false means any code change you made should be discarded",
+    "- summary: a concise one-sentence summary of the accomplishment in this iteration",
+    "- key_changes_made: an array of descriptions for key changes you made. don't group this by file - group by logical units of work. don't describe activities - describe material outcomes",
+    "- key_learnings: an array of new learnings that were surprising, weren't captured by previous notes and would be informative for future iterations",
+  ];
+
+  if (params.stopWhen !== undefined) {
+    outputFields.push(
+      "- should_fully_stop: set to true ONLY when the stop condition below is fully met and the entire loop should end. default to false",
+    );
+  }
+
+  const stopConditionSection =
+    params.stopWhen !== undefined
+      ? `\n\n## Stop Condition\n\nThe user has configured a condition to end the loop: ${params.stopWhen}\nIf this condition is fully met after this iteration's work, set should_fully_stop=true in your output. Otherwise set it to false (or omit it).`
+      : "";
+
   return `You are working autonomously towards an objective given below.
 This is iteration ${params.n}. Each iteration aims to make an incremental step forward, not to complete the entire objective.
 
@@ -16,10 +35,7 @@ This is iteration ${params.n}. Each iteration aims to make an incremental step f
 
 ## Output
 
-- success: whether you were able to make a meaningful contribution that got us closer towards the objective. setting this to false means any code change you made should be discarded
-- summary: a concise one-sentence summary of the accomplishment in this iteration
-- key_changes_made: an array of descriptions for key changes you made. don't group this by file - group by logical units of work. don't describe activities - describe material outcomes
-- key_learnings: an array of new learnings that were surprising, weren't captured by previous notes and would be informative for future iterations
+${outputFields.join("\n")}${stopConditionSection}
 
 ## Objective
 


### PR DESCRIPTION
## Summary
- Add `--stop-when <condition>` runtime flag that injects a natural-language stop condition into each iteration prompt and ends the loop when the agent sets `should_fully_stop` in its structured output.
- Honor `should_fully_stop` on both successful and failed iterations so the agent can signal completion even when the final iteration made no commit.
- Document the new flag in `README.md` and `AGENTS.md` (flags table, runtime caps bullet, `RunLimits` description, and runtime-only flag list).

## Risk Assessment

✅ Low: Small, well-tested additive feature with a narrow abort path; prior-round concern about failed-iteration handling is addressed and the stop check is correctly placed after record-keeping but before backoff.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `src/core/orchestrator.ts:249` - The stop check requires both record.success and result.shouldFullyStop. If an agent legitimately reports should_fully_stop=true alongside success=false (e.g. stop condition is &#34;no further improvements are possible&#34; - the natural reading is success=false because no meaningful change was made, yet the loop should end), the orchestrator will ignore the stop signal and keep iterating. Worth confirming this gate is intentional; if so, the prompt could be clearer that should_fully_stop only has effect on successful iterations.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed</summary>

**Round 1** - found 4 issues (3 warnings, 1 info)
- ⚠️ `README.md:170` - README.md Flags table documents --max-iterations, --max-tokens, --agent, --prevent-sleep, --worktree, --version but does not list the new --stop-when &lt;condition&gt; flag added in src/cli.ts. Add a row describing the flag (ends the loop when the agent reports the natural-language condition is met).
- ℹ️ `README.md:139` - The &#34;Runtime caps&#34; bullet under &#34;How It Works&#34; explains --max-iterations and --max-tokens, but --stop-when is the third runtime cap introduced in this change and is not mentioned. Update the bullet (or add a companion bullet) to describe that --stop-when aborts after the iteration in which the agent sets should_fully_stop.
- ⚠️ `AGENTS.md:33` - AGENTS.md says &#34;The `RunLimits` object enforces `--max-iterations` (between iterations) and `--max-tokens` (mid-iteration via AbortController).&#34; RunLimits now also carries stopWhen; update this sentence to mention --stop-when (post-iteration, honored on both successful and failed iterations via the agent&#39;s should_fully_stop output field).
- ⚠️ `AGENTS.md:49` - AGENTS.md lists runtime-only flags that are never persisted as &#34;(--max-iterations, --max-tokens)&#34;. --stop-when is also runtime-only (only passed through RunLimits, never written to config.yml) and should be added to this list.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
