### PR TITLE
feat(core): support angular commit message preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Entry point is `src/cli.ts`. It parses flags with commander, resolves config, ha
 
 ### Agents (`src/core/agents/`)
 
-Each agent implements the `Agent` interface in `types.ts` (`name`, async `run(prompt, cwd, options)` returning `{ output, usage }`, optional `close()`). They share two responsibilities: stream stdout, extract a structured `AgentOutput` (`success`, `summary`, `key_changes_made`, `key_learnings`, plus `should_fully_stop` only when `--stop-when` is active) that matches the schema built by `buildAgentOutputSchema(...)`, and accumulate `TokenUsage`. `factory.ts` picks one based on config.
+Each agent implements the `Agent` interface in `types.ts` (`name`, async `run(prompt, cwd, options)` returning `{ output, usage }`, optional `close()`). They share two responsibilities: stream stdout, extract a structured `AgentOutput` (`success`, `summary`, `key_changes_made`, `key_learnings`, configurable commit-message fields such as `type`/`scope`, plus `should_fully_stop` only when `--stop-when` is active) that matches the schema built by `buildAgentOutputSchema(...)`, and accumulate `TokenUsage`. `factory.ts` picks one based on config.
 
 - `claude.ts` / `codex.ts`: spawn the CLI per iteration in non-interactive mode. Codex uses `--output-schema` pointing at the run's schema file; Claude uses `--json-schema`.
 - `rovodev.ts` / `opencode.ts`: long-running local HTTP servers managed via `managed-process.ts` (start once, reuse across iterations, close on shutdown). OpenCode creates a per-run session and applies a blanket allow rule to avoid prompt blocking.
@@ -46,7 +46,7 @@ Reserved args managed by gnhf are rejected in `config.ts` via `isReservedAgentAr
 
 ### Config (`src/core/config.ts`)
 
-Loads `~/.gnhf/config.yml` (bootstrapped on first run). CLI flags override config; runtime-only flags (`--max-iterations`, `--max-tokens`, `--stop-when`) are never persisted. `agentPathOverride` and `agentArgsOverride` are per-agent; paths resolve relative to `~/.gnhf/` and support `~` expansion.
+Loads `~/.gnhf/config.yml` (bootstrapped on first run). CLI flags override config; runtime-only flags (`--max-iterations`, `--max-tokens`, `--stop-when`) are never persisted. `agentPathOverride` and `agentArgsOverride` are per-agent; paths resolve relative to `~/.gnhf/` and support `~` expansion. `commitMessage.preset: angular` switches successful iteration commits from `gnhf #<iteration>: <summary>` to Angular-style headers.
 
 ### Git helpers (`src/core/git.ts`)
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The iteration and token caps are runtime-only flags and are not persisted in `co
 `commitMessage` controls the subject line that gnhf uses for each successful iteration commit.
 
 - Omit it to keep the default `gnhf #<iteration>: <summary>` format.
-- Set `preset: angular` to ask the agent for `type` and optional `scope`, then commit as `type(scope): summary` for semantic-release style workflows.
+- Set `preset: angular` to ask the agent for `type` and optional `scope`, then commit as `type(scope): summary` for semantic-release style workflows. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `test`, and `chore`; invalid or missing types fall back to `chore`, and missing scopes are omitted.
 
 ### Custom Agent Paths
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ agent: claude
 #     - model_reasoning_effort="high"
 #     - --full-auto
 
+# Commit message convention (optional)
+# Defaults to: gnhf #<iteration>: <summary>
+# Use the angular preset for semantic-release compatible headers:
+# commitMessage:
+#   preset: angular
+
 # Abort after this many consecutive failures
 maxConsecutiveFailures: 3
 
@@ -219,6 +225,11 @@ The iteration and token caps are runtime-only flags and are not persisted in `co
 - Use it for agent-specific options like models, profiles, or reasoning settings without adding a dedicated `gnhf` config field for each one.
 - For `codex` and `claude`, `gnhf` adds its usual non-interactive permission default only when you do not provide your own permission or execution-mode flag. If you set one explicitly, `gnhf` treats that as user-managed and does not add its default on top.
 - Flags that `gnhf` manages itself for a given agent, such as output-shaping or local-server startup flags, are rejected during config loading so you get a clear error instead of duplicate-argument ambiguity.
+
+`commitMessage` controls the subject line that gnhf uses for each successful iteration commit.
+
+- Omit it to keep the default `gnhf #<iteration>: <summary>` format.
+- Set `preset: angular` to ask the agent for `type` and optional `scope`, then commit as `type(scope): summary` for semantic-release style workflows.
 
 ### Custom Agent Paths
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, sep } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { ANGULAR_COMMIT_MESSAGE } from "./core/commit-message.js";
 import type { Config } from "./core/config.js";
 import type { RunInfo } from "./core/run.js";
 
