### PR TITLE
feat(core): add anonymous run telemetry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,9 @@ jobs:
 
       - run: npm run build
         if: ${{ steps.release.outputs.release_created }}
+        env:
+          GNHF_UMAMI_HOST: https://a.kunchenguid.com
+          GNHF_UMAMI_WEBSITE_ID: ${{ vars.GNHF_UMAMI_WEBSITE_ID }}
 
       - run: npm publish --access public --provenance
         if: ${{ steps.release.outputs.release_created }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@ All git invocations go through `execFileSync` with explicit argv. `git.injection
 
 When `preventSleep` is on and the process wasn't already re-exec'd under a sleep-inhibitor, gnhf re-execs itself under `caffeinate` (macOS), `systemd-inhibit` (Linux), or a PowerShell `SetThreadExecutionState` helper (Windows). The re-exec uses `GNHF_SLEEP_INHIBITED=1` as the loop-breaker and `GNHF_REEXEC_STDIN_PROMPT_FILE` to pass piped stdin across the re-exec (the original process writes a 0600 temp file, the child reads and unlinks it).
 
+### Telemetry (`src/core/telemetry.ts`)
+
+Anonymous run summaries POSTed to a self-hosted Umami instance.
+One pageview at run start and one `track("run", ...)` event at the end - never per-iteration, and never with `cwd`, branch slug, prompt content, or anything else that could identify a user or repo.
+Build-time defaults are injected via `tsdown.config.ts`'s `define` from `GNHF_UMAMI_HOST` / `GNHF_UMAMI_WEBSITE_ID`; runtime env vars of the same name override, and `GNHF_TELEMETRY=0|false|off` disables.
+**User-facing docs about telemetry must stay minimal: cover only the opt-out env var (`GNHF_TELEMETRY=0`) and that the data is anonymous. Do not document fields, endpoint, or build-time injection in the README.**
+
 ## Conventions
 
 - ESM-only, `.js` import extensions in TypeScript source (`import { foo } from "./foo.js"`). tsdown bundles it all into `dist/cli.mjs`.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Including a snippet of `gnhf.log` is the single most useful thing you can attach
 
 ## Telemetry
 
-`gnhf` sends one anonymous run summary per invocation to my self-hosted analytics so I can see what's actually getting used.
+`gnhf` sends anonymous usage telemetry to my self-hosted analytics so I can see what's actually getting used.
 No prompts, repo paths, or branch names are sent.
 Set `GNHF_TELEMETRY=0` to turn it off.
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ Every run writes a JSONL debug log to `.gnhf/runs/<runId>/gnhf.log` alongside `n
 
 Including a snippet of `gnhf.log` is the single most useful thing you can attach when filing an issue.
 
+## Telemetry
+
+`gnhf` sends one anonymous run summary per invocation to my self-hosted analytics so I can see what's actually getting used.
+No prompts, repo paths, or branch names are sent.
+Set `GNHF_TELEMETRY=0` to turn it off.
+
 ## Agents
 
 `gnhf` supports six native agents plus ACP targets:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ npm link
                     └──────────────────────────────────────┘
 ```
 
-- **Incremental commits** — each successful iteration is a separate git commit, so you can cherry-pick or revert individual changes
+- **Incremental commits** - each successful iteration is a separate unsigned git commit, so you can cherry-pick or revert individual changes without GPG or SSH signing prompts blocking the run
 - **Failure handling** - all failed iterations are rolled back with `git reset --hard`; agent-reported failures proceed to the next iteration immediately, retryable hard agent errors use exponential backoff, and permanent agent errors such as Claude low credit balance abort immediately and print the run log path. Complete no-op iterations are reported as failures and count toward the consecutive-failure abort limit.
 - **Runtime caps** - `--max-iterations` stops before the next iteration begins, `--max-tokens` can abort mid-iteration once reported usage reaches the cap, and `--stop-when` ends the loop after an iteration whose agent output reports the natural-language condition is met; resumed runs reuse the saved stop condition unless you pass a new value, or `--stop-when ""` to clear it; uncommitted work is rolled back in either case, and in the interactive TUI the final state remains visible until you press Ctrl+C to exit
 - **Iteration finalization** - agents are expected to finish validation, stop any background processes they started, and only then emit the final JSON result for the iteration

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -16,6 +16,20 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const distCliPath = join(repoRoot, "dist", "cli.mjs");
 const fixtureBinDir = join(repoRoot, "e2e", "fixtures");
 
+// Empty gitconfig pointed at by GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM so the
+// developer's real ~/.gitconfig (which may enable commit.gpgsign, set a
+// credential helper, install hooks via core.hooksPath, etc.) cannot affect
+// these tests. Created once per worker; vitest reaps tmpdirs between runs.
+const emptyGitConfigDir = mkdtempSync(join(tmpdir(), "gnhf-e2e-gitconfig-"));
+const emptyGitConfigPath = join(emptyGitConfigDir, "gitconfig");
+writeFileSync(emptyGitConfigPath, "", "utf-8");
+
+const sanitizedGitEnv: NodeJS.ProcessEnv = {
+  GIT_CONFIG_GLOBAL: emptyGitConfigPath,
+  GIT_CONFIG_SYSTEM: emptyGitConfigPath,
+  GIT_TERMINAL_PROMPT: "0",
+};
+
 interface RunResult {
   code: number | null;
   signal: NodeJS.Signals | null;
@@ -24,7 +38,12 @@ interface RunResult {
 }
 
 function git(args: string[], cwd: string): string {
-  return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...sanitizedGitEnv },
+  }).trim();
 }
 
 function createRepo(): string {
@@ -142,6 +161,7 @@ function createTestEnv(
 
   return {
     ...process.env,
+    ...sanitizedGitEnv,
     HOME: home,
     USERPROFILE: home,
     PATH: `${fixtureBinDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ import {
 import { readStdinText } from "./core/stdin.js";
 import { startSleepPrevention } from "./core/sleep.js";
 import { createAgent } from "./core/agents/factory.js";
+import { getDefaultTelemetry, initDefaultTelemetry } from "./core/telemetry.js";
 import {
   getCommitMessageSchemaFields,
   type CommitMessageConfig,
@@ -549,6 +550,15 @@ program
         process.exit(1);
       }
 
+      initDefaultTelemetry({
+        app: "gnhf",
+        version: packageVersion,
+        platform: process.platform,
+        arch: process.arch,
+      });
+      const telemetry = getDefaultTelemetry();
+      const runStartedAt = Date.now();
+
       if (!prompt && process.env.GNHF_SLEEP_INHIBITED === "1") {
         prompt = readReexecStdinPrompt(process.env);
       }
@@ -751,6 +761,17 @@ program
         }
       }
 
+      const runMode: "new" | "resume" | "worktree" = options.worktree
+        ? "worktree"
+        : startIteration > 0
+          ? "resume"
+          : "new";
+
+      telemetry.pageview("/run", {
+        agent: config.agent,
+        mode: runMode,
+      });
+
       initDebugLog(runInfo.logPath);
       appendDebugLog("run:start", {
         args: process.argv.slice(2),
@@ -901,6 +922,24 @@ program
           commitCount: finalState.commitCount,
           worktreePath,
         });
+
+        telemetry.track("run", {
+          agent: config.agent,
+          mode: runMode,
+          status: finalState.status,
+          signal: shutdownSignal ?? undefined,
+          iterations: finalState.currentIteration,
+          success_count: finalState.successCount,
+          fail_count: finalState.failCount,
+          commit_count: finalState.commitCount,
+          total_input_tokens: finalState.totalInputTokens,
+          total_output_tokens: finalState.totalOutputTokens,
+          duration_ms: Date.now() - runStartedAt,
+          prevent_sleep: config.preventSleep === true,
+          commit_message_preset: effectiveCommitMessage?.preset ?? "default",
+          stop_when_set: effectiveStopWhen !== undefined,
+        });
+        await telemetry.close(1_000);
 
         if (finalState.status === "aborted") {
           console.error(`\n  gnhf: Run log: ${runInfo.logPath}\n`);

--- a/src/core/git.test.ts
+++ b/src/core/git.test.ts
@@ -27,6 +27,18 @@ function argsOfCall(index: number): string[] {
   return call[1] as string[];
 }
 
+function optionsOfCall(index: number): {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+} {
+  const call = mockExecFileSync.mock.calls[index];
+  if (!call) throw new Error(`no call at index ${index}`);
+  return (call[2] ?? {}) as {
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+  };
+}
+
 describe("git utilities", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,11 +64,11 @@ describe("git utilities", () => {
       expect(mockExecFileSync).toHaveBeenCalledWith(
         "git",
         ["status", "--porcelain"],
-        {
+        expect.objectContaining({
           cwd: "/my/repo",
           encoding: "utf-8",
           stdio: "pipe",
-        },
+        }),
       );
     });
   });
@@ -67,11 +79,11 @@ describe("git utilities", () => {
       expect(mockExecFileSync).toHaveBeenCalledWith(
         "git",
         ["checkout", "-b", "feature/test"],
-        {
+        expect.objectContaining({
           cwd: "/repo",
           encoding: "utf-8",
           stdio: "pipe",
-        },
+        }),
       );
     });
   });
