### PR TITLE
fix(renderer): clear terminal title on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You wake up to a branch full of clean work and a log of everything that happened
 
 - **Dead simple** — one command starts an autonomous loop that runs until you request stop or a configured runtime cap is reached
 - **Long running** — each iteration is committed on success, rolled back on failure, with sensible retries; retryable hard agent errors back off exponentially while agent-reported failures continue immediately
-- **Live terminal title** — interactive runs keep your terminal title updated with live status, token totals, and commit count, then restore the previous title on exit
+- **Live terminal title** — interactive runs keep your terminal title updated with live status, token totals, and commit count, then clear or restore it on exit depending on terminal support
 - **Agent-agnostic**: works with Claude Code, Codex, Rovo Dev, OpenCode, GitHub Copilot CLI, Pi, or ACP targets out of the box
 
 ## Quick Start

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -939,7 +939,10 @@ describe("Renderer terminal title", () => {
       await expect(renderer.waitUntilExit()).resolves.toBe("stopped");
 
       const titles = extractTerminalTitles(stdoutWrite);
-      expect(titles.at(-1)).toBe("gnhf stopped · 12K in · 8K out · 12 commits");
+      const meaningfulTitles = titles.filter((t: string) => t !== "");
+      expect(meaningfulTitles.at(-1)).toBe(
+        "gnhf stopped · 12K in · 8K out · 12 commits",
+      );
     } finally {
       restoreStdoutTty();
       restoreStdinTty();
@@ -994,9 +997,20 @@ describe("Renderer terminal title", () => {
     try {
       const renderer = new Renderer(orchestrator, "ship it", "claude", vi.fn());
       renderer.start();
+      stdoutWrite.mockClear();
       renderer.stop();
 
-      expect(extractTitleStackOps(stdoutWrite)).toEqual(["22", "23"]);
+      expect(extractTitleStackOps(stdoutWrite)).toEqual(["23"]);
+      const titles = extractTerminalTitles(stdoutWrite);
+      expect(titles).toContain("");
+      const output = stdoutWrite.mock.calls
+        .map((args: unknown[]) => String(args[0]))
+        .join("");
+      const emptyTitleIdx = output.indexOf(`${titlePrefix}${bell}`);
+      const restoreIdx = output.indexOf(`${escape}[23${titleStackSuffix}`);
+      expect(emptyTitleIdx).toBeGreaterThanOrEqual(0);
+      expect(restoreIdx).toBeGreaterThanOrEqual(0);
+      expect(emptyTitleIdx).toBeLessThan(restoreIdx);
     } finally {
       restoreStdoutTty();
       restoreStdinTty();

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -648,7 +648,11 @@ export class Renderer {
       process.stdin.removeAllListeners("data");
     }
     if (this.titleSaved) {
-      process.stdout.write(restoreTerminalTitle());
+      // Clear the custom title first, then attempt the xterm stack restore.
+      // Many modern terminals (iTerm2, macOS Terminal, Alacritty, Ghostty)
+      // ignore the title save/restore stack, so without the explicit clear
+      // our "gnhf · ..." title would persist after exit.
+      process.stdout.write(emitTerminalTitle("") + restoreTerminalTitle());
       this.titleSaved = false;
       this.prevTitle = null;
     }


### PR DESCRIPTION
## Summary
- Clear the terminal title when the renderer exits before attempting xterm title stack restoration, preventing stale `gnhf` titles in terminals that ignore save/restore sequences.
- Update renderer coverage for title cleanup behavior and refresh the README wording to describe restore-when-supported or clear-on-exit behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to terminal title cleanup on renderer shutdown with focused test coverage and no material correctness or safety issues found.

## Testing

- Summary: Exercised the renderer unit tests covering terminal title updates, title clearing before restore, and non-TTY behavior; all focused tests passed.
- `npx vitest run src/renderer.test.ts`
- Outcome: ✅ passed across 1 run (28.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/renderer.test.ts`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `README.md:49` - The README still says interactive runs &#34;restore the previous title on exit&#34;, but the renderer now deliberately emits an empty title before attempting xterm stack restore because common terminals ignore title save/restore. On those terminals the user-visible fallback is clearing the gnhf title, not restoring the prior title, so the feature description should mention restore-when-supported or clear-on-exit behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