@@ -71,6 +72,7 @@ async function runCliWithMocks(
   const startSleepPrevention =
     overrides.startSleepPrevention ??
     vi.fn(() => Promise.resolve({ type: "skipped", reason: "unsupported" }));
+  const setupRun = vi.fn(() => stubRunInfo);
 
   const orchestratorStart =
     overrides.orchestratorStart ?? vi.fn(() => Promise.resolve());
@@ -119,7 +121,7 @@ async function runCliWithMocks(
     removeWorktree: overrides.removeWorktree ?? vi.fn(),
   }));
   vi.doMock("./core/run.js", () => ({
-    setupRun: vi.fn(() => stubRunInfo),
+    setupRun,
     resumeRun: vi.fn(),
     getLastIterationNumber: vi.fn(() => 0),
   }));
@@ -187,6 +189,7 @@ async function runCliWithMocks(
     appendDebugLog,
     loadConfig,
     createAgent,
+    setupRun,
     orchestratorCtor,
     orchestratorGetState,
     readStdinText,
@@ -353,6 +356,52 @@ describe("cli", () => {
       undefined,
       undefined,
       { includeStopField: true },
+    );
+  });
+
+  it("threads commit message fields into run setup and agent creation", async () => {
+    const { createAgent, setupRun } = await runCliWithMocks(["ship it"], {
+      agent: "codex",
+      agentPathOverride: {},
+      agentArgsOverride: {},
+      commitMessage: ANGULAR_COMMIT_MESSAGE,
+      maxConsecutiveFailures: 3,
+      preventSleep: false,
+    });
+
+    const expectedSchemaOptions = {
+      includeStopField: false,
+      commitFields: [
+        {
+          name: "type",
+          allowed: [
+            "build",
+            "ci",
+            "docs",
+            "feat",
+            "fix",
+            "perf",
+            "refactor",
+            "test",
+            "chore",
+          ],
+        },
+        { name: "scope" },
+      ],
+    };
+    expect(setupRun).toHaveBeenCalledWith(
+      expect.stringMatching(/^ship-it-/),
+      "ship it",
+      "abc123",
+      process.cwd(),
+      expectedSchemaOptions,
+    );
+    expect(createAgent).toHaveBeenCalledWith(
+      "codex",
+      stubRunInfo,
+      undefined,
+      undefined,
+      expectedSchemaOptions,
     );
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import {
 import { readStdinText } from "./core/stdin.js";
 import { startSleepPrevention } from "./core/sleep.js";
 import { createAgent } from "./core/agents/factory.js";
+import { getCommitMessageSchemaFields } from "./core/commit-message.js";
 import { Orchestrator } from "./core/orchestrator.js";
 import { MockOrchestrator } from "./mock-orchestrator.js";
 import { Renderer } from "./renderer.js";
@@ -411,8 +412,10 @@ program
       const currentBranch = getCurrentBranch(cwd);
       const onGnhfBranch = currentBranch.startsWith("gnhf/");
 
+      const commitFields = getCommitMessageSchemaFields(config.commitMessage);
       const schemaOptions = {
         includeStopField: options.stopWhen !== undefined,
+        ...(commitFields.length === 0 ? {} : { commitFields }),
       };
 
       let runInfo;

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -126,6 +126,30 @@ describe("createAgent", () => {
     });
   });
 
+  it("hands ClaudeAgent a schema with configured commit message fields", () => {
+    createAgent("claude", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+      commitFields: [
+        { name: "type", allowed: ["feat", "fix"] },
+        { name: "scope" },
+      ],
+    });
+
+    expect(ClaudeAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+      schema: {
+        ...noStopSchema,
+        properties: {
+          ...noStopSchema.properties,
+          type: { type: "string", enum: ["feat", "fix"] },
+          scope: { type: "string" },
+        },
+        required: [...noStopSchema.required, "type", "scope"],
+      },
+    });
+  });
+
   it("creates a CodexAgent when name is 'codex'", () => {
     const agent = createAgent("codex", stubRunInfo, undefined, undefined, {
       includeStopField: false,

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -1,4 +1,8 @@
-import { buildAgentOutputSchema, type Agent } from "./types.js";
+import {
+  buildAgentOutputSchema,
+  type Agent,
+  type AgentOutputCommitField,
+} from "./types.js";
 import type { AgentName } from "../config.js";
 import type { RunInfo } from "../run.js";
 import { ClaudeAgent } from "./claude.js";
@@ -8,6 +12,7 @@ import { RovoDevAgent } from "./rovodev.js";
 
 export interface CreateAgentOptions {
   includeStopField: boolean;
+  commitFields?: AgentOutputCommitField[];
 }
 
 export function createAgent(
@@ -19,6 +24,7 @@ export function createAgent(
 ): Agent {
   const schema = buildAgentOutputSchema({
     includeStopField: options.includeStopField,
+    commitFields: options.commitFields,
   });
   switch (name) {
     case "claude":

--- a/src/core/agents/types.test.ts
+++ b/src/core/agents/types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentOutputSchema } from "./types.js";
+
+describe("buildAgentOutputSchema", () => {
+  it("adds configured commit message fields to properties and required", () => {
+    const schema = buildAgentOutputSchema({
+      includeStopField: false,
+      commitFields: [
+        {
+          name: "type",
+          allowed: ["feat", "fix"],
+        },
+        {
+          name: "scope",
+        },
+      ],
+    });
+
+    expect(schema.properties.type).toEqual({
+      type: "string",
+      enum: ["feat", "fix"],
+    });
+    expect(schema.properties.scope).toEqual({ type: "string" });
+    expect(schema.required).toContain("type");
+    expect(schema.required).toContain("scope");
+  });
+});

--- a/src/core/agents/types.ts
+++ b/src/core/agents/types.ts
@@ -4,13 +4,22 @@ export interface AgentOutput {
   key_changes_made: unknown;
   key_learnings: unknown;
   should_fully_stop?: boolean;
+  [key: string]: unknown;
 }
 
 export interface AgentOutputSchema {
   type: "object";
   additionalProperties: false;
-  properties: Record<string, { type: string; items?: { type: string } }>;
+  properties: Record<
+    string,
+    { type: string; items?: { type: string }; enum?: string[] }
+  >;
   required: string[];
+}
+
+export interface AgentOutputCommitField {
+  name: string;
+  allowed?: string[];
 }
 
 // Codex's --output-schema enforces OpenAI strict mode, which requires every
@@ -18,6 +27,7 @@ export interface AgentOutputSchema {
 // is false. So include should_fully_stop only when the run actually uses it.
 export function buildAgentOutputSchema(opts: {
   includeStopField: boolean;
+  commitFields?: AgentOutputCommitField[];
 }): AgentOutputSchema {
   const properties: AgentOutputSchema["properties"] = {
     success: { type: "boolean" },
@@ -26,6 +36,13 @@ export function buildAgentOutputSchema(opts: {
     key_learnings: { type: "array", items: { type: "string" } },
   };
   const required = ["success", "summary", "key_changes_made", "key_learnings"];
+  for (const field of opts.commitFields ?? []) {
+    properties[field.name] = {
+      type: "string",
+      ...(field.allowed === undefined ? {} : { enum: field.allowed }),
+    };
+    required.push(field.name);
+  }
   if (opts.includeStopField) {
     properties.should_fully_stop = { type: "boolean" };
     required.push("should_fully_stop");

--- a/src/core/commit-message-config.ts
+++ b/src/core/commit-message-config.ts
@@ -1,0 +1,30 @@
+import type { CommitMessageConfig } from "./commit-message.js";
+import { InvalidConfigError } from "./config-errors.js";
+
+export function normalizeCommitMessageConfig(
+  value: unknown,
+): CommitMessageConfig | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidConfigError(
+      `Invalid config value for commitMessage: expected an object`,
+    );
+  }
+
+  const raw = value as Record<string, unknown>;
+  if (raw.preset !== "angular") {
+    throw new InvalidConfigError(
+      `Invalid config value for commitMessage.preset: expected "angular"`,
+    );
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (key !== "preset") {
+      throw new InvalidConfigError(
+        `Unsupported config key for commitMessage.${key}`,
+      );
+    }
+  }
+
+  return { preset: "angular" };
+}

--- a/src/core/commit-message.test.ts
+++ b/src/core/commit-message.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildCommitMessage } from "./commit-message.js";
+
+describe("buildCommitMessage", () => {
+  it("renders the pre-existing gnhf commit subject when config is omitted", () => {
+    const message = buildCommitMessage(
+      undefined,
+      {
+        success: true,
+        summary: "add retry coverage",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+      { iteration: 3 },
+    );
+
+    expect(message).toBe("gnhf #3: add retry coverage");
+  });
+
+  it("renders an Angular header with a scope", () => {
+    const message = buildCommitMessage(
+      { preset: "angular" },
+      {
+        success: true,
+        summary: "handle empty output",
+        key_changes_made: [],
+        key_learnings: [],
+        type: "fix",
+        scope: "core",
+      },
+      { iteration: 1 },
+    );
+
+    expect(message).toBe("fix(core): handle empty output");
+  });
+
+  it("renders an Angular header without a scope", () => {
+    const message = buildCommitMessage(
+      { preset: "angular" },
+      {
+        success: true,
+        summary: "refresh docs",
+        key_changes_made: [],
+        key_learnings: [],
+        type: "docs",
+        scope: "",
+      },
+      { iteration: 1 },
+    );
+
+    expect(message).toBe("docs: refresh docs");
+  });
+
+  it("falls back to configured field defaults when output omits them", () => {
+    const message = buildCommitMessage(
+      { preset: "angular" },
+      {
+        success: true,
+        summary: "tidy internal naming",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+      { iteration: 2 },
+    );
+
+    expect(message).toBe("chore: tidy internal naming");
+  });
+
+  it("falls back to the default Angular type when output provides an invalid type", () => {
+    const message = buildCommitMessage(
+      { preset: "angular" },
+      {
+        success: true,
+        summary: "tidy internal naming",
+        key_changes_made: [],
+        key_learnings: [],
+        type: "wip",
+      },
+      { iteration: 2 },
+    );
+
+    expect(message).toBe("chore: tidy internal naming");
+  });
+
+  it("collapses newlines in rendered headers", () => {
+    const message = buildCommitMessage(
+      { preset: "angular" },
+      {
+        success: true,
+        summary: "add parser\nwith extra spacing",
+        key_changes_made: [],
+        key_learnings: [],
+        type: "feat",
+      },
+      { iteration: 4 },
+    );
+
+    expect(message).toBe("feat: add parser with extra spacing");
+  });
+});

--- a/src/core/commit-message.ts
+++ b/src/core/commit-message.ts
@@ -1,0 +1,100 @@
+import type { AgentOutput, AgentOutputCommitField } from "./agents/types.js";
+
+export type CommitMessagePreset = "angular";
+
+export interface CommitMessageConfig {
+  preset: CommitMessagePreset;
+}
+
+export interface CommitMessageContext {
+  iteration: number;
+}
+
+export interface CommitMessagePromptField {
+  name: string;
+  description: string;
+  allowed?: string[];
+  default: string;
+}
+
+export const ANGULAR_COMMIT_MESSAGE: CommitMessageConfig = {
+  preset: "angular",
+};
+
+const ANGULAR_COMMIT_TYPES = [
+  "build",
+  "ci",
+  "docs",
+  "feat",
+  "fix",
+  "perf",
+  "refactor",
+  "test",
+  "chore",
+];
+
+const ANGULAR_COMMIT_MESSAGE_FIELDS: CommitMessagePromptField[] = [
+  {
+    name: "type",
+    description: "Commit type",
+    allowed: ANGULAR_COMMIT_TYPES,
+    default: "chore",
+  },
+  {
+    name: "scope",
+    description: "Optional commit scope",
+    default: "",
+  },
+];
+
+export function getCommitMessageSchemaFields(
+  config: CommitMessageConfig | undefined,
+): AgentOutputCommitField[] {
+  if (config === undefined) return [];
+  return ANGULAR_COMMIT_MESSAGE_FIELDS.map((field) => ({
+    name: field.name,
+    ...(field.allowed === undefined ? {} : { allowed: field.allowed }),
+  }));
+}
+
+export function getCommitMessagePromptFields(
+  config: CommitMessageConfig | undefined,
+): CommitMessagePromptField[] {
+  if (config === undefined) return [];
+  return ANGULAR_COMMIT_MESSAGE_FIELDS;
+}
+
+function collapseHeader(message: string): string {
+  return message.replace(/\s+/g, " ").trim();
+}
+
+function outputString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function resolveAngularType(value: unknown): string {
+  const candidate = outputString(value);
+  if (candidate !== null && ANGULAR_COMMIT_TYPES.includes(candidate)) {
+    return candidate;
+  }
+  return "chore";
+}
+
+function resolveAngularScope(value: unknown): string {
+  const scope = outputString(value)?.trim() ?? "";
+  return scope === "" ? "" : `(${scope})`;
+}
+
+export function buildCommitMessage(
+  config: CommitMessageConfig | undefined,
+  output: AgentOutput,
+  context: CommitMessageContext,
+): string {
+  if (config === undefined) {
+    return collapseHeader(`gnhf #${context.iteration}: ${output.summary}`);
+  }
+
+  const type = resolveAngularType(output.type);
+  const scope = resolveAngularScope(output.scope);
+  return collapseHeader(`${type}${scope}: ${output.summary}`);
+}

--- a/src/core/config-errors.ts
+++ b/src/core/config-errors.ts
@@ -1,0 +1,1 @@
+export class InvalidConfigError extends Error {}

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -22,7 +22,40 @@ const HOME = "/mock-home";
 const CONFIG_DIR = join(HOME, ".gnhf");
 const CONFIG_PATH = join(CONFIG_DIR, "config.yml");
 const BOOTSTRAP_CONFIG_TEMPLATE = (agent: string) =>
-  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort="high"\n#     - --full-auto\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
+  [
+    "# Agent to use by default",
+    `agent: ${agent}`,
+    "",
+    "# Custom paths to agent binaries (optional)",
+    "# Paths may be absolute, bare executable names on PATH,",
+    "# ~-prefixed, or relative to this config directory.",
+    "# Note: rovodev overrides must point to an acli-compatible binary.",
+    "# agentPathOverride:",
+    "#   claude: /path/to/custom-claude",
+    "#   codex: /path/to/custom-codex",
+    "",
+    "# Per-agent CLI arg overrides (optional)",
+    "# agentArgsOverride:",
+    "#   codex:",
+    "#     - -m",
+    "#     - gpt-5.4",
+    "#     - -c",
+    '#     - model_reasoning_effort="high"',
+    "#     - --full-auto",
+    "",
+    "# Commit message convention (optional)",
+    "# Defaults to: gnhf #<iteration>: <summary>",
+    "# Use Angular-style semantic-release headers:",
+    "# commitMessage:",
+    "#   preset: angular",
+    "",
+    "# Abort after this many consecutive failures",
+    "maxConsecutiveFailures: 3",
+    "",
+    "# Prevent the machine from sleeping during a run",
+    "preventSleep: true",
+    "",
+  ].join("\n");
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -51,6 +84,7 @@ describe("loadConfig", () => {
       maxConsecutiveFailures: 3,
       preventSleep: true,
     });
+    expect(config).not.toHaveProperty("commitMessage");
   });
 
   it("still returns defaults when default config creation fails", () => {
@@ -189,6 +223,89 @@ describe("loadConfig", () => {
 
     expect(mockReadFileSync).toHaveBeenCalledWith(CONFIG_PATH, "utf-8");
     expect(config.agent).toBe("codex");
+  });
+
+  it("reads the Angular commit message preset from config", () => {
+    mockReadFileSync.mockReturnValue("commitMessage:\n  preset: angular\n");
+
+    const config = loadConfig();
+
+    expect(config.commitMessage).toEqual({
+      preset: "angular",
+    });
+  });
+
+  it("throws when commitMessage omits a preset", () => {
+    mockReadFileSync.mockReturnValue("commitMessage: {}\n");
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for commitMessage\.preset: expected "angular"/,
+    );
+  });
+
+  it("throws when commitMessage is present without a value", () => {
+    mockReadFileSync.mockReturnValue("commitMessage:\n");
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for commitMessage: expected an object/,
+    );
+  });
+
+  it("throws when commitMessage uses the gnhf preset explicitly", () => {
+    mockReadFileSync.mockReturnValue("commitMessage:\n  preset: gnhf\n");
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for commitMessage\.preset: expected "angular"/,
+    );
+  });
+
+  it("throws when commitMessage uses the custom preset", () => {
+    mockReadFileSync.mockReturnValue("commitMessage:\n  preset: custom\n");
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for commitMessage\.preset: expected "angular"/,
+    );
+  });
+
+  it("throws when commitMessage includes a template", () => {
+    mockReadFileSync.mockReturnValue(
+      [
+        "commitMessage:",
+        "  preset: angular",
+        '  template: "{{type}}: {{summary}}"',
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /Unsupported config key for commitMessage\.template/,
+    );
+  });
+
+  it("throws when commitMessage includes fields", () => {
+    mockReadFileSync.mockReturnValue(
+      [
+        "commitMessage:",
+        "  preset: angular",
+        "  fields:",
+        "    scope:",
+        "      description: Optional commit scope",
+        '      default: ""',
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /Unsupported config key for commitMessage\.fields/,
+    );
+  });
+
+  it("throws when commitMessage has an unknown preset", () => {
+    mockReadFileSync.mockReturnValue("commitMessage:\n  preset: semantic\n");
+
+    expect(() => loadConfig()).toThrow(
+      /Invalid config value for commitMessage\.preset: expected "angular"/,
+    );
   });
 
   it("merges file config with defaults", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,6 +2,9 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
+import type { CommitMessageConfig } from "./commit-message.js";
+import { normalizeCommitMessageConfig } from "./commit-message-config.js";
+import { InvalidConfigError } from "./config-errors.js";
 
 export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
 
@@ -11,6 +14,7 @@ export interface Config {
   agent: AgentName;
   agentPathOverride: Partial<Record<AgentName, string>>;
   agentArgsOverride: Partial<Record<AgentName, string[]>>;
+  commitMessage?: CommitMessageConfig;
   maxConsecutiveFailures: number;
   preventSleep: boolean;
 }
@@ -22,8 +26,6 @@ const DEFAULT_CONFIG: Config = {
   maxConsecutiveFailures: 3,
   preventSleep: true,
 };
-
-class InvalidConfigError extends Error {}
 
 function normalizePreventSleep(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
@@ -267,6 +269,21 @@ function normalizeConfig(
     delete normalized.agentArgsOverride;
   }
 
+  const hasCommitMessage = Object.prototype.hasOwnProperty.call(
+    config,
+    "commitMessage",
+  );
+  if (hasCommitMessage) {
+    const commitMessage = normalizeCommitMessageConfig(config.commitMessage);
+    if (commitMessage === undefined) {
+      delete normalized.commitMessage;
+    } else {
+      normalized.commitMessage = commitMessage;
+    }
+  } else {
+    delete normalized.commitMessage;
+  }
+
   return normalized;
 }
 
@@ -341,6 +358,12 @@ function serializeConfig(config: Config): string {
     "#     - -c",
     '#     - model_reasoning_effort="high"',
     "#     - --full-auto",
+    "",
+    "# Commit message convention (optional)",
+    "# Defaults to: gnhf #<iteration>: <summary>",
+    "# Use Angular-style semantic-release headers:",
+    "# commitMessage:",
+    "#   preset: angular",
   ];
 
   if (agentPathOverrideSection) {

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -33,6 +33,7 @@ vi.mock("../templates/iteration-prompt.js", () => ({
 import { commitAll, resetHard } from "./git.js";
 import { appendNotes } from "./run.js";
 import { Orchestrator } from "./orchestrator.js";
+import { ANGULAR_COMMIT_MESSAGE } from "./commit-message.js";
 import type { Agent, AgentResult } from "./agents/types.js";
 import type { Config } from "./config.js";
 import type { RunInfo } from "./run.js";
@@ -125,7 +126,46 @@ describe("Orchestrator output normalization", () => {
       ["learning"],
     );
     expect(mockCommitAll).toHaveBeenCalledTimes(1);
+    expect(mockCommitAll).toHaveBeenCalledWith("gnhf #1: done", "/repo");
     expect(orchestrator.getState().status).toBe("aborted");
+  });
+
+  it("uses the configured commit message convention for successful iterations", async () => {
+    const agent: Agent = {
+      name: "claude",
+      run: vi.fn(async () => ({
+        output: {
+          success: true,
+          summary: "handle empty output",
+          key_changes_made: ["file.ts"],
+          key_learnings: [],
+          type: "fix",
+          scope: "core",
+        },
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      })),
+    };
+    const orchestrator = new Orchestrator(
+      { ...config, commitMessage: ANGULAR_COMMIT_MESSAGE },
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { maxIterations: 1 },
+    );
+
+    await orchestrator.start();
+
+    expect(mockCommitAll).toHaveBeenCalledWith(
+      "fix(core): handle empty output",
+      "/repo",
+    );
   });
 
   it("handles key_learnings returned as a JSON string instead of an array", async () => {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -12,6 +12,7 @@ import {
   getHeadCommit,
   resetHard,
 } from "./git.js";
+import { buildCommitMessage } from "./commit-message.js";
 import { buildIterationPrompt } from "../templates/iteration-prompt.js";
 
 export interface IterationRecord {
@@ -196,6 +197,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           runId: this.runInfo.runId,
           prompt: this.prompt,
           stopWhen: this.limits.stopWhen,
+          commitMessage: this.config.commitMessage,
         });
 
         appendDebugLog("iteration:start", {
@@ -458,7 +460,9 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
       toStringArray(output.key_learnings),
     );
     commitAll(
-      `gnhf #${this.state.currentIteration}: ${output.summary}`,
+      buildCommitMessage(this.config.commitMessage, output, {
+        iteration: this.state.currentIteration,
+      }),
       this.cwd,
     );
     this.state.commitCount = getBranchCommitCount(

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -134,6 +134,28 @@ describe("setupRun", () => {
     expect(schema.required).toContain("should_fully_stop");
   });
 
+  it("writes configured commit message fields into output-schema.json", () => {
+    setupRun("run-abc", "test", "abc123", P, {
+      includeStopField: false,
+      commitFields: [
+        { name: "type", allowed: ["feat", "fix"] },
+        { name: "scope" },
+      ],
+    });
+    const schemaCall = mockWriteFileSync.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" && call[0].endsWith("output-schema.json"),
+    );
+    const schema = JSON.parse(schemaCall![1] as string);
+    expect(schema.properties.type).toEqual({
+      type: "string",
+      enum: ["feat", "fix"],
+    });
+    expect(schema.properties.scope).toEqual({ type: "string" });
+    expect(schema.required).toContain("type");
+    expect(schema.required).toContain("scope");
+  });
+
   it("writes the branch base commit for new runs", () => {
     setupRun("run-abc", "test", "abc123", P, { includeStopField: false });
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -8,7 +8,10 @@ import {
 } from "node:fs";
 import { join, dirname, isAbsolute } from "node:path";
 import { execFileSync } from "node:child_process";
-import { buildAgentOutputSchema } from "./agents/types.js";
+import {
+  buildAgentOutputSchema,
+  type AgentOutputCommitField,
+} from "./agents/types.js";
 import { findLegacyRunBaseCommit, getHeadCommit } from "./git.js";
 
 export interface RunInfo {
@@ -24,16 +27,27 @@ export interface RunInfo {
 
 const LOG_FILENAME = "gnhf.log";
 
-function writeSchemaFile(schemaPath: string, includeStopField: boolean): void {
+function writeSchemaFile(
+  schemaPath: string,
+  schemaOptions: RunSchemaOptions,
+): void {
   writeFileSync(
     schemaPath,
-    JSON.stringify(buildAgentOutputSchema({ includeStopField }), null, 2),
+    JSON.stringify(
+      buildAgentOutputSchema({
+        includeStopField: schemaOptions.includeStopField,
+        commitFields: schemaOptions.commitFields,
+      }),
+      null,
+      2,
+    ),
     "utf-8",
   );
 }
 
 export interface RunSchemaOptions {
   includeStopField: boolean;
+  commitFields?: AgentOutputCommitField[];
 }
 
 function ensureRunMetadataIgnored(cwd: string): void {
@@ -85,7 +99,7 @@ export function setupRun(
   }
 
   const schemaPath = join(runDir, "output-schema.json");
-  writeSchemaFile(schemaPath, schemaOptions.includeStopField);
+  writeSchemaFile(schemaPath, schemaOptions);
 
   const logPath = join(runDir, LOG_FILENAME);
 
@@ -123,7 +137,7 @@ export function resumeRun(
   const promptPath = join(runDir, "prompt.md");
   const notesPath = join(runDir, "notes.md");
   const schemaPath = join(runDir, "output-schema.json");
-  writeSchemaFile(schemaPath, schemaOptions.includeStopField);
+  writeSchemaFile(schemaPath, schemaOptions);
   const logPath = join(runDir, LOG_FILENAME);
   const baseCommitPath = join(runDir, "base-commit");
   const baseCommit = existsSync(baseCommitPath)

--- a/src/templates/iteration-prompt.test.ts
+++ b/src/templates/iteration-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildIterationPrompt } from "./iteration-prompt.js";
+import { ANGULAR_COMMIT_MESSAGE } from "../core/commit-message.js";
 
 describe("buildIterationPrompt", () => {
   it("includes the iteration number", () => {
@@ -70,5 +71,22 @@ describe("buildIterationPrompt", () => {
     expect(result).toContain("should_fully_stop");
     expect(result).toContain("set it to false");
     expect(result).not.toContain("omit it");
+  });
+
+  it("adds commit message field instructions when the convention requires them", () => {
+    const result = buildIterationPrompt({
+      n: 1,
+      runId: "run-1",
+      prompt: "do stuff",
+      commitMessage: ANGULAR_COMMIT_MESSAGE,
+    });
+
+    expect(result).toContain("type: Commit type");
+    expect(result).toContain(
+      "allowed values: build, ci, docs, feat, fix, perf, refactor, test, chore",
+    );
+    expect(result).toContain('default: "chore"');
+    expect(result).toContain("scope: Optional commit scope");
+    expect(result).toContain('default: ""');
   });
 });

--- a/src/templates/iteration-prompt.ts
+++ b/src/templates/iteration-prompt.ts
@@ -1,8 +1,14 @@
+import {
+  getCommitMessagePromptFields,
+  type CommitMessageConfig,
+} from "../core/commit-message.js";
+
 export function buildIterationPrompt(params: {
   n: number;
   runId: string;
   prompt: string;
   stopWhen?: string;
+  commitMessage?: CommitMessageConfig;
 }): string {
   const outputFields = [
     "- success: whether you were able to make a meaningful contribution that got us closer towards the objective. setting this to false means any code change you made should be discarded",
@@ -10,6 +16,18 @@ export function buildIterationPrompt(params: {
     "- key_changes_made: an array of descriptions for key changes you made. don't group this by file - group by logical units of work. don't describe activities - describe material outcomes",
     "- key_learnings: an array of new learnings that were surprising, weren't captured by previous notes and would be informative for future iterations",
   ];
+
+  for (const field of getCommitMessagePromptFields(params.commitMessage)) {
+    const constraints = [
+      field.allowed === undefined
+        ? null
+        : `allowed values: ${field.allowed.join(", ")}`,
+      `default: ${JSON.stringify(field.default)}`,
+    ].filter((value): value is string => value !== null);
+    outputFields.push(
+      `- ${field.name}: ${field.description}. ${constraints.join("; ")}`,
+    );
+  }
 
   if (params.stopWhen !== undefined) {
     outputFields.push(


### PR DESCRIPTION
## Summary
- Adds `commitMessage.preset: angular` configuration to generate successful iteration commits as Angular-style `type(scope): summary` headers instead of the default `gnhf #<iteration>: <summary>` format.
- Threads commit-message fields through agent output schemas, run setup, iteration prompts, and orchestrator commits so agents provide constrained `type` and optional `scope` values.
- Documents the new preset and supported commit types, with focused tests covering config loading, schema generation, prompt output, and commit formatting.

## Risk Assessment

✅ Low: The change is well-bounded to config parsing, prompt/schema plumbing, and commit subject rendering, with no substantiated correctness or security issues in the changed code.

## Testing

- Summary: <code>Exercised the commit message convention path across schema generation, config loading, run setup, prompt construction, agent creation, orchestrator commit rendering, and CLI wiring; all relevant tests passed after resolving the missing local dependency setup with `npm install`.</code>
- `npx vitest run src/core/commit-message.test.ts src/core/agents/types.test.ts src/core/agents/factory.test.ts src/core/config.test.ts src/core/run.test.ts src/templates/iteration-prompt.test.ts src/core/orchestrator.test.ts src/cli.test.ts`
- Outcome: ✅ passed across 1 run (2m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/commit-message.test.ts src/core/agents/types.test.ts src/core/agents/factory.test.ts src/core/config.test.ts src/core/run.test.ts src/templates/iteration-prompt.test.ts src/core/orchestrator.test.ts src/cli.test.ts`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 issues (1 warning, 2 infos)
- ⚠️ `README.md:232` - The new `commitMessage.preset: angular` user-facing documentation explains the resulting `type(scope): summary` format but does not document the constrained `type` values (`build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `test`, `chore`) or the default/fallback behavior (`chore`, empty scope) that the code and agent schema enforce. Add these details so users know what commit subjects the preset can produce.
- ℹ️ `AGENTS.md:39` - The agent architecture docs still describe `AgentOutput` as only `success`, `summary`, `key_changes_made`, `key_learnings`, plus optional `should_fully_stop`. With the new commit message convention, `buildAgentOutputSchema` can also require commit-message fields such as `type` and `scope`; update this section to mention configurable commit fields in the structured output schema.
- ℹ️ `AGENTS.md:49` - The config docs list `agentPathOverride` and `agentArgsOverride` but omit the new `commitMessage` config option. Update this section to include `commitMessage.preset: angular` and note that it changes successful iteration commit subjects from the default `gnhf #&lt;iteration&gt;: &lt;summary&gt;` format to Angular-style headers.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
