### PR TITLE
Add GitHub Copilot CLI agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to agents1 when working with code in this repository
 
 ## Project
 
-`gnhf` ("good night, have fun") is a CLI that runs a coding agent (Claude Code, Codex, Rovo Dev, or OpenCode) in a loop inside a git repo. Each successful iteration is a separate commit on a dedicated `gnhf/<slug>` branch; failures get `git reset --hard`, and only hard agent errors trigger exponential backoff. Target: Node 20+, published to npm as a single-file ESM bundle.
+`gnhf` ("good night, have fun") is a CLI that runs a coding agent (Claude Code, Codex, Rovo Dev, OpenCode, or GitHub Copilot CLI) in a loop inside a git repo. Each successful iteration is a separate commit on a dedicated `gnhf/<slug>` branch; failures get `git reset --hard`, and only hard agent errors trigger exponential backoff. Target: Node 20+, published to npm as a single-file ESM bundle.
 
 ## Commands
 
@@ -38,7 +38,7 @@ Entry point is `src/cli.ts`. It parses flags with commander, resolves config, ha
 
 Each agent implements the `Agent` interface in `types.ts` (`name`, async `run(prompt, cwd, options)` returning `{ output, usage }`, optional `close()`). They share two responsibilities: stream stdout, extract a structured `AgentOutput` (`success`, `summary`, `key_changes_made`, `key_learnings`, plus `should_fully_stop` only when `--stop-when` is active) that matches the schema built by `buildAgentOutputSchema(...)`, and accumulate `TokenUsage`. `factory.ts` picks one based on config.
 
-- `claude.ts` / `codex.ts`: spawn the CLI per iteration in non-interactive mode. Codex uses `--output-schema` pointing at the run's schema file; Claude uses `--json-schema`, treats the last successful structured result as terminal, and after a short grace period shuts down a lingering Claude process tree if it stays alive.
+- `claude.ts` / `codex.ts` / `copilot.ts`: spawn the CLI per iteration in non-interactive mode. Codex uses `--output-schema` pointing at the run's schema file; Claude uses `--json-schema`, treats the last successful structured result as terminal, and after a short grace period shuts down a lingering Claude process tree if it stays alive. Copilot uses JSONL output plus prompt-level schema instructions, then parses the final `assistant.message` content.
 - `rovodev.ts` / `opencode.ts`: long-running local HTTP servers managed via `managed-process.ts` (start once, reuse across iterations, close on shutdown). OpenCode creates a per-run session and applies a blanket allow rule to avoid prompt blocking.
 - `stream-utils.ts`: shared JSONL parsing, `AbortSignal` wiring, and child-process lifecycle helpers. When touching agent streaming, start here.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 - **Dead simple** — one command starts an autonomous loop that runs until you Ctrl+C or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries; hard agent errors back off exponentially while agent-reported failures continue immediately
 - **Live terminal title** — interactive runs keep your terminal title updated with live status, token totals, and commit count, then restore the previous title on exit
-- **Agent-agnostic** — works with Claude Code, Codex, Rovo Dev, or OpenCode out of the box
+- **Agent-agnostic**: works with Claude Code, Codex, Rovo Dev, OpenCode, or GitHub Copilot CLI out of the box
 
 ## Quick Start
 
@@ -173,7 +173,7 @@ If you run `gnhf` on an existing `gnhf/` branch with a different prompt, gnhf as
 
 | Flag                     | Description                                                                | Default                |
 | ------------------------ | -------------------------------------------------------------------------- | ---------------------- |
-| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, or `opencode`)                 | config file (`claude`) |
+| `--agent <agent>`        | Agent to use (`claude`, `codex`, `rovodev`, `opencode`, or `copilot`)      | config file (`claude`) |
 | `--max-iterations <n>`   | Abort after `n` total iterations                                           | unlimited              |
 | `--max-tokens <n>`       | Abort after `n` total input+output tokens                                  | unlimited              |
 | `--stop-when <cond>`     | End the loop when the agent reports this natural-language condition is met | unlimited              |
@@ -186,13 +186,14 @@ If you run `gnhf` on an existing `gnhf/` branch with a different prompt, gnhf as
 Config lives at `~/.gnhf/config.yml`:
 
 ```yaml
-# Agent to use by default (claude, codex, rovodev, or opencode)
+# Agent to use by default (claude, codex, rovodev, opencode, or copilot)
 agent: claude
 
 # Custom paths to agent binaries (optional)
 # agentPathOverride:
 #   claude: /path/to/custom-claude
 #   codex: /path/to/custom-codex
+#   copilot: /path/to/custom-copilot
 
 # Per-agent CLI arg overrides (optional)
 # agentArgsOverride:
@@ -202,6 +203,9 @@ agent: claude
 #     - -c
 #     - model_reasoning_effort="high"
 #     - --full-auto
+#   copilot:
+#     - --model
+#     - gpt-5.4
 
 # Abort after this many consecutive failures
 maxConsecutiveFailures: 3
@@ -218,7 +222,7 @@ The iteration and token caps are runtime-only flags and are not persisted in `co
 `agentArgsOverride.<name>` lets you pass through extra CLI flags for any supported agent.
 
 - Use it for agent-specific options like models, profiles, or reasoning settings without adding a dedicated `gnhf` config field for each one.
