### PR TITLE
fix(agents): make stop output schema conditional on --stop-when

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Entry point is `src/cli.ts`. It parses flags with commander, resolves config, ha
 
 ### Agents (`src/core/agents/`)
 
-Each agent implements the `Agent` interface in `types.ts` (`name`, async `run(prompt, cwd, options)` returning `{ output, usage }`, optional `close()`). They share two responsibilities: stream stdout, extract a structured `AgentOutput` (`success`, `summary`, `key_changes_made`, `key_learnings`) that matches `AGENT_OUTPUT_SCHEMA`, and accumulate `TokenUsage`. `factory.ts` picks one based on config.
+Each agent implements the `Agent` interface in `types.ts` (`name`, async `run(prompt, cwd, options)` returning `{ output, usage }`, optional `close()`). They share two responsibilities: stream stdout, extract a structured `AgentOutput` (`success`, `summary`, `key_changes_made`, `key_learnings`, plus `should_fully_stop` only when `--stop-when` is active) that matches the schema built by `buildAgentOutputSchema(...)`, and accumulate `TokenUsage`. `factory.ts` picks one based on config.
 
 - `claude.ts` / `codex.ts`: spawn the CLI per iteration in non-interactive mode. Codex uses `--output-schema` pointing at the run's schema file; Claude uses `--json-schema`.
 - `rovodev.ts` / `opencode.ts`: long-running local HTTP servers managed via `managed-process.ts` (start once, reuse across iterations, close on shutdown). OpenCode creates a per-run session and applies a blanket allow rule to avoid prompt blocking.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -245,6 +245,7 @@ describe("cli", () => {
       stubRunInfo,
       undefined,
       undefined,
+      { includeStopField: false },
     );
   });
 
@@ -266,6 +267,7 @@ describe("cli", () => {
       stubRunInfo,
       undefined,
       undefined,
+      { includeStopField: false },
     );
   });
 
@@ -287,6 +289,7 @@ describe("cli", () => {
       stubRunInfo,
       undefined,
       undefined,
+      { includeStopField: false },
     );
   });
 
@@ -308,6 +311,7 @@ describe("cli", () => {
       stubRunInfo,
       undefined,
       undefined,
+      { includeStopField: false },
     );
   });
 
@@ -322,11 +326,34 @@ describe("cli", () => {
       preventSleep: false,
     });
 
-    expect(createAgent).toHaveBeenCalledWith("codex", stubRunInfo, undefined, [
-      "-m",
-      "gpt-5.4",
-      "--full-auto",
-    ]);
+    expect(createAgent).toHaveBeenCalledWith(
+      "codex",
+      stubRunInfo,
+      undefined,
+      ["-m", "gpt-5.4", "--full-auto"],
+      { includeStopField: false },
+    );
+  });
+
+  it("threads includeStopField=true into agent creation when --stop-when is set", async () => {
+    const { createAgent } = await runCliWithMocks(
+      ["ship it", "--stop-when", "all tests pass"],
+      {
+        agent: "codex",
+        agentPathOverride: {},
+        agentArgsOverride: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: false,
+      },
+    );
+
+    expect(createAgent).toHaveBeenCalledWith(
+      "codex",
+      stubRunInfo,
+      undefined,
+      undefined,
+      { includeStopField: true },
+    );
   });
 
   it("passes max iteration and token caps to the orchestrator", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,13 +87,17 @@ function humanizeErrorMessage(message: string): string {
   return message;
 }
 
-function initializeNewBranch(prompt: string, cwd: string): RunInfo {
+function initializeNewBranch(
+  prompt: string,
+  cwd: string,
+  schemaOptions: { includeStopField: boolean },
+): RunInfo {
   ensureCleanWorkingTree(cwd);
   const baseCommit = getHeadCommit(cwd);
   const branchName = slugifyPrompt(prompt);
   createBranch(branchName, cwd);
   const runId = branchName.split("/")[1]!;
-  return setupRun(runId, prompt, baseCommit, cwd);
+  return setupRun(runId, prompt, baseCommit, cwd, schemaOptions);
 }
 
 interface WorktreeRunResult {
@@ -102,7 +106,11 @@ interface WorktreeRunResult {
   effectiveCwd: string;
 }
 
-function initializeWorktreeRun(prompt: string, cwd: string): WorktreeRunResult {
+function initializeWorktreeRun(
+  prompt: string,
+  cwd: string,
+  schemaOptions: { includeStopField: boolean },
+): WorktreeRunResult {
   // Intentionally skip ensureCleanWorkingTree() — git worktree add creates
   // an independent working directory from HEAD; uncommitted changes in the
   // main checkout don't carry over, so a dirty tree is harmless here.
@@ -116,7 +124,13 @@ function initializeWorktreeRun(prompt: string, cwd: string): WorktreeRunResult {
     runId,
   );
   createWorktree(repoRoot, worktreePath, branchName);
-  const runInfo = setupRun(runId, prompt, baseCommit, worktreePath);
+  const runInfo = setupRun(
+    runId,
+    prompt,
+    baseCommit,
+    worktreePath,
+    schemaOptions,
+  );
   return { runInfo, worktreePath, effectiveCwd: worktreePath };
 }
 
@@ -397,6 +411,10 @@ program
       const currentBranch = getCurrentBranch(cwd);
       const onGnhfBranch = currentBranch.startsWith("gnhf/");
 
+      const schemaOptions = {
+        includeStopField: options.stopWhen !== undefined,
+      };
+
       let runInfo;
       let startIteration = 0;
 
@@ -413,7 +431,7 @@ program
           process.exit(1);
         }
 
-        const wt = initializeWorktreeRun(prompt, cwd);
+        const wt = initializeWorktreeRun(prompt, cwd, schemaOptions);
         runInfo = wt.runInfo;
         effectiveCwd = wt.effectiveCwd;
         worktreePath = wt.worktreePath;
@@ -436,7 +454,7 @@ program
         });
       } else if (onGnhfBranch) {
         const existingRunId = currentBranch.slice("gnhf/".length);
-        const existing = resumeRun(existingRunId, cwd);
+        const existing = resumeRun(existingRunId, cwd, schemaOptions);
         const existingPrompt = readFileSync(existing.promptPath, "utf-8");
 
         if (!prompt || prompt === existingPrompt) {
@@ -456,9 +474,15 @@ program
 
           if (answer === "o") {
             ensureCleanWorkingTree(cwd);
-            runInfo = setupRun(existingRunId, prompt, existing.baseCommit, cwd);
+            runInfo = setupRun(
+              existingRunId,
+              prompt,
+              existing.baseCommit,
+              cwd,
+              schemaOptions,
+            );
           } else if (answer === "n") {
-            runInfo = initializeNewBranch(prompt, cwd);
+            runInfo = initializeNewBranch(prompt, cwd, schemaOptions);
           } else {
             process.exit(0);
           }
@@ -469,7 +493,7 @@ program
           return;
         }
 
-        runInfo = initializeNewBranch(prompt, cwd);
+        runInfo = initializeNewBranch(prompt, cwd, schemaOptions);
       }
 
       let sleepPreventionCleanup: (() => Promise<void>) | null = null;