@@ -136,19 +148,67 @@ describe("git utilities", () => {
     it("stages all files and passes the message as its own argv entry", () => {
       commitAll("initial commit", "/repo");
       expect(argsOfCall(0)).toEqual(["add", "-A"]);
-      expect(argsOfCall(1)).toEqual(["commit", "-m", "initial commit"]);
+      expect(argsOfCall(1)).toEqual([
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "tag.gpgsign=false",
+        "commit",
+        "-m",
+        "initial commit",
+      ]);
+    });
+
+    it("disables GPG signing on the commit so a configured signing key cannot prompt", () => {
+      commitAll("anything", "/repo");
+      const args = argsOfCall(1);
+      expect(args).toContain("commit.gpgsign=false");
+      expect(args).toContain("tag.gpgsign=false");
+      expect(args.indexOf("commit.gpgsign=false")).toBeLessThan(
+        args.indexOf("commit"),
+      );
+    });
+
+    it("preserves shell metacharacters in the message without any escaping", () => {
+      const injection = "feat: `touch /tmp/pwn` && $(evil) \"quoted\" 'tick'";
+      commitAll(injection, "/repo");
+      expect(argsOfCall(1)).toContain(injection);
     });
 
     it("does not throw when there is nothing to commit", () => {
       mockExecFileSync.mockImplementation((_cmd, args) => {
         const argv = args as string[];
-        if (argv[0] === "commit") {
+        if (argv.includes("commit")) {
           throw new Error("nothing to commit");
         }
         return "";
       });
 
       expect(() => commitAll("empty", "/repo")).not.toThrow();
+    });
+  });
+
+  describe("prompt-blocking env vars", () => {
+    it("sets GIT_TERMINAL_PROMPT=0 on every git invocation so HTTPS auth prompts cannot block", () => {
+      ensureCleanWorkingTree("/repo");
+      expect(optionsOfCall(0).env?.GIT_TERMINAL_PROMPT).toBe("0");
+    });
+
+    it("preserves existing process.env keys alongside GIT_TERMINAL_PROMPT", () => {
+      ensureCleanWorkingTree("/repo");
+      const env = optionsOfCall(0).env ?? {};
+      expect(env.PATH).toBe(process.env.PATH);
+      expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    });
+
+    it("keeps GIT_TERMINAL_PROMPT=0 when the caller passes its own env (e.g. LC_ALL)", () => {
+      // getCurrentBranch -> isGitRepository sets LC_ALL=C internally; the
+      // helper must still inject GIT_TERMINAL_PROMPT into that custom env.
+      getCurrentBranch("/repo");
+      // First call is the rev-parse --git-dir probe with LC_ALL=C.
+      const probe = optionsOfCall(0);
+      expect(probe.env?.LC_ALL).toBe("C");
+      expect(probe.env?.GIT_TERMINAL_PROMPT).toBe("0");
     });
   });
 

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -14,17 +14,25 @@ function translateGitError(error: unknown): Error {
 // characters like `, $, ", ', and ; are harmless data rather than executable
 // syntax. Do not add a code path that builds a shell command string from
 // user- or agent-provided input.
+//
+// Always inject GIT_TERMINAL_PROMPT=0 so a misconfigured credential helper
+// or an HTTPS auth challenge can't hang a long-running gnhf loop on a
+// terminal prompt. GPG signing is a separate prompt pathway (pinentry) and
+// is disabled where it matters via `-c commit.gpgsign=false` at the call
+// site (see commitAll), since GIT_TERMINAL_PROMPT does not cover it.
 function git(
   args: string[],
   cwd: string,
   options: { env?: NodeJS.ProcessEnv } = {},
 ): string {
+  const baseEnv = options.env ?? process.env;
+  const env: NodeJS.ProcessEnv = { ...baseEnv, GIT_TERMINAL_PROMPT: "0" };
   try {
     return execFileSync("git", args, {
       cwd,
       encoding: "utf-8",
       stdio: "pipe",
-      ...(options.env ? { env: options.env } : {}),
+      env,
     }).trim();
   } catch (error) {
     throw translateGitError(error);
@@ -117,7 +125,22 @@ export function getBranchCommitCount(baseCommit: string, cwd: string): number {
 export function commitAll(message: string, cwd: string): void {
   git(["add", "-A"], cwd);
   try {
-    git(["commit", "-m", message], cwd);
+    // -c commit.gpgsign=false / tag.gpgsign=false: a user with global
+    // signing enabled would otherwise have every gnhf iteration spawn gpg
+    // and (for a locked agent) wait on a pinentry passphrase prompt that
+    // never arrives in the alt-screen TUI.
+    git(
+      [
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "tag.gpgsign=false",
+        "commit",
+        "-m",
+        message,
+      ],
+      cwd,
+    );
   } catch {
     // Nothing to commit (no changes) -- that's fine
   }

--- a/src/core/telemetry.test.ts
+++ b/src/core/telemetry.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createTelemetryClient,
+  resolveTelemetryConfig,
+  type TelemetryClient,
+} from "./telemetry.js";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function createFetchSpy(options: { delayMs?: number; throws?: Error } = {}): {
+  fetch: typeof fetch;
+  spy: ReturnType<typeof vi.fn>;
+  requests: CapturedRequest[];
+  release: () => void;
+} {
+  const requests: CapturedRequest[] = [];
+  let resolveBlocking: (() => void) | null = null;
+
+  const fetchImpl = vi.fn(
+    async (url: string | URL | Request, init: RequestInit = {}) => {
+      if (options.throws) throw options.throws;
+
+      const headers: Record<string, string> = {};
+      if (init.headers) {
+        for (const [k, v] of Object.entries(
+          init.headers as Record<string, string>,
+        )) {
+          headers[k] = v;
+        }
+      }
+      requests.push({
+        url: typeof url === "string" ? url : url.toString(),
+        method: init.method ?? "GET",
+        headers,
+        body: init.body
+          ? (JSON.parse(init.body as string) as unknown)
+          : undefined,
+      });
+
+      if (options.delayMs !== undefined) {
+        await new Promise<void>((resolve) => {
+          resolveBlocking = resolve;
+          setTimeout(resolve, options.delayMs);
+        });
+      }
+      return new Response(null, { status: 200 });
+    },
+  );
+
+  return {
+    fetch: fetchImpl as unknown as typeof fetch,
+    spy: fetchImpl,
+    requests,
+    release: () => resolveBlocking?.(),
+  };
+}
+
+describe("resolveTelemetryConfig", () => {
+  it("disables telemetry when GNHF_TELEMETRY=0", () => {
+    const config = resolveTelemetryConfig({
+      env: { GNHF_TELEMETRY: "0" },
+      buildHost: "https://build.example",
+      buildWebsiteID: "build-id",
+    });
+    expect(config.enabled).toBe(false);
+  });
+
+  it.each(["false", "off", "FALSE", "Off"])(
+    "disables telemetry when GNHF_TELEMETRY=%s",
+    (value) => {
+      const config = resolveTelemetryConfig({
+        env: { GNHF_TELEMETRY: value },
+        buildHost: "https://build.example",
+        buildWebsiteID: "build-id",
+      });
+      expect(config.enabled).toBe(false);
+    },
+  );
+
+  it("disables when no website ID is configured", () => {
+    const config = resolveTelemetryConfig({
+      env: {},
+      buildHost: "https://build.example",
+      buildWebsiteID: "",
+    });
+    expect(config.enabled).toBe(false);
+  });
+
+  it("uses env vars over build-time defaults", () => {
+    const config = resolveTelemetryConfig({
+      env: {
+        GNHF_UMAMI_HOST: "https://env.example",
+        GNHF_UMAMI_WEBSITE_ID: "env-id",
+      },
+      buildHost: "https://build.example",
+      buildWebsiteID: "build-id",
+    });
+    expect(config.enabled).toBe(true);
+    expect(config.host).toBe("https://env.example");
+    expect(config.websiteID).toBe("env-id");
+  });
+
+  it("falls back to build-time defaults when env vars are unset", () => {
+    const config = resolveTelemetryConfig({
+      env: {},
+      buildHost: "https://build.example",
+      buildWebsiteID: "build-id",
+    });
+    expect(config.enabled).toBe(true);
+    expect(config.host).toBe("https://build.example");
+    expect(config.websiteID).toBe("build-id");
+  });
+
+  it("falls back to the hard-coded host when neither env nor build provide it", () => {
+    const config = resolveTelemetryConfig({
+      env: { GNHF_UMAMI_WEBSITE_ID: "env-id" },
+      buildHost: "",
+      buildWebsiteID: "",
+    });
+    expect(config.enabled).toBe(true);
+    expect(config.host).toBe("https://a.kunchenguid.com");
+  });
+
+  it("trims whitespace around env values", () => {
+    const config = resolveTelemetryConfig({
+      env: {
+        GNHF_UMAMI_HOST: "  https://env.example  ",
+        GNHF_UMAMI_WEBSITE_ID: "  env-id  ",
+      },
+      buildHost: "",
+      buildWebsiteID: "",
+    });
+    expect(config.host).toBe("https://env.example");
+    expect(config.websiteID).toBe("env-id");
+  });
+});
+
+describe("TelemetryClient", () => {
+  let client: TelemetryClient;
+
+  afterEach(async () => {
+    await client?.close(50);
+  });
+
+  it("sends an Umami /api/send POST with the expected payload shape", async () => {
+    const { fetch, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.2.3",
+      platform: "darwin",
+      arch: "arm64",
+      fetch,
+    });
+
+    client.track("run", { agent: "claude", status: "success" });
+    await client.close(500);
+
+    expect(requests).toHaveLength(1);
+    const req = requests[0]!;
+    expect(req.url).toBe("https://a.example.com/api/send");
+    expect(req.method).toBe("POST");
+    expect(req.headers["Content-Type"]).toBe("application/json");
+    expect(req.headers["User-Agent"]).toMatch(/^gnhf\/1\.2\.3 telemetry$/);
+
+    const body = req.body as {
+      type: string;
+      payload: {
+        website: string;
+        hostname: string;
+        title: string;
+        url: string;
+        name: string;
+        data: Record<string, unknown>;
+        timestamp: number;
+      };
+    };
+    expect(body.type).toBe("event");
+    expect(body.payload.website).toBe("site-1");
+    expect(body.payload.hostname).toBe("cli");
+    expect(body.payload.name).toBe("run");
+    expect(body.payload.url).toBe("app://gnhf/run");
+    expect(body.payload.data).toMatchObject({
+      agent: "claude",
+      status: "success",
+    });
+    expect(typeof body.payload.timestamp).toBe("number");
+  });
+
+  it("appends /api/send when host already has a path", async () => {
+    const { fetch, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com/umami/",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    client.track("run", {});
+    await client.close(500);
+
+    expect(requests[0]!.url).toBe("https://a.example.com/umami/api/send");
+  });
+
+  it("treats a host already ending in /api/send as the full endpoint", async () => {
+    const { fetch, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com/api/send",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    client.track("run", {});
+    await client.close(500);
+
+    expect(requests[0]!.url).toBe("https://a.example.com/api/send");
+  });
+
+  it("issues pageviews with the supplied path and no event name", async () => {
+    const { fetch, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    client.pageview("/run", { agent: "codex" });
+    await client.close(500);
+
+    const body = requests[0]!.body as {
+      payload: { url: string; name?: string };
+    };
+    expect(body.payload.url).toBe("/run");
+    expect(body.payload.name).toBeFalsy();
+  });
+
+  it("does nothing when disabled", async () => {
+    const { fetch, spy, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: false,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    client.track("run", { agent: "claude" });
+    client.pageview("/run", {});
+    await client.close(500);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("swallows fetch failures so callers never see them", async () => {
+    const { fetch } = createFetchSpy({ throws: new Error("network down") });
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    expect(() => client.track("run", {})).not.toThrow();
+    await expect(client.close(500)).resolves.toBeUndefined();
+  });
+
+  it("close() waits for in-flight requests up to the timeout", async () => {
+    const { fetch, requests, release } = createFetchSpy({ delayMs: 10_000 });
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    client.track("run", {});
+    const closePromise = client.close(20);
+    await closePromise;
+    expect(requests).toHaveLength(1);
+    release();
+  });
+
+  it("ignores send calls after close()", async () => {
+    const { fetch, spy, requests } = createFetchSpy();
+    client = createTelemetryClient({
+      enabled: true,
+      host: "https://a.example.com",
+      websiteID: "site-1",
+      app: "gnhf",
+      version: "1.0.0",
+      fetch,
+    });
+
+    await client.close(50);
+    client.track("run", {});
+    expect(spy).not.toHaveBeenCalled();
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -1,0 +1,277 @@
+/**
+ * Anonymous usage telemetry for gnhf, sent to a self-hosted Umami instance.
+ *
+ * The wire format mirrors no-mistakes' telemetry: POST /api/send with
+ * { type: "event", payload: { website, hostname, title, url, name, data,
+ * timestamp } }. Events use a synthetic "app://gnhf/<event>" URL so Umami
+ * treats CLI events as distinct pages.
+ *
+ * Layering (highest wins): GNHF_TELEMETRY=0|false|off opt-out, then
+ * GNHF_UMAMI_HOST/GNHF_UMAMI_WEBSITE_ID env vars, then build-time defaults
+ * injected via tsdown's `define`, then a hard-coded host fallback.
+ */
+
+declare const __GNHF_UMAMI_HOST__: string;
+declare const __GNHF_UMAMI_WEBSITE_ID__: string;
+
+const HARDCODED_FALLBACK_HOST = "https://a.kunchenguid.com";
+const UMAMI_PATH = "/api/send";
+const DEFAULT_HOSTNAME = "cli";
+const DEFAULT_TITLE = "gnhf CLI";
+const DEFAULT_REQUEST_TIMEOUT_MS = 1_000;
+
+export type TelemetryFields = Record<string, unknown>;
+
+export interface TelemetryClient {
+  track(name: string, fields?: TelemetryFields): void;
+  pageview(path: string, fields?: TelemetryFields): void;
+  close(timeoutMs?: number): Promise<void>;
+}
+
+export interface TelemetryClientConfig {
+  enabled: boolean;
+  host: string;
+  websiteID: string;
+  app: string;
+  version: string;
+  platform?: string;
+  arch?: string;
+  fetch?: typeof fetch;
+  requestTimeoutMs?: number;
+}
+
+export interface ResolvedTelemetryConfig {
+  enabled: boolean;
+  host: string;
+  websiteID: string;
+}
+
+interface ResolveInput {
+  env: NodeJS.ProcessEnv;
+  buildHost: string;
+  buildWebsiteID: string;
+}
+
+export function resolveTelemetryConfig(
+  input: ResolveInput,
+): ResolvedTelemetryConfig {
+  const optOut = (input.env.GNHF_TELEMETRY ?? "").trim().toLowerCase();
+  if (optOut === "0" || optOut === "false" || optOut === "off") {
+    return { enabled: false, host: "", websiteID: "" };
+  }
+
+  const websiteID =
+    (input.env.GNHF_UMAMI_WEBSITE_ID ?? "").trim() ||
+    input.buildWebsiteID.trim();
+  if (!websiteID) {
+    return { enabled: false, host: "", websiteID: "" };
+  }
+
+  const host =
+    (input.env.GNHF_UMAMI_HOST ?? "").trim() ||
+    input.buildHost.trim() ||
+    HARDCODED_FALLBACK_HOST;
+
+  return { enabled: true, host, websiteID };
+}
+
+export function getBuildTimeUmamiHost(): string {
+  return typeof __GNHF_UMAMI_HOST__ === "string" ? __GNHF_UMAMI_HOST__ : "";
+}
+
+export function getBuildTimeUmamiWebsiteID(): string {
+  return typeof __GNHF_UMAMI_WEBSITE_ID__ === "string"
+    ? __GNHF_UMAMI_WEBSITE_ID__
+    : "";
+}
+
+function normalizeEndpoint(host: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(host.trim());
+  } catch {
+    return null;
+  }
+  if (!url.protocol || !url.host) return null;
+
+  const pathname = url.pathname.replace(/\/+$/, "");
+  if (pathname.endsWith(UMAMI_PATH)) {
+    url.pathname = pathname;
+  } else {
+    url.pathname = pathname + UMAMI_PATH;
+  }
+  return url.toString();
+}
+
+function eventURL(app: string, name: string): string {
+  if (!name) return `app://${app}`;
+  return `app://${app}/${name.replace(/\./g, "/")}`;
+}
+
+function normalizePagePath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) return "/";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+class NoopClient implements TelemetryClient {
+  track(): void {}
+  pageview(): void {}
+  async close(): Promise<void> {}
+}
+
+class HttpClient implements TelemetryClient {
+  private readonly endpoint: string;
+  private readonly websiteID: string;
+  private readonly app: string;
+  private readonly version: string;
+  private readonly userAgent: string;
+  private readonly platform: string;
+  private readonly arch: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly inFlight = new Set<Promise<void>>();
+  private closed = false;
+
+  constructor(endpoint: string, config: TelemetryClientConfig) {
+    this.endpoint = endpoint;
+    this.websiteID = config.websiteID;
+    this.app = config.app;
+    this.version = config.version;
+    this.userAgent = `${config.app}/${config.version} telemetry`;
+    this.platform = config.platform ?? "";
+    this.arch = config.arch ?? "";
+    this.fetchImpl = config.fetch ?? fetch;
+    this.timeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  track(name: string, fields: TelemetryFields = {}): void {
+    if (this.closed) return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    this.send(trimmed, eventURL(this.app, trimmed), fields);
+  }
+
+  pageview(path: string, fields: TelemetryFields = {}): void {
+    if (this.closed) return;
+    this.send("", normalizePagePath(path), fields);
+  }
+
+  async close(timeoutMs = 1_000): Promise<void> {
+    this.closed = true;
+    if (this.inFlight.size === 0) return;
+
+    const drained = Promise.allSettled(Array.from(this.inFlight)).then(
+      () => undefined,
+    );
+    if (timeoutMs <= 0) return;
+    await Promise.race([
+      drained,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, timeoutMs).unref?.();
+      }),
+    ]);
+  }
+
+  private send(name: string, url: string, fields: TelemetryFields): void {
+    const data: Record<string, unknown> = { ...fields };
+    if (this.platform && data.platform === undefined)
+      data.platform = this.platform;
+    if (this.arch && data.arch === undefined) data.arch = this.arch;
+    if (data.version === undefined) data.version = this.version;
+
+    const payload = {
+      type: "event",
+      payload: {
+        website: this.websiteID,
+        hostname: DEFAULT_HOSTNAME,
+        title: DEFAULT_TITLE,
+        url,
+        name,
+        data,
+        timestamp: Math.floor(Date.now() / 1000),
+      },
+    };
+
+    let body: string;
+    try {
+      body = JSON.stringify(payload);
+    } catch {
+      return;
+    }
+
+    const promise = this.fire(body);
+    this.inFlight.add(promise);
+    promise.finally(() => this.inFlight.delete(promise));
+  }
+
+  private async fire(body: string): Promise<void> {
+    try {
+      const response = await this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": this.userAgent,
+        },
+        body,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+      // Drain the body so the connection can be reused.
+      try {
+        await response.body?.cancel?.();
+      } catch {
+        // Ignore.
+      }
+    } catch {
+      // Telemetry is best-effort.
+    }
+  }
+}
+
+export function createTelemetryClient(
+  config: TelemetryClientConfig,
+): TelemetryClient {
+  if (!config.enabled) return new NoopClient();
+  const endpoint = normalizeEndpoint(config.host);
+  if (!endpoint || !config.websiteID) return new NoopClient();
+  return new HttpClient(endpoint, config);
+}
+
+let defaultClient: TelemetryClient | null = null;
+
+export interface DefaultTelemetryInit {
+  app: string;
+  version: string;
+  platform?: string;
+  arch?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function initDefaultTelemetry(
+  init: DefaultTelemetryInit,
+): TelemetryClient {
+  const resolved = resolveTelemetryConfig({
+    env: init.env ?? process.env,
+    buildHost: getBuildTimeUmamiHost(),
+    buildWebsiteID: getBuildTimeUmamiWebsiteID(),
+  });
+  defaultClient = createTelemetryClient({
+    enabled: resolved.enabled,
+    host: resolved.host,
+    websiteID: resolved.websiteID,
+    app: init.app,
+    version: init.version,
+    platform: init.platform,
+    arch: init.arch,
+  });
+  return defaultClient;
+}
+
+export function getDefaultTelemetry(): TelemetryClient {
+  return defaultClient ?? new NoopClient();
+}
+
+/** Test-only: reset the module-level singleton between tests. */
+export function resetDefaultTelemetryForTests(): void {
+  defaultClient = null;
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "tsdown";
 
+const buildUmamiHost = process.env.GNHF_UMAMI_HOST ?? "";
+const buildUmamiWebsiteID = process.env.GNHF_UMAMI_WEBSITE_ID ?? "";
+
 export default defineConfig({
   entry: ["src/cli.ts"],
   format: "esm",
@@ -9,4 +12,8 @@ export default defineConfig({
   clean: true,
   outDir: "dist",
   dts: false,
+  define: {
+    __GNHF_UMAMI_HOST__: JSON.stringify(buildUmamiHost),
+    __GNHF_UMAMI_WEBSITE_ID__: JSON.stringify(buildUmamiWebsiteID),
+  },
 });


### PR DESCRIPTION
## Summary
- Add anonymous telemetry for `gnhf` runs, with start and completion reporting, opt-out via `GNHF_TELEMETRY=0`, and build/runtime Umami configuration.
- Disable GPG signing for automated iteration commits to avoid non-interactive commit hangs, and document that `gnhf` iteration commits are unsigned.
- Update user-facing telemetry docs and add unit/e2e coverage for telemetry and git commit behavior.

## Risk Assessment

⚠️ Medium: The implementation is otherwise bounded, but the telemetry path can leak custom ACP target names despite the anonymous telemetry requirement.

## Testing

- Summary: Exercised the telemetry and git unit tests plus the e2e CLI suite after installing missing dependencies; all selected tests passed on retry.
- `npx vitest run src/core/telemetry.test.ts src/core/git.test.ts`
- `npm run test:e2e`
- Outcome: ✅ passed across 1 run (1m13s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/git.test.ts` - merge conflict rebasing onto origin/main

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/git.ts:132` - `commitAll` now forces `commit.gpgsign=false`, so users or repos that intentionally require signed commits will silently get unsigned gnhf iteration commits instead of honoring their Git policy. If avoiding pinentry hangs is the intended tradeoff, this should be an explicit product decision or opt-out rather than an unconditional override.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/cli.ts:771` - Telemetry sends `config.agent` verbatim, which includes arbitrary `acp:&lt;target&gt;` names; custom ACP target names can identify a private/internal agent setup and weaken the anonymous-telemetry guarantee. Consider normalizing ACP specs to a non-identifying value such as `acp` before sending both the pageview and final run event.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/telemetry.test.ts src/core/git.test.ts`
- `npm run test:e2e`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:276` - The telemetry section says `gnhf` sends one anonymous run summary per invocation, but the implemented behavior sends a pageview at run start and a separate `run` event at completion. Update this user-facing wording to avoid claiming a single summary/request while still keeping the documentation minimal and focused on anonymous telemetry plus the `GNHF_TELEMETRY=0` opt-out.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