-- For `codex` and `claude`, `gnhf` adds its usual non-interactive permission default only when you do not provide your own permission or execution-mode flag. If you set one explicitly, `gnhf` treats that as user-managed and does not add its default on top.
+- For `codex`, `claude`, and `copilot`, `gnhf` adds its usual non-interactive permission default only when you do not provide your own permission or execution-mode flag. If you set one explicitly, `gnhf` treats that as user-managed and does not add its default on top.
 - Flags that `gnhf` manages itself for a given agent, such as output-shaping or local-server startup flags, are rejected during config loading so you get a clear error instead of duplicate-argument ambiguity.
 
 ### Custom Agent Paths
@@ -229,6 +233,7 @@ Use `agentPathOverride` to point any agent at a custom binary — useful for wra
 agentPathOverride:
   claude: ~/bin/claude-code-switch
   codex: /usr/local/bin/my-codex-wrapper
+  copilot: ~/bin/copilot-wrapper
 ```
 
 Paths may be absolute, bare executable names already on your `PATH`, `~`-prefixed, or relative to the config directory (`~/.gnhf/`). The override replaces only the binary name; all standard arguments are preserved, so the replacement must be CLI-compatible with the original agent. On Windows, `.cmd` and `.bat` wrappers are supported, including bare names resolved from `PATH`. For `rovodev`, the override must point to an `acli`-compatible binary since gnhf invokes it as `<bin> rovodev serve ...`.
@@ -242,14 +247,15 @@ Including a snippet of `gnhf.log` is the single most useful thing you can attach
 
 ## Agents
 
-`gnhf` supports four agents:
+`gnhf` supports five agents:
 
-| Agent       | Flag               | Requirements                                                               | Notes                                                                                                                                                                                                                        |
-| ----------- | ------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                        | `gnhf` invokes `claude` directly in non-interactive mode. After Claude emits a successful structured result, `gnhf` treats that result as final and shuts down any lingering Claude process tree after a short grace period. |
-| Codex       | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                            | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                                |
-| Rovo Dev    | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.        | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                                       |
-| OpenCode    | `--agent opencode` | Install `opencode` and configure at least one usable model provider first. | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.             |
+| Agent              | Flag               | Requirements                                                               | Notes                                                                                                                                                                                                                        |
+| ------------------ | ------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code        | `--agent claude`   | Install Anthropic's `claude` CLI and sign in first.                        | `gnhf` invokes `claude` directly in non-interactive mode. After Claude emits a successful structured result, `gnhf` treats that result as final and shuts down any lingering Claude process tree after a short grace period. |
+| Codex              | `--agent codex`    | Install OpenAI's `codex` CLI and sign in first.                            | `gnhf` invokes `codex exec` directly in non-interactive mode.                                                                                                                                                                |
+| GitHub Copilot CLI | `--agent copilot`  | Install GitHub Copilot CLI and sign in first.                              | `gnhf` invokes `copilot` directly in non-interactive JSONL mode. Copilot currently exposes assistant output tokens, but not full input/cache token totals; see https://github.com/github/copilot-cli/issues/1152.             |
+| Rovo Dev           | `--agent rovodev`  | Install Atlassian's `acli` and authenticate it with Rovo Dev first.        | `gnhf` starts a local `acli rovodev serve --disable-session-token <port>` process automatically in the repo workspace.                                                                                                       |
+| OpenCode           | `--agent opencode` | Install `opencode` and configure at least one usable model provider first. | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.             |
 
 ## Development
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -14,6 +14,7 @@ import type { RunInfo } from "./core/run.js";
 const packageVersion = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
 ).version as string;
+const TEST_AGENT_NAMES = ["claude", "codex", "rovodev", "opencode", "copilot"];
 
 const stubRunInfo: RunInfo = {
   runId: "run-abc",
@@ -100,7 +101,10 @@ async function runCliWithMocks(
   const orchestratorCtor = vi.fn();
 
   vi.resetModules();
-  vi.doMock("./core/config.js", () => ({ loadConfig }));
+  vi.doMock("./core/config.js", () => ({
+    AGENT_NAMES: TEST_AGENT_NAMES,
+    loadConfig,
+  }));
   vi.doMock("./core/debug-log.js", () => ({
     appendDebugLog,
     initDebugLog,
@@ -308,6 +312,28 @@ describe("cli", () => {
     expect(loadConfig).toHaveBeenCalledWith({ agent: "opencode" });
     expect(createAgent).toHaveBeenCalledWith(
       "opencode",
+      stubRunInfo,
+      undefined,
+      undefined,
+      { includeStopField: false },
+    );
+  });
+
+  it("accepts copilot as an explicit --agent override", async () => {
+    const { loadConfig, createAgent } = await runCliWithMocks(
+      ["ship it", "--agent", "copilot"],
+      {
+        agent: "copilot",
+        agentPathOverride: {},
+        agentArgsOverride: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: false,
+      },
+    );
+
+    expect(loadConfig).toHaveBeenCalledWith({ agent: "copilot" });
+    expect(createAgent).toHaveBeenCalledWith(
+      "copilot",
       stubRunInfo,
       undefined,
       undefined,
@@ -638,7 +664,10 @@ describe("cli", () => {
     );
 
     vi.resetModules();
-    vi.doMock("./core/config.js", () => ({ loadConfig }));
+    vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
+      loadConfig,
+    }));
     vi.doMock("./core/debug-log.js", () => ({
       appendDebugLog: vi.fn(),
       initDebugLog: vi.fn(),
@@ -784,6 +813,7 @@ describe("cli", () => {
     });
     vi.doMock("node:readline", () => ({ createInterface }));
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -912,6 +942,7 @@ describe("cli", () => {
       };
     });
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1044,6 +1075,7 @@ describe("cli", () => {
       createInterface: vi.fn(() => readlineInterface),
     }));
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1171,6 +1203,7 @@ describe("cli", () => {
       createInterface: vi.fn(() => readlineInterface),
     }));
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1295,6 +1328,7 @@ describe("cli", () => {
       })),
     }));
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1394,6 +1428,7 @@ describe("cli", () => {
       })),
     }));
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1583,6 +1618,7 @@ describe("cli", () => {
 
     vi.resetModules();
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1659,6 +1695,7 @@ describe("cli", () => {
 
     vi.resetModules();
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1753,6 +1790,7 @@ describe("cli", () => {
 
     vi.resetModules();
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},
@@ -1868,6 +1906,7 @@ describe("cli", () => {
 
     vi.resetModules();
     vi.doMock("./core/config.js", () => ({
+      AGENT_NAMES: TEST_AGENT_NAMES,
       loadConfig: vi.fn(() => ({
         agent: "claude",
         agentPathOverride: {},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { createInterface } from "node:readline";
 import { Command, InvalidArgumentError } from "commander";
-import { loadConfig } from "./core/config.js";
+import { AGENT_NAMES, loadConfig, type AgentName } from "./core/config.js";
 import {
   appendDebugLog,
   initDebugLog,
@@ -51,6 +51,10 @@ const GNHF_REEXEC_STDIN_PROMPT = "GNHF_REEXEC_STDIN_PROMPT";
 const GNHF_REEXEC_STDIN_PROMPT_FILE = "GNHF_REEXEC_STDIN_PROMPT_FILE";
 const GNHF_REEXEC_STDIN_PROMPT_DIR_PREFIX = "gnhf-stdin-";
 const GNHF_REEXEC_STDIN_PROMPT_FILENAME = "prompt.txt";
+const AGENT_NAME_SET = new Set<string>(AGENT_NAMES);
+const AGENT_NAME_LIST = `"${AGENT_NAMES.slice(0, -1).join('", "')}", or "${
+  AGENT_NAMES[AGENT_NAMES.length - 1]
+}"`;
 
 class PromptSignalError extends Error {
   constructor(public readonly signal: NodeJS.Signals) {
@@ -85,6 +89,10 @@ function humanizeErrorMessage(message: string): string {
   }
 
   return message;
+}
+
+function isAgentName(name: string): name is AgentName {
+  return AGENT_NAME_SET.has(name);
 }
 
 function initializeNewBranch(
@@ -289,10 +297,7 @@ program
   .description("Before I go to bed, I tell my agents: good night, have fun")
   .version(packageVersion)
   .argument("[prompt]", "The objective for the coding agent")
-  .option(
-    "--agent <agent>",
-    "Agent to use (claude, codex, rovodev, or opencode)",
-  )
+  .option("--agent <agent>", `Agent to use (${AGENT_NAMES.join(", ")})`)
   .option(
     "--max-iterations <n>",
     "Abort after N total iterations",
@@ -357,15 +362,9 @@ program
       let promptFromStdin = false;
 
       const agentName = options.agent;
-      if (
-        agentName !== undefined &&
-        agentName !== "claude" &&
-        agentName !== "codex" &&
-        agentName !== "rovodev" &&
-        agentName !== "opencode"
-      ) {
+      if (agentName !== undefined && !isAgentName(agentName)) {
         console.error(
-          `Unknown agent: ${options.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${options.agent}. Use ${AGENT_NAME_LIST}.`,
         );
         process.exit(1);
       }
@@ -373,7 +372,7 @@ program
       const loadedConfig = loadConfig(
         agentName
           ? {
-              agent: agentName as "claude" | "codex" | "rovodev" | "opencode",
+              agent: agentName,
             }
           : {},
       );
@@ -383,14 +382,9 @@ program
           ? {}
           : { preventSleep: options.preventSleep }),
       };
-      if (
-        config.agent !== "claude" &&
-        config.agent !== "codex" &&
-        config.agent !== "rovodev" &&
-        config.agent !== "opencode"
-      ) {
+      if (!isAgentName(config.agent)) {
         console.error(
-          `Unknown agent: ${config.agent}. Use "claude", "codex", "rovodev", or "opencode".`,
+          `Unknown agent: ${config.agent}. Use ${AGENT_NAME_LIST}.`,
         );
         process.exit(1);
       }

--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+import { execFileSync, spawn } from "node:child_process";
+import { CopilotAgent } from "./copilot.js";
+import { buildAgentOutputSchema } from "./types.js";
+
+const mockSpawn = vi.mocked(spawn);
+
+function createMockProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  return proc as typeof proc & ReturnType<typeof spawn>;
+}
+
+function emitJson(proc: ReturnType<typeof createMockProcess>, event: unknown) {
+  proc.stdout.emit("data", Buffer.from(`${JSON.stringify(event)}\n`));
+}
+
+describe("CopilotAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("spawns copilot in non-interactive JSONL mode with the default permission flag", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent({ platform: "win32" });
+
+    agent.run("test prompt", "/work/dir");
+
+    const args = mockSpawn.mock.calls[0]![1] as string[];
+    expect(mockSpawn).toHaveBeenCalledWith("copilot", args, {
+      cwd: "/work/dir",
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    expect(args[0]).toBe("-p");
+    expect(args[1]).toContain("test prompt");
+    expect(args[1]).toContain("gnhf final output contract");
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--output-format",
+        "json",
+        "--stream",
+        "off",
+        "--no-color",
+        "--allow-all",
+      ]),
+    );
+  });
+
+  it("uses a shell on Windows for cmd wrapper paths", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent({
+      bin: "C:\\tools\\copilot.cmd",
+      platform: "win32",
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "C:\\tools\\copilot.cmd",
+      expect.any(Array),
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it("uses a shell on Windows when a bare override resolves to a cmd wrapper", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    vi.mocked(execFileSync).mockReturnValue(
+      "C:\\tools\\copilot-switch.cmd\r\n" as never,
+    );
+    const agent = new CopilotAgent({
+      bin: "copilot-switch",
+      platform: "win32",
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "copilot-switch",
+      expect.any(Array),
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it("passes configured extra args through and suppresses the default permission flag", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent({
+      extraArgs: ["--model", "gpt-5.4", "--allow-all-tools"],
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    const args = mockSpawn.mock.calls[0]![1] as string[];
+    expect(args.slice(0, 3)).toEqual([
+      "--model",
+      "gpt-5.4",
+      "--allow-all-tools",
+    ]);
+    expect(args).not.toContain("--allow-all");
+  });
+
+  it("kills the full process tree on Windows when aborted", async () => {
+    const proc = createMockProcess();
+    Object.defineProperty(proc, "pid", { value: 6789 });
+    mockSpawn.mockReturnValue(proc);
+    const controller = new AbortController();
+    const agent = new CopilotAgent({ platform: "win32" });
+
+    const promise = agent.run("test prompt", "/work/dir", {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("Agent was aborted");
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+      "taskkill",
+      ["/T", "/F", "/PID", "6789"],
+      { stdio: "ignore" },
+    );
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it("parses the final assistant message and accumulates output tokens", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const onMessage = vi.fn();
+    const onUsage = vi.fn();
+    const agent = new CopilotAgent();
+    const content = JSON.stringify({
+      success: true,
+      summary: "ok",
+      key_changes_made: [],
+      key_learnings: [],
+    });
+
+    const promise = agent.run("test prompt", "/work/dir", {
+      onMessage,
+      onUsage,
+    });
+    emitJson(proc, {
+      type: "assistant.message",
+      data: { content, outputTokens: 7 },
+    });
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toEqual({
+      output: {
+        success: true,
+        summary: "ok",
+        key_changes_made: [],
+        key_learnings: [],
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 7,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    });
+    expect(onMessage).toHaveBeenCalledWith(content);
+    expect(onUsage).toHaveBeenCalledWith({
+      inputTokens: 0,
+      outputTokens: 7,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+  });
+
+  it("accepts a fenced JSON final answer", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, {
+      type: "assistant.message",
+      data: {
+        content:
+          '```json\n{"success":true,"summary":"ok","key_changes_made":[],"key_learnings":[]}\n```',
+      },
+    });
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      output: {
+        success: true,
+        summary: "ok",
+      },
+    });
+  });
+
+  it("includes should_fully_stop in the prompt contract when the schema requires it", () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent({
+      schema: buildAgentOutputSchema({ includeStopField: true }),
+    });
+
+    agent.run("test prompt", "/work/dir");
+
+    const args = mockSpawn.mock.calls[0]![1] as string[];
+    expect(args[1]).toContain("should_fully_stop");
+  });
+
+  it("rejects when copilot returns no assistant message", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    proc.emit("close", 0);
+
+    await expect(promise).rejects.toThrow("copilot returned no agent message");
+  });
+
+  it("rejects when the final assistant message is not valid JSON", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, {
+      type: "assistant.message",
+      data: { content: "not json" },
+    });
+    proc.emit("close", 0);
+
+    await expect(promise).rejects.toThrow("Failed to parse copilot output");
+  });
+});

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -1,0 +1,302 @@
+import { execFileSync, spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import {
+  buildAgentOutputSchema,
+  type Agent,
+  type AgentOutput,
+  type AgentOutputSchema,
+  type AgentResult,
+  type AgentRunOptions,
+  type TokenUsage,
+} from "./types.js";
+import {
+  parseJSONLStream,
+  setupAbortHandler,
+  setupChildProcessHandlers,
+} from "./stream-utils.js";
+
+interface CopilotAssistantMessageEvent {
+  type: "assistant.message";
+  data: {
+    content?: string;
+    outputTokens?: number;
+  };
+}
+
+interface CopilotUsageEvent {
+  usage?: Record<string, unknown>;
+}
+
+type CopilotEvent =
+  | CopilotAssistantMessageEvent
+  | (CopilotUsageEvent & { type: string });
+
+interface CopilotAgentDeps {
+  bin?: string;
+  extraArgs?: string[];
+  platform?: NodeJS.Platform;
+  schema?: AgentOutputSchema;
+}
+
+function shouldUseWindowsShell(
+  bin: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== "win32") {
+    return false;
+  }
+
+  if (/\.(cmd|bat)$/i.test(bin)) {
+    return true;
+  }
+
+  if (/[\\/]/.test(bin)) {
+    return false;
+  }
+
+  try {
+    const resolved = execFileSync("where", [bin], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const firstMatch = resolved
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    return firstMatch ? /\.(cmd|bat)$/i.test(firstMatch) : false;
+  } catch {
+    return false;
+  }
+}
+
+function terminateCopilotProcess(
+  child: ReturnType<typeof spawn>,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32" && child.pid) {
+    try {
+      execFileSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Best-effort: the process may have already exited.
+    }
+    return;
+  }
+
+  child.kill("SIGTERM");
+}
+
+function userSpecifiedPermissionMode(userArgs: string[]): boolean {
+  return userArgs.some(
+    (arg) =>
+      arg === "--allow-all" ||
+      arg === "--yolo" ||
+      arg === "--allow-all-tools" ||
+      arg === "--allow-all-paths" ||
+      arg === "--allow-all-urls" ||
+      arg === "--allow-tool" ||
+      arg.startsWith("--allow-tool=") ||
+      arg === "--allow-url" ||
+      arg.startsWith("--allow-url=") ||
+      arg === "--deny-tool" ||
+      arg.startsWith("--deny-tool=") ||
+      arg === "--deny-url" ||
+      arg.startsWith("--deny-url=") ||
+      arg === "--available-tools" ||
+      arg.startsWith("--available-tools=") ||
+      arg === "--excluded-tools" ||
+      arg.startsWith("--excluded-tools="),
+  );
+}
+
+function buildCopilotPrompt(prompt: string, schema: AgentOutputSchema): string {
+  return `${prompt}
+
+## gnhf final output contract
+
+When the iteration is complete, your final answer must be a single JSON object that matches this JSON Schema:
+
+\`\`\`json
+${JSON.stringify(schema, null, 2)}
+\`\`\`
+
+Return only the JSON object in the final answer. Do not wrap it in Markdown. Do not include explanatory prose outside the JSON object.`;
+}
+
+function buildCopilotArgs(
+  prompt: string,
+  schema: AgentOutputSchema,
+  extraArgs?: string[],
+): string[] {
+  const userArgs = extraArgs ?? [];
+
+  return [
+    ...userArgs,
+    "-p",
+    buildCopilotPrompt(prompt, schema),
+    "--output-format",
+    "json",
+    "--stream",
+    "off",
+    "--no-color",
+    ...(userSpecifiedPermissionMode(userArgs) ? [] : ["--allow-all"]),
+  ];
+}
+
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/i);
+  return match?.[1]?.trim() ?? trimmed;
+}
+
+function numberField(
+  usage: Record<string, unknown>,
+  names: string[],
+): number | undefined {
+  for (const name of names) {
+    const value = usage[name];
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function usageFromRecord(usage: Record<string, unknown>): TokenUsage | null {
+  const inputTokens = numberField(usage, ["inputTokens", "input_tokens"]);
+  const outputTokens = numberField(usage, ["outputTokens", "output_tokens"]);
+  const cacheReadTokens = numberField(usage, [
+    "cacheReadTokens",
+    "cache_read_tokens",
+    "cache_read_input_tokens",
+  ]);
+  const cacheCreationTokens = numberField(usage, [
+    "cacheCreationTokens",
+    "cacheWriteTokens",
+    "cache_creation_tokens",
+    "cache_creation_input_tokens",
+    "cache_write_tokens",
+  ]);
+
+  if (
+    inputTokens === undefined &&
+    outputTokens === undefined &&
+    cacheReadTokens === undefined &&
+    cacheCreationTokens === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    cacheReadTokens: cacheReadTokens ?? 0,
+    cacheCreationTokens: cacheCreationTokens ?? 0,
+  };
+}
+
+export class CopilotAgent implements Agent {
+  name = "copilot";
+
+  private bin: string;
+  private extraArgs?: string[];
+  private platform: NodeJS.Platform;
+  private schema: AgentOutputSchema;
+
+  constructor(binOrDeps: string | CopilotAgentDeps = {}) {
+    const deps = typeof binOrDeps === "string" ? { bin: binOrDeps } : binOrDeps;
+    this.bin = deps.bin ?? "copilot";
+    this.extraArgs = deps.extraArgs;
+    this.platform = deps.platform ?? process.platform;
+    this.schema =
+      deps.schema ?? buildAgentOutputSchema({ includeStopField: false });
+  }
+
+  run(
+    prompt: string,
+    cwd: string,
+    options?: AgentRunOptions,
+  ): Promise<AgentResult> {
+    const { onUsage, onMessage, signal, logPath } = options ?? {};
+
+    return new Promise((resolve, reject) => {
+      const logStream = logPath ? createWriteStream(logPath) : null;
+
+      const child = spawn(
+        this.bin,
+        buildCopilotArgs(prompt, this.schema, this.extraArgs),
+        {
+          cwd,
+          shell: shouldUseWindowsShell(this.bin, this.platform),
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        },
+      );
+
+      if (
+        setupAbortHandler(signal, child, reject, () =>
+          terminateCopilotProcess(child, this.platform),
+        )
+      ) {
+        return;
+      }
+
+      let lastAgentMessage: string | null = null;
+      const cumulative: TokenUsage = {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      };
+
+      parseJSONLStream<CopilotEvent>(child.stdout!, logStream, (event) => {
+        if (event.type === "assistant.message") {
+          const data = (event as CopilotAssistantMessageEvent).data;
+          if (typeof data.content === "string") {
+            lastAgentMessage = data.content;
+            onMessage?.(data.content);
+          }
+          if (typeof data.outputTokens === "number") {
+            cumulative.outputTokens += data.outputTokens;
+            onUsage?.({ ...cumulative });
+          }
+        }
+
+        if ("usage" in event && event.usage) {
+          const usage = usageFromRecord(event.usage);
+          if (usage) {
+            cumulative.inputTokens = usage.inputTokens;
+            cumulative.outputTokens = Math.max(
+              cumulative.outputTokens,
+              usage.outputTokens,
+            );
+            cumulative.cacheReadTokens = usage.cacheReadTokens;
+            cumulative.cacheCreationTokens = usage.cacheCreationTokens;
+            onUsage?.({ ...cumulative });
+          }
+        }
+      });
+
+      setupChildProcessHandlers(child, "copilot", logStream, reject, () => {
+        if (!lastAgentMessage) {
+          reject(new Error("copilot returned no agent message"));
+          return;
+        }
+
+        try {
+          const output = JSON.parse(
+            stripJsonFence(lastAgentMessage),
+          ) as AgentOutput;
+          resolve({ output, usage: cumulative });
+        } catch (err) {
+          reject(
+            new Error(
+              `Failed to parse copilot output: ${err instanceof Error ? err.message : err}`,
+            ),
+          );
+        }
+      });
+    });
+  }
+}

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -22,6 +22,17 @@ vi.mock("./codex.js", () => {
   return { CodexAgent };
 });
 
+vi.mock("./copilot.js", () => {
+  const CopilotAgent = vi.fn(function (
+    this: Record<string, unknown>,
+    deps?: Record<string, unknown>,
+  ) {
+    this.name = "copilot";
+    this.deps = deps;
+  });
+  return { CopilotAgent };
+});
+
 vi.mock("./rovodev.js", () => {
   const RovoDevAgent = vi.fn(function (
     this: Record<string, unknown>,
@@ -48,6 +59,7 @@ vi.mock("./opencode.js", () => {
 
 import { createAgent } from "./factory.js";
 import { ClaudeAgent } from "./claude.js";
+import { CopilotAgent } from "./copilot.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
@@ -135,6 +147,46 @@ describe("createAgent", () => {
       extraArgs: undefined,
     });
     expect(agent.name).toBe("codex");
+  });
+
+  it("creates a CopilotAgent when name is 'copilot'", () => {
+    const agent = createAgent("copilot", stubRunInfo, undefined, undefined, {
+      includeStopField: false,
+    });
+    expect(CopilotAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+      schema: noStopSchema,
+    });
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("passes per-agent extra args through to the CopilotAgent", () => {
+    const agent = createAgent(
+      "copilot",
+      stubRunInfo,
+      undefined,
+      ["--model", "gpt-5.4"],
+      { includeStopField: false },
+    );
+
+    expect(CopilotAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: ["--model", "gpt-5.4"],
+      schema: noStopSchema,
+    });
+    expect(agent.name).toBe("copilot");
+  });
+
+  it("hands CopilotAgent a schema that requires should_fully_stop when includeStopField is true", () => {
+    createAgent("copilot", stubRunInfo, undefined, undefined, {
+      includeStopField: true,
+    });
+    expect(CopilotAgent).toHaveBeenCalledWith({
+      bin: undefined,
+      extraArgs: undefined,
+      schema: withStopSchema,
+    });
   });
 
   it("passes per-agent extra args through to the CodexAgent", () => {

--- a/src/core/agents/factory.ts
+++ b/src/core/agents/factory.ts
@@ -2,6 +2,7 @@ import { buildAgentOutputSchema, type Agent } from "./types.js";
 import type { AgentName } from "../config.js";
 import type { RunInfo } from "../run.js";
 import { ClaudeAgent } from "./claude.js";
+import { CopilotAgent } from "./copilot.js";
 import { CodexAgent } from "./codex.js";
 import { OpenCodeAgent } from "./opencode.js";
 import { RovoDevAgent } from "./rovodev.js";
@@ -31,6 +32,12 @@ export function createAgent(
       return new CodexAgent(runInfo.schemaPath, {
         bin: pathOverride,
         extraArgs: agentArgsOverride,
+      });
+    case "copilot":
+      return new CopilotAgent({
+        bin: pathOverride,
+        extraArgs: agentArgsOverride,
+        schema,
       });
     case "opencode":
       return new OpenCodeAgent({

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -22,7 +22,7 @@ const HOME = "/mock-home";
 const CONFIG_DIR = join(HOME, ".gnhf");
 const CONFIG_PATH = join(CONFIG_DIR, "config.yml");
 const BOOTSTRAP_CONFIG_TEMPLATE = (agent: string) =>
-  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort="high"\n#     - --full-auto\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
+  `# Agent to use by default\nagent: ${agent}\n\n# Custom paths to agent binaries (optional)\n# Paths may be absolute, bare executable names on PATH,\n# ~-prefixed, or relative to this config directory.\n# Note: rovodev overrides must point to an acli-compatible binary.\n# agentPathOverride:\n#   claude: /path/to/custom-claude\n#   codex: /path/to/custom-codex\n#   copilot: /path/to/custom-copilot\n\n# Per-agent CLI arg overrides (optional)\n# agentArgsOverride:\n#   codex:\n#     - -m\n#     - gpt-5.4\n#     - -c\n#     - model_reasoning_effort="high"\n#     - --full-auto\n#   copilot:\n#     - --model\n#     - gpt-5.4\n\n# Abort after this many consecutive failures\nmaxConsecutiveFailures: 3\n\n# Prevent the machine from sleeping during a run\npreventSleep: true\n`;
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -182,6 +182,29 @@ describe("loadConfig", () => {
     });
   });
 
+  it("supports bootstrapping copilot as the configured agent", () => {
+    mockReadFileSync.mockImplementation(() => {
+      const error = new Error("ENOENT");
+      Object.assign(error, { code: "ENOENT" });
+      throw error;
+    });
+
+    const config = loadConfig({ agent: "copilot" });
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CONFIG_PATH,
+      BOOTSTRAP_CONFIG_TEMPLATE("copilot"),
+      "utf-8",
+    );
+    expect(config).toEqual({
+      agent: "copilot",
+      agentPathOverride: {},
+      agentArgsOverride: {},
+      maxConsecutiveFailures: 3,
+      preventSleep: true,
+    });
+  });
+
   it("reads config from ~/.gnhf/config.yml", () => {
     mockReadFileSync.mockReturnValue("agent: codex\n");
 
@@ -287,6 +310,9 @@ describe("loadConfig", () => {
         "  opencode:",
         "    - --model",
         "    - gpt-5",
+        "  copilot:",
+        "    - --model",
+        "    - gpt-5.4",
         "",
       ].join("\n"),
     );
@@ -298,6 +324,7 @@ describe("loadConfig", () => {
       codex: ["-m", "gpt-5.4"],
       rovodev: ["--profile", "work"],
       opencode: ["--model", "gpt-5"],
+      copilot: ["--model", "gpt-5.4"],
     });
   });
 
@@ -455,6 +482,16 @@ describe("loadConfig", () => {
 
     expect(() => loadConfig()).toThrow(
       /agentArgsOverride\.rovodev\[0\].*managed by gnhf/,
+    );
+  });
+
+  it("throws when agentArgsOverride.copilot contains gnhf-managed flags", () => {
+    mockReadFileSync.mockReturnValue(
+      "agentArgsOverride:\n  copilot:\n    - --output-format=json\n",
+    );
+
+    expect(() => loadConfig()).toThrow(
+      /agentArgsOverride\.copilot\[0\].*managed by gnhf/,
     );
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,9 +3,15 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
-export type AgentName = "claude" | "codex" | "rovodev" | "opencode";
+export const AGENT_NAMES = [
+  "claude",
+  "codex",
+  "rovodev",
+  "opencode",
+  "copilot",
+] as const;
 
-const AGENT_NAMES = ["claude", "codex", "rovodev", "opencode"] as const;
+export type AgentName = (typeof AGENT_NAMES)[number];
 
 export interface Config {
   agent: AgentName;
@@ -24,6 +30,11 @@ const DEFAULT_CONFIG: Config = {
 };
 
 class InvalidConfigError extends Error {}
+
+function formatAgentNameList(): string {
+  const quoted = AGENT_NAMES.map((name) => `"${name}"`);
+  return `${quoted.slice(0, -1).join(", ")}, or ${quoted[quoted.length - 1]}`;
+}
 
 function normalizePreventSleep(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
@@ -71,6 +82,25 @@ function isReservedAgentArg(agent: AgentName, arg: string): boolean {
         arg === "rovodev" ||
         arg === "serve" ||
         arg === "--disable-session-token"
+      );
+    case "copilot":
+      return (
+        arg === "-p" ||
+        arg === "--prompt" ||
+        arg.startsWith("--prompt=") ||
+        arg === "-i" ||
+        arg === "--interactive" ||
+        arg.startsWith("--interactive=") ||
+        arg === "-s" ||
+        arg === "--silent" ||
+        arg === "--output-format" ||
+        arg.startsWith("--output-format=") ||
+        arg === "--stream" ||
+        arg.startsWith("--stream=") ||
+        arg === "--no-color" ||
+        arg === "--share" ||
+        arg.startsWith("--share=") ||
+        arg === "--share-gist"
       );
   }
 }
@@ -120,7 +150,7 @@ function normalizeAgentPathOverride(
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentPathOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentPathOverride: "${key}". Use ${formatAgentNameList()}.`,
       );
     }
     if (typeof val !== "string") {
@@ -193,7 +223,7 @@ function normalizeAgentArgsOverride(
   )) {
     if (!validNames.has(key)) {
       throw new InvalidConfigError(
-        `Invalid agent name in agentArgsOverride: "${key}". Use "claude", "codex", "rovodev", or "opencode".`,
+        `Invalid agent name in agentArgsOverride: "${key}". Use ${formatAgentNameList()}.`,
       );
     }
     const args = normalizeAgentExtraArgs(
@@ -332,6 +362,7 @@ function serializeConfig(config: Config): string {
     "# agentPathOverride:",
     "#   claude: /path/to/custom-claude",
     "#   codex: /path/to/custom-codex",
+    "#   copilot: /path/to/custom-copilot",
     "",
     "# Per-agent CLI arg overrides (optional)",
     "# agentArgsOverride:",
@@ -341,6 +372,9 @@ function serializeConfig(config: Config): string {
     "#     - -c",
     '#     - model_reasoning_effort="high"',
     "#     - --full-auto",
+    "#   copilot:",
+    "#     - --model",
+    "#     - gpt-5.4",
   ];
 
   if (agentPathOverrideSection) {


### PR DESCRIPTION
## Summary
- add a CopilotAgent adapter that runs `copilot` non-interactively with JSONL output and prompt-level schema instructions
- wire `copilot` through config, CLI validation, and agent factory surfaces
- document Copilot CLI support and conservative token usage mapping

## Notes
Copilot CLI currently exposes assistant output tokens, but not full input/cache token totals in JSONL usage; this PR reports known output tokens and leaves unavailable fields at zero rather than infer them. Upstream tracking: https://github.com/github/copilot-cli/issues/1152

## Tests
- npm run lint
- npm run format:check
- npm run typecheck
- npm test

Closes #79