### PR TITLE
fix(opencode): pass --model via HTTP API instead of serve CLI

### DIFF
--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -545,11 +545,55 @@ describe("OpenCodeAgent", () => {
     });
   });
 
-  it("passes configured extra args through to opencode serve", async () => {
+  it("extracts --model from extraArgs and passes it as an object via the prompt body", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const configuredAgent = new OpenCodeAgent({
-      extraArgs: ["--model", "gpt-5"],
+      extraArgs: ["--model", "fireworks-ai/accounts/fireworks/models/qwen3p6-plus"],
+      fetch: fetchMock as typeof fetch,
+      getPort,
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", {
+            input: 10,
+            output: 4,
+            read: 0,
+            write: 0,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await configuredAgent.run("test prompt", "/repo");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "opencode",
+      ["serve", "--hostname", "127.0.0.1", "--port", "8765", "--print-logs"],
+      expect.objectContaining({
+        cwd: "/repo",
+      }),
+    );
+
+    const messageBody = JSON.parse(
+      String(fetchMock.mock.calls[3]?.[1]?.body ?? ""),
+    );
+    expect(messageBody.model).toEqual({
+      providerID: "fireworks-ai",
+      modelID: "accounts/fireworks/models/qwen3p6-plus",
+    });
+  });
+
+  it("passes non-model extra args through to opencode serve", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const configuredAgent = new OpenCodeAgent({
+      extraArgs: ["--pure", "--model", "anthropic/claude-sonnet-4-20250514", "--log-level", "DEBUG"],
       fetch: fetchMock as typeof fetch,
       getPort,
     });
@@ -569,8 +613,9 @@ describe("OpenCodeAgent", () => {
       "opencode",
       [
         "serve",
-        "--model",
-        "gpt-5",
+        "--pure",
+        "--log-level",
+        "DEBUG",
         "--hostname",
         "127.0.0.1",
         "--port",
@@ -581,6 +626,34 @@ describe("OpenCodeAgent", () => {
         cwd: "/repo",
       }),
     );
+  });
+
+  it("does not include model in the prompt body when no --model is given", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("done", {
+            input: 10,
+            output: 4,
+            read: 0,
+            write: 0,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await agent.run("test prompt", "/repo");
+
+    const messageBody = JSON.parse(
+      String(fetchMock.mock.calls[3]?.[1]?.body ?? ""),
+    );
+    expect(messageBody.model).toBeUndefined();
   });
 
   it("uses a shell on Windows so PATH-resolved .cmd shims can launch", async () => {

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -136,6 +136,52 @@ const BLANKET_PERMISSION_RULESET = [
   { permission: "*", pattern: "*", action: "allow" },
 ] as const;
 
+interface OpenCodeModelRef {
+  providerID: string;
+  modelID: string;
+}
+
+/**
+ * Extract `--model`/`-m` and its value from an args array.
+ * Returns the model ref (or undefined) and a filtered copy of the array
+ * with the model flag + value removed.  Handles both `--model value` and
+ * `--model=value` forms.
+ *
+ * The CLI format is `provider/model` (e.g.
+ * `fireworks-ai/accounts/fireworks/models/qwen3p6-plus`).  The opencode
+ * serve HTTP API expects `{ providerID, modelID }`, so we split on the
+ * first `/`.
+ */
+function extractModelArg(
+  args: string[],
+): { model: OpenCodeModelRef | undefined; rest: string[] } {
+  let raw: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--model" || arg === "-m") {
+      raw = args[++i];
+    } else if (arg.startsWith("--model=")) {
+      raw = arg.slice("--model=".length);
+    } else {
+      rest.push(arg);
+    }
+  }
+
+  let model: OpenCodeModelRef | undefined;
+  if (raw) {
+    const slashIndex = raw.indexOf("/");
+    if (slashIndex > 0) {
+      model = {
+        providerID: raw.slice(0, slashIndex),
+        modelID: raw.slice(slashIndex + 1),
+      };
+    }
+  }
+
+  return { model, rest };
+}
+
 function buildStructuredOutputFormat(schema: AgentOutputSchema) {
   return {
     type: "json_schema",
@@ -271,6 +317,7 @@ export class OpenCodeAgent implements Agent {
   private fetchFn: typeof fetch;
   private getPortFn: () => Promise<number>;
   private killProcessFn: typeof process.kill;
+  private model?: OpenCodeModelRef;
   private platform: NodeJS.Platform;
   private schema: AgentOutputSchema;
   private spawnFn: typeof spawn;
@@ -279,7 +326,11 @@ export class OpenCodeAgent implements Agent {
 
   constructor(deps: OpenCodeDeps = {}) {
     this.bin = deps.bin ?? "opencode";
-    this.extraArgs = deps.extraArgs;
+    // `opencode serve` does not accept --model; extract it from extraArgs
+    // and pass it via the HTTP API instead.
+    const { model, rest } = extractModelArg(deps.extraArgs ?? []);
+    this.model = model;
+    this.extraArgs = rest.length > 0 ? rest : undefined;
     this.fetchFn = deps.fetch ?? fetch;
     this.getPortFn = deps.getPort ?? getAvailablePort;
     this.killProcessFn = deps.killProcess ?? process.kill.bind(process);
@@ -698,6 +749,7 @@ export class OpenCodeAgent implements Agent {
             role: "user",
             parts: [{ type: "text", text: prompt }],
             format: buildStructuredOutputFormat(this.schema),
+            ...(this.model ? { model: this.model } : {}),
           },
           signal,
         });


### PR DESCRIPTION
## Summary

- Extract `--model`/`-m` from `extraArgs` before spawning `opencode serve` (which doesn't accept it)
- Parse the `provider/model` CLI format into `{ providerID, modelID }` object (required by the opencode HTTP API)
- Pass the model object in the `prompt_async` request body
- Non-model extra args continue to be passed to `opencode serve` as before

Fixes #83

## Test plan

- [x] Existing test updated: verifies `--model` is excluded from spawn args and included as object in prompt body
- [x] New test: non-model extra args (e.g. `--pure`, `--log-level`) still passed to `opencode serve`
- [x] New test: no `model` field in prompt body when `--model` is not configured
- [x] All 361 unit tests pass
- [x] All 6 e2e tests pass
- [x] Manually verified with `fireworks-ai/accounts/fireworks/models/qwen3p6-plus` — gnhf successfully runs opencode iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)