### PR TITLE
fix(agents): extend Rovo Dev startup timeout

### DIFF
--- a/src/core/agents/rovodev.test.ts
+++ b/src/core/agents/rovodev.test.ts
@@ -311,6 +311,50 @@ describe("RovoDevAgent", () => {
     );
   });
 
+  it("waits 90 seconds for the server to become healthy before timing out", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    try {
+      const proc = createMockProcess();
+      const server = {
+        baseUrl: "http://127.0.0.1:8765",
+        child: proc,
+        cwd: "/repo",
+        detached: true,
+        port: 8765,
+        readyPromise: Promise.resolve(),
+        closed: false,
+        stdout: "",
+        stderr: "",
+      };
+      fetchMock.mockResolvedValue(new Response("not ready", { status: 503 }));
+      let settled = false;
+
+      const promise = agent["waitForHealthy"](server);
+      const expectation = expect(promise).rejects.toThrow(
+        "Timed out waiting for rovodev serve to become ready on port 8765",
+      );
+      promise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(89_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reuses the existing server process across runs", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/rovodev.ts
+++ b/src/core/agents/rovodev.ts
@@ -391,7 +391,7 @@ export class RovoDevAgent implements Agent {
     server: RovoDevServer,
     signal?: AbortSignal,
   ): Promise<void> {
-    const deadline = Date.now() + 30_000;
+    const deadline = Date.now() + 90_000;
     let spawnErrorMessage: string | null = null;
 
     server.child.once("error", (error) => {


### PR DESCRIPTION
## Summary
- Increase the Rovo Dev managed-process startup timeout so slower server launches do not fail prematurely.
- Add targeted Rovo Dev agent coverage for startup timeout handling, validated by `npx vitest run src/core/agents/rovodev.test.ts`.

## Risk Assessment

✅ Low: The change is a narrowly scoped timeout increase for Rovo Dev server startup with no material correctness, security, performance, or simplification issues found in the changed code.

## Testing

- Summary: Exercised the Rovo Dev agent startup, session, shutdown, abort, and new 90 second readiness-timeout boundary; the focused suite passes.
- `npx vitest run src/core/agents/rovodev.test.ts`
- Outcome: ✅ passed across 1 run (1m18s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/agents/rovodev.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