@@ -529,6 +553,7 @@ program
         runInfo,
         config.agentPathOverride[config.agent],
         config.agentArgsOverride?.[config.agent],
+        schemaOptions,
       );
       const orchestrator = new Orchestrator(
         config,

--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -8,8 +8,13 @@ vi.mock("node:child_process", () => ({
 
 import { execFileSync, spawn } from "node:child_process";
 import { ClaudeAgent } from "./claude.js";
+import { buildAgentOutputSchema } from "./types.js";
 
 const mockSpawn = vi.mocked(spawn);
+
+const STOP_SCHEMA = buildAgentOutputSchema({
+  includeStopField: true,
+});
 
 function createMockProcess() {
   const proc = Object.assign(new EventEmitter(), {
@@ -61,6 +66,31 @@ describe("ClaudeAgent", () => {
         stdio: ["ignore", "pipe", "pipe"],
         env: process.env,
       },
+    );
+  });
+
+  it("uses the configured schema for --json-schema", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new ClaudeAgent({
+      schema: STOP_SCHEMA,
+    });
+
+    configuredAgent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      [
+        "-p",
+        "test prompt",
+        "--verbose",
+        "--output-format",
+        "stream-json",
+        "--json-schema",
+        JSON.stringify(STOP_SCHEMA),
+        "--dangerously-skip-permissions",
+      ],
+      expect.any(Object),
     );
   });
 

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -1,12 +1,13 @@
 import { execFileSync, spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import {
-  AGENT_OUTPUT_SCHEMA,
+  buildAgentOutputSchema,
   type Agent,
-  type AgentResult,
   type AgentOutput,
-  type TokenUsage,
+  type AgentOutputSchema,
+  type AgentResult,
   type AgentRunOptions,
+  type TokenUsage,
 } from "./types.js";
 import {
   parseJSONLStream,
@@ -47,6 +48,7 @@ interface ClaudeAgentDeps {
   bin?: string;
   extraArgs?: string[];
   platform?: NodeJS.Platform;
+  schema?: AgentOutputSchema;
 }
 
 function shouldUseWindowsShell(
@@ -98,7 +100,11 @@ function terminateClaudeProcess(
   child.kill("SIGTERM");
 }
 
-function buildClaudeArgs(prompt: string, extraArgs?: string[]): string[] {
+function buildClaudeArgs(
+  prompt: string,
+  schema: AgentOutputSchema,
+  extraArgs?: string[],
+): string[] {
   const userArgs = extraArgs ?? [];
   const userSpecifiedPermissionMode = userArgs.some(
     (arg) =>
@@ -117,7 +123,7 @@ function buildClaudeArgs(prompt: string, extraArgs?: string[]): string[] {
     "--output-format",
     "stream-json",
     "--json-schema",
-    JSON.stringify(AGENT_OUTPUT_SCHEMA),
+    JSON.stringify(schema),
     ...(userSpecifiedPermissionMode ? [] : ["--dangerously-skip-permissions"]),
   ];
 }
@@ -162,12 +168,15 @@ export class ClaudeAgent implements Agent {
   private bin: string;
   private extraArgs?: string[];
   private platform: NodeJS.Platform;
+  private schema: AgentOutputSchema;
 
   constructor(binOrDeps: string | ClaudeAgentDeps = {}) {
     const deps = typeof binOrDeps === "string" ? { bin: binOrDeps } : binOrDeps;
     this.bin = deps.bin ?? "claude";
     this.extraArgs = deps.extraArgs;
     this.platform = deps.platform ?? process.platform;
+    this.schema =
+      deps.schema ?? buildAgentOutputSchema({ includeStopField: false });
   }
 
   run(
@@ -180,12 +189,16 @@ export class ClaudeAgent implements Agent {
     return new Promise((resolve, reject) => {
       const logStream = logPath ? createWriteStream(logPath) : null;
 
-      const child = spawn(this.bin, buildClaudeArgs(prompt, this.extraArgs), {
-        cwd,
-        shell: shouldUseWindowsShell(this.bin, this.platform),
-        stdio: ["ignore", "pipe", "pipe"],
-        env: process.env,
-      });
+      const child = spawn(
+        this.bin,
+        buildClaudeArgs(prompt, this.schema, this.extraArgs),
+        {
+          cwd,
+          shell: shouldUseWindowsShell(this.bin, this.platform),
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        },
+      );
 
       if (
         setupAbortHandler(signal, child, reject, () =>

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -64,31 +64,72 @@ const stubRunInfo: RunInfo = {
   baseCommitPath: "/repo/.gnhf/runs/test-run/base-commit",
 };
 
+const noStopSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    success: { type: "boolean" },
+    summary: { type: "string" },
+    key_changes_made: { type: "array", items: { type: "string" } },
+    key_learnings: { type: "array", items: { type: "string" } },
+  },
+  required: ["success", "summary", "key_changes_made", "key_learnings"],
+};
+
+const withStopSchema = {
+  ...noStopSchema,
+  properties: {
+    ...noStopSchema.properties,
+    should_fully_stop: { type: "boolean" },
+  },
+  required: [...noStopSchema.required, "should_fully_stop"],
+};
+
 describe("createAgent", () => {
   it("creates a ClaudeAgent when name is 'claude'", () => {
-    const agent = createAgent("claude", stubRunInfo);
+    const agent = createAgent("claude", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+    });
     expect(ClaudeAgent).toHaveBeenCalledWith({
       bin: undefined,
       extraArgs: undefined,
+      schema: noStopSchema,
     });
     expect(agent.name).toBe("claude");
   });
 
   it("passes per-agent extra args through to the ClaudeAgent", () => {
-    const agent = createAgent("claude", stubRunInfo, undefined, [
-      "--model",
-      "sonnet",
-    ]);
+    const agent = createAgent(
+      "claude",
+      stubRunInfo,
+      undefined,
+      ["--model", "sonnet"],
+      { includeStopField: false },
+    );
 
     expect(ClaudeAgent).toHaveBeenCalledWith({
       bin: undefined,
       extraArgs: ["--model", "sonnet"],
+      schema: noStopSchema,
     });
     expect(agent.name).toBe("claude");
   });
 
+  it("hands ClaudeAgent a schema that requires should_fully_stop when includeStopField is true", () => {
+    createAgent("claude", stubRunInfo, undefined, undefined, {
+      includeStopField: true,
+    });
+    expect(ClaudeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+      schema: withStopSchema,
+    });
+  });
+
   it("creates a CodexAgent when name is 'codex'", () => {
-    const agent = createAgent("codex", stubRunInfo);
+    const agent = createAgent("codex", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+    });
     expect(CodexAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
       bin: undefined,
       extraArgs: undefined,
@@ -97,11 +138,13 @@ describe("createAgent", () => {
   });
 
   it("passes per-agent extra args through to the CodexAgent", () => {
-    const agent = createAgent("codex", stubRunInfo, undefined, [
-      "-m",
-      "gpt-5.4",
-      "--full-auto",
-    ]);
+    const agent = createAgent(
+      "codex",
+      stubRunInfo,
+      undefined,
+      ["-m", "gpt-5.4", "--full-auto"],
+      { includeStopField: false },
+    );
 
     expect(CodexAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
       bin: undefined,
@@ -111,7 +154,9 @@ describe("createAgent", () => {
   });
 
   it("creates a RovoDevAgent when name is 'rovodev'", () => {
-    const agent = createAgent("rovodev", stubRunInfo);
+    const agent = createAgent("rovodev", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+    });
     expect(RovoDevAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
       bin: undefined,
       extraArgs: undefined,
@@ -120,10 +165,13 @@ describe("createAgent", () => {
   });
 
   it("passes per-agent extra args through to the RovoDevAgent", () => {
-    const agent = createAgent("rovodev", stubRunInfo, undefined, [
-      "--profile",
-      "work",
-    ]);
+    const agent = createAgent(
+      "rovodev",
+      stubRunInfo,
+      undefined,
+      ["--profile", "work"],
+      { includeStopField: false },
+    );
 
     expect(RovoDevAgent).toHaveBeenCalledWith(stubRunInfo.schemaPath, {
       bin: undefined,
@@ -133,24 +181,42 @@ describe("createAgent", () => {
   });
 
   it("creates an OpenCodeAgent when name is 'opencode'", () => {
-    const agent = createAgent("opencode", stubRunInfo);
+    const agent = createAgent("opencode", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+    });
     expect(OpenCodeAgent).toHaveBeenCalledWith({
       bin: undefined,
       extraArgs: undefined,
+      schema: noStopSchema,
     });
     expect(agent.name).toBe("opencode");
   });
 
   it("passes per-agent extra args through to the OpenCodeAgent", () => {
-    const agent = createAgent("opencode", stubRunInfo, undefined, [
-      "--model",
-      "gpt-5",
-    ]);
+    const agent = createAgent(
+      "opencode",
+      stubRunInfo,
+      undefined,
+      ["--model", "gpt-5"],
+      { includeStopField: false },
+    );
 
     expect(OpenCodeAgent).toHaveBeenCalledWith({
       bin: undefined,
       extraArgs: ["--model", "gpt-5"],
+      schema: noStopSchema,
     });
     expect(agent.name).toBe("opencode");
+  });
+
+  it("hands OpenCodeAgent a schema that requires should_fully_stop when includeStopField is true", () => {
+    createAgent("opencode", stubRunInfo, undefined, undefined, {
+      includeStopField: true,
+    });
+    expect(OpenCodeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+      schema: withStopSchema,
+    });
   });
 });

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "./types.js";
+import { buildAgentOutputSchema, type Agent } from "./types.js";
 import type { AgentName } from "../config.js";
 import type { RunInfo } from "../run.js";
 import { ClaudeAgent } from "./claude.js";
@@ -6,17 +6,26 @@ import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
 
+export interface CreateAgentOptions {
+  includeStopField: boolean;
+}
+
 export function createAgent(
   name: AgentName,
   runInfo: RunInfo,
-  pathOverride?: string,
-  agentArgsOverride?: string[],
+  pathOverride: string | undefined,
+  agentArgsOverride: string[] | undefined,
+  options: CreateAgentOptions,
 ): Agent {
+  const schema = buildAgentOutputSchema({
+    includeStopField: options.includeStopField,
+  });
   switch (name) {
     case "claude":
       return new ClaudeAgent({
         bin: pathOverride,
         extraArgs: agentArgsOverride,
+        schema,
       });
     case "codex":
       return new CodexAgent(runInfo.schemaPath, {
@@ -27,6 +36,7 @@ export function createAgent(
       return new OpenCodeAgent({
         bin: pathOverride,
         extraArgs: agentArgsOverride,
+        schema,
       });
     case "rovodev":
       return new RovoDevAgent(runInfo.schemaPath, {

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -29,6 +29,10 @@ const DEFAULT_AGENT_OUTPUT_SCHEMA = buildAgentOutputSchema({
   includeStopField: false,
 });
 
+const STOP_AGENT_OUTPUT_SCHEMA = buildAgentOutputSchema({
+  includeStopField: true,
+});
+
 const mockSpawn = vi.mocked(spawn);
 
 function createMockProcess() {
@@ -493,6 +497,52 @@ describe("OpenCodeAgent", () => {
     expect(onMessage).toHaveBeenCalledWith(
       '{"success":true,"summary":"done","key_changes_made":[],"key_learnings":[]}',
     );
+  });
+
+  it("uses the configured schema in both the prompt text and request format", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new OpenCodeAgent({
+      fetch: fetchMock as typeof fetch,
+      getPort,
+      schema: STOP_AGENT_OUTPUT_SCHEMA,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: "session-123",
+          directory: "/repo",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", {
+            input: 100,
+            output: 20,
+            read: 0,
+            write: 0,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await configuredAgent.run("test prompt", "/repo");
+
+    const messageBody = JSON.parse(
+      String(fetchMock.mock.calls[3]?.[1]?.body ?? ""),
+    );
+    expect(messageBody.parts[0]?.text).toContain(
+      JSON.stringify(STOP_AGENT_OUTPUT_SCHEMA),
+    );
+    expect(messageBody.format).toEqual({
+      type: "json_schema",
+      schema: STOP_AGENT_OUTPUT_SCHEMA,
+      retryCount: 1,
+    });
   });
 
   it("passes configured extra args through to opencode serve", async () => {

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -23,7 +23,11 @@ vi.mock("../debug-log.js", () => ({
 
 import { execFileSync, spawn } from "node:child_process";
 import { OpenCodeAgent } from "./opencode.js";
-import { AGENT_OUTPUT_SCHEMA } from "./types.js";
+import { buildAgentOutputSchema } from "./types.js";
+
+const DEFAULT_AGENT_OUTPUT_SCHEMA = buildAgentOutputSchema({
+  includeStopField: false,
+});
 
 const mockSpawn = vi.mocked(spawn);
 
@@ -455,7 +459,7 @@ describe("OpenCodeAgent", () => {
     expect(messageBody.parts[0]?.text).toContain("reply with only valid JSON");
     expect(messageBody.format).toEqual({
       type: "json_schema",
-      schema: AGENT_OUTPUT_SCHEMA,
+      schema: DEFAULT_AGENT_OUTPUT_SCHEMA,
       retryCount: 1,
     });
     expect(

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -6,9 +6,10 @@ import {
 import { createWriteStream, type WriteStream } from "node:fs";
 import { createServer } from "node:net";
 import {
-  AGENT_OUTPUT_SCHEMA,
+  buildAgentOutputSchema,
   type Agent,
   type AgentOutput,
+  type AgentOutputSchema,
   type AgentResult,
   type AgentRunOptions,
   type TokenUsage,
@@ -87,6 +88,7 @@ interface OpenCodeDeps {
   getPort?: () => Promise<number>;
   killProcess?: typeof process.kill;
   platform?: NodeJS.Platform;
+  schema?: AgentOutputSchema;
   spawn?: typeof spawn;
 }
 
@@ -134,11 +136,13 @@ const BLANKET_PERMISSION_RULESET = [
   { permission: "*", pattern: "*", action: "allow" },
 ] as const;
 
-const STRUCTURED_OUTPUT_FORMAT = {
-  type: "json_schema",
-  schema: AGENT_OUTPUT_SCHEMA,
-  retryCount: 1,
-} as const;
+function buildStructuredOutputFormat(schema: AgentOutputSchema) {
+  return {
+    type: "json_schema",
+    schema,
+    retryCount: 1,
+  } as const;
+}
 
 function buildOpencodeChildEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
@@ -147,14 +151,14 @@ function buildOpencodeChildEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
-function buildPrompt(prompt: string): string {
+function buildPrompt(prompt: string, schema: AgentOutputSchema): string {
   return [
     prompt,
     "",
     "When you finish, reply with only valid JSON.",
     "Do not wrap the JSON in markdown fences.",
     "Do not include any prose before or after the JSON.",
-    `The JSON must match this schema exactly: ${JSON.stringify(AGENT_OUTPUT_SCHEMA)}`,
+    `The JSON must match this schema exactly: ${JSON.stringify(schema)}`,
   ].join("\n");
 }
 
@@ -268,6 +272,7 @@ export class OpenCodeAgent implements Agent {
   private getPortFn: () => Promise<number>;
   private killProcessFn: typeof process.kill;
   private platform: NodeJS.Platform;
+  private schema: AgentOutputSchema;
   private spawnFn: typeof spawn;
   private server: OpenCodeServer | null = null;
   private closingPromise: Promise<void> | null = null;
@@ -279,6 +284,8 @@ export class OpenCodeAgent implements Agent {
     this.getPortFn = deps.getPort ?? getAvailablePort;
     this.killProcessFn = deps.killProcess ?? process.kill.bind(process);
     this.platform = deps.platform ?? process.platform;
+    this.schema =
+      deps.schema ?? buildAgentOutputSchema({ includeStopField: false });
     this.spawnFn = deps.spawn ?? spawn;
   }
 
@@ -317,7 +324,7 @@ export class OpenCodeAgent implements Agent {
       const result = await this.streamMessage(
         server,
         sessionId,
-        buildPrompt(prompt),
+        buildPrompt(prompt, this.schema),
         runController.signal,
         logStream,
         onUsage,
@@ -690,7 +697,7 @@ export class OpenCodeAgent implements Agent {
           body: {
             role: "user",
             parts: [{ type: "text", text: prompt }],
-            format: STRUCTURED_OUTPUT_FORMAT,
+            format: buildStructuredOutputFormat(this.schema),
           },
           signal,
         });

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -6,18 +6,37 @@ export interface AgentOutput {
   should_fully_stop?: boolean;
 }
 
-export const AGENT_OUTPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
+export interface AgentOutputSchema {
+  type: "object";
+  additionalProperties: false;
+  properties: Record<string, { type: string; items?: { type: string } }>;
+  required: string[];
+}
+
+// Codex's --output-schema enforces OpenAI strict mode, which requires every
+// key in `properties` to also appear in `required` when additionalProperties
+// is false. So include should_fully_stop only when the run actually uses it.
+export function buildAgentOutputSchema(opts: {
+  includeStopField: boolean;
+}): AgentOutputSchema {
+  const properties: AgentOutputSchema["properties"] = {
     success: { type: "boolean" },
     summary: { type: "string" },
     key_changes_made: { type: "array", items: { type: "string" } },
     key_learnings: { type: "array", items: { type: "string" } },
-    should_fully_stop: { type: "boolean" },
-  },
-  required: ["success", "summary", "key_changes_made", "key_learnings"],
-} as const;
+  };
+  const required = ["success", "summary", "key_changes_made", "key_learnings"];
+  if (opts.includeStopField) {
+    properties.should_fully_stop = { type: "boolean" };
+    required.push("should_fully_stop");
+  }
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties,
+    required,
+  };
+}
 
 export interface TokenUsage {
   inputTokens: number;

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -48,7 +48,9 @@ describe("setupRun", () => {
   });
 
   it("creates the run directory recursively", () => {
-    setupRun("test-run-1", "fix bugs", "abc123", P);
+    setupRun("test-run-1", "fix bugs", "abc123", P, {
+      includeStopField: false,
+    });
     expect(mockMkdirSync).toHaveBeenCalledWith(join(P, ".git", "info"), {
       recursive: true,
     });
@@ -59,7 +61,7 @@ describe("setupRun", () => {
   });
 
   it("writes the ignore rule to .git/info/exclude", () => {
-    setupRun("run-abc", "test", "abc123", P);
+    setupRun("run-abc", "test", "abc123", P, { includeStopField: false });
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       join(P, ".git", "info", "exclude"),
@@ -69,7 +71,9 @@ describe("setupRun", () => {
   });
 
   it("writes PROMPT.md with the prompt text", () => {
-    setupRun("run-abc", "improve coverage", "abc123", P);
+    setupRun("run-abc", "improve coverage", "abc123", P, {
+      includeStopField: false,
+    });
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       join(P, ".gnhf", "runs", "run-abc", "prompt.md"),
       "improve coverage",
@@ -78,7 +82,9 @@ describe("setupRun", () => {
   });
 
   it("writes notes.md with header and objective", () => {
-    setupRun("run-abc", "improve coverage", "abc123", P);
+    setupRun("run-abc", "improve coverage", "abc123", P, {
+      includeStopField: false,
+    });
     const notesCall = mockWriteFileSync.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].endsWith("notes.md"),
     );
@@ -90,7 +96,7 @@ describe("setupRun", () => {
   });
 
   it("writes output-schema.json with valid JSON schema", () => {
-    setupRun("run-abc", "test", "abc123", P);
+    setupRun("run-abc", "test", "abc123", P, { includeStopField: false });
     const schemaCall = mockWriteFileSync.mock.calls.find(
       (call) =>
         typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
@@ -105,8 +111,30 @@ describe("setupRun", () => {
     expect(schema.required).toContain("key_learnings");
   });
 
+  it("omits should_fully_stop from the schema when includeStopField is false", () => {
+    setupRun("run-abc", "test", "abc123", P, { includeStopField: false });
+    const schemaCall = mockWriteFileSync.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
+    );
+    const schema = JSON.parse(schemaCall![1] as string);
+    expect(schema.properties.should_fully_stop).toBeUndefined();
+    expect(schema.required).not.toContain("should_fully_stop");
+  });
+
+  it("includes should_fully_stop in both properties and required when includeStopField is true", () => {
+    setupRun("run-abc", "test", "abc123", P, { includeStopField: true });
+    const schemaCall = mockWriteFileSync.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
+    );
+    const schema = JSON.parse(schemaCall![1] as string);
+    expect(schema.properties.should_fully_stop).toEqual({ type: "boolean" });
+    expect(schema.required).toContain("should_fully_stop");
+  });
+
   it("writes the branch base commit for new runs", () => {
-    setupRun("run-abc", "test", "abc123", P);
+    setupRun("run-abc", "test", "abc123", P, { includeStopField: false });
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       join(P, ".gnhf", "runs", "run-abc", "base-commit"),
@@ -122,7 +150,7 @@ describe("setupRun", () => {
       path === baseCommitPath ? "old123\n" : "",
     );
 
-    setupRun("run-abc", "test", "new456", P);
+    setupRun("run-abc", "test", "new456", P, { includeStopField: false });
 
     expect(mockWriteFileSync).not.toHaveBeenCalledWith(
       baseCommitPath,
@@ -133,7 +161,9 @@ describe("setupRun", () => {
 
   it("returns correct RunInfo paths", () => {
     const runDir = join(P, ".gnhf", "runs", "my-run");
-    const info = setupRun("my-run", "prompt text", "abc123", P);
+    const info = setupRun("my-run", "prompt text", "abc123", P, {
+      includeStopField: false,
+    });
     expect(info).toEqual({
       runId: "my-run",
       runDir,
@@ -156,7 +186,7 @@ describe("resumeRun", () => {
     const runDir = join(P, ".gnhf", "runs", "run-abc");
     mockExistsSync.mockImplementation((path) => path === runDir);
 
-    resumeRun("run-abc", P);
+    resumeRun("run-abc", P, { includeStopField: false });
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       join(runDir, "output-schema.json"),
@@ -169,6 +199,23 @@ describe("resumeRun", () => {
     );
     const schema = JSON.parse(schemaCall![1] as string);
     expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties.should_fully_stop).toBeUndefined();
+    expect(schema.required).not.toContain("should_fully_stop");
+  });
+
+  it("rewrites output-schema.json with should_fully_stop when includeStopField is true", () => {
+    const runDir = join(P, ".gnhf", "runs", "run-abc");
+    mockExistsSync.mockImplementation((path) => path === runDir);
+
+    resumeRun("run-abc", P, { includeStopField: true });
+
+    const schemaCall = mockWriteFileSync.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
+    );
+    const schema = JSON.parse(schemaCall![1] as string);
+    expect(schema.properties.should_fully_stop).toEqual({ type: "boolean" });
+    expect(schema.required).toContain("should_fully_stop");
   });
 
   it("reads the stored base commit when present", () => {
@@ -181,7 +228,7 @@ describe("resumeRun", () => {
       path === baseCommitPath ? "abc123\n" : "",
     );
 
-    const info = resumeRun("run-abc", P);
+    const info = resumeRun("run-abc", P, { includeStopField: false });
 
     expect(info.baseCommit).toBe("abc123");
     expect(info.logPath).toBe(join(runDir, "gnhf.log"));
@@ -192,7 +239,7 @@ describe("resumeRun", () => {
     mockExistsSync.mockImplementation((path) => path === runDir);
     mockFindLegacyRunBaseCommit.mockReturnValue("legacy123");
 
-    const info = resumeRun("run-abc", P);
+    const info = resumeRun("run-abc", P, { includeStopField: false });
 
     expect(mockFindLegacyRunBaseCommit).toHaveBeenCalledWith("run-abc", P);
     expect(mockWriteFileSync).toHaveBeenCalledWith(
@@ -209,7 +256,7 @@ describe("resumeRun", () => {
     mockFindLegacyRunBaseCommit.mockReturnValue(null);
     mockGetHeadCommit.mockReturnValue("head456");
 
-    const info = resumeRun("run-abc", P);
+    const info = resumeRun("run-abc", P, { includeStopField: false });
 
     expect(mockGetHeadCommit).toHaveBeenCalledWith(P);
     expect(info.baseCommit).toBe("head456");

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { join, dirname, isAbsolute } from "node:path";
 import { execFileSync } from "node:child_process";
-import { AGENT_OUTPUT_SCHEMA } from "./agents/types.js";
+import { buildAgentOutputSchema } from "./agents/types.js";
 import { findLegacyRunBaseCommit, getHeadCommit } from "./git.js";
 
 export interface RunInfo {
@@ -24,12 +24,16 @@ export interface RunInfo {
 
 const LOG_FILENAME = "gnhf.log";
 
-function writeSchemaFile(schemaPath: string): void {
+function writeSchemaFile(schemaPath: string, includeStopField: boolean): void {
   writeFileSync(
     schemaPath,
-    JSON.stringify(AGENT_OUTPUT_SCHEMA, null, 2),
+    JSON.stringify(buildAgentOutputSchema({ includeStopField }), null, 2),
     "utf-8",
   );
+}
+
+export interface RunSchemaOptions {
+  includeStopField: boolean;
 }
 
 function ensureRunMetadataIgnored(cwd: string): void {
@@ -61,6 +65,7 @@ export function setupRun(
   prompt: string,
   baseCommit: string,
   cwd: string,
+  schemaOptions: RunSchemaOptions,
 ): RunInfo {
   ensureRunMetadataIgnored(cwd);
 
@@ -78,7 +83,7 @@ export function setupRun(
   );
 
   const schemaPath = join(runDir, "output-schema.json");
-  writeSchemaFile(schemaPath);
+  writeSchemaFile(schemaPath, schemaOptions.includeStopField);
 
   const logPath = join(runDir, LOG_FILENAME);
 
@@ -103,7 +108,11 @@ export function setupRun(
   };
 }
 
-export function resumeRun(runId: string, cwd: string): RunInfo {
+export function resumeRun(
+  runId: string,
+  cwd: string,
+  schemaOptions: RunSchemaOptions,
+): RunInfo {
   const runDir = join(cwd, ".gnhf", "runs", runId);
   if (!existsSync(runDir)) {
     throw new Error(`Run directory not found: ${runDir}`);
@@ -112,7 +121,7 @@ export function resumeRun(runId: string, cwd: string): RunInfo {
   const promptPath = join(runDir, "prompt.md");
   const notesPath = join(runDir, "notes.md");
   const schemaPath = join(runDir, "output-schema.json");
-  writeSchemaFile(schemaPath);
+  writeSchemaFile(schemaPath, schemaOptions.includeStopField);
   const logPath = join(runDir, LOG_FILENAME);
   const baseCommitPath = join(runDir, "base-commit");
   const baseCommit = existsSync(baseCommitPath)

--- a/src/templates/iteration-prompt.test.ts
+++ b/src/templates/iteration-prompt.test.ts
@@ -68,5 +68,7 @@ describe("buildIterationPrompt", () => {
     expect(result).toContain("Stop Condition");
     expect(result).toContain("all tasks are done");
     expect(result).toContain("should_fully_stop");
+    expect(result).toContain("set it to false");
+    expect(result).not.toContain("omit it");
   });
 });

--- a/src/templates/iteration-prompt.ts
+++ b/src/templates/iteration-prompt.ts
@@ -19,7 +19,7 @@ export function buildIterationPrompt(params: {
 
   const stopConditionSection =
     params.stopWhen !== undefined
-      ? `\n\n## Stop Condition\n\nThe user has configured a condition to end the loop: ${params.stopWhen}\nIf this condition is fully met after this iteration's work, set should_fully_stop=true in your output. Otherwise set it to false (or omit it).`
+      ? `\n\n## Stop Condition\n\nThe user has configured a condition to end the loop: ${params.stopWhen}\nIf this condition is fully met after this iteration's work, set should_fully_stop=true in your output. Otherwise set it to false.`
       : "";
 
   return `You are working autonomously towards an objective given below.


### PR DESCRIPTION
## Summary
- Build the agent output schema dynamically so `should_fully_stop` is only included when `--stop-when` is active, avoiding schema validation failures for normal runs.
- Thread the schema choice through CLI run setup, resume/worktree flows, and agent creation so Claude, OpenCode, and the persisted run schema all use the same contract.
- Align the iteration prompt and maintainer docs with the dynamic stop-field behavior, and add coverage around CLI, run, factory, and agent schema handling.

## Risk Assessment

✅ Low: The change is narrowly scoped to threading an optional stop-field schema through run setup and agent construction, and the updated prompt/schema behavior appears internally consistent across the touched code paths.

## Testing

- Summary: Exercised the optional stop-field change through the CLI, run metadata/schema writing, agent factory wiring, iteration prompt text, and direct Claude/OpenCode schema propagation; after restoring missing dependencies, all targeted tests passed.
- `npx vitest run src/cli.test.ts src/core/run.test.ts src/core/agents/factory.test.ts src/core/agents/claude.test.ts src/core/agents/opencode.test.ts src/templates/iteration-prompt.test.ts`
- `npx vitest run src/core/agents/claude.test.ts src/core/agents/opencode.test.ts src/cli.test.ts src/core/run.test.ts src/core/agents/factory.test.ts src/templates/iteration-prompt.test.ts`
- Outcome: ✅ passed across 1 run (6m34s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `src/core/agents/types.ts:31` - `buildAgentOutputSchema()` now makes `should_fully_stop` required whenever `--stop-when` is set, but the iteration prompt still tells the agent it may omit that field when false. That mismatch can make valid `--stop-when` iterations fail schema validation across agents if they follow the prompt and omit the key. Align the prompt and schema so the field is either always emitted or remains optional.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/cli.test.ts src/core/run.test.ts src/core/agents/factory.test.ts src/core/agents/claude.test.ts src/core/agents/opencode.test.ts src/templates/iteration-prompt.test.ts`
- `npx vitest run src/core/agents/claude.test.ts src/core/agents/opencode.test.ts src/cli.test.ts src/core/run.test.ts src/core/agents/factory.test.ts src/templates/iteration-prompt.test.ts`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `AGENTS.md:39` - The maintainer architecture docs are stale: they still say agents match `AGENT_OUTPUT_SCHEMA`, but that constant was replaced by `buildAgentOutputSchema(...)` and the schema now conditionally includes `should_fully_stop` only when `--stop-when` is active. Update this section to describe the dynamic schema and optional stop field behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
