### PR TITLE
fix(agents): count ACP thought streams as output tokens

### DIFF
--- a/e2e/e2e-acp.test.ts
+++ b/e2e/e2e-acp.test.ts
@@ -207,6 +207,12 @@ describe("gnhf acp e2e", () => {
       // estimate. Catches the bug where `inputTokens` is hardcoded to the
       // raw `used` delta and stays at 0 for adapters that never emit usage.
       expect(Number(iterationEnd?.totalInputTokens)).toBeGreaterThan(0);
+      // Output tokens are estimated from streamed text_delta chars across
+      // both `output` and `thought` streams. The opencode persona in
+      // particular streams ~70% of its text on the thought stream, so this
+      // catches the regression where only `output`-stream chars were
+      // counted and reasoning-heavy adapters sat at 0.
+      expect(Number(iterationEnd?.totalOutputTokens)).toBeGreaterThan(0);
     },
     45_000,
   );

--- a/src/core/agents/acp.test.ts
+++ b/src/core/agents/acp.test.ts
@@ -231,7 +231,7 @@ describe("AcpAgent", () => {
     expect(result.output).toEqual(VALID_OUTPUT);
   });
 
-  it("surfaces tool_call text via onMessage but suppresses noisy status text", async () => {
+  it("suppresses tool_call and status text from onMessage so only assistant prose surfaces", async () => {
     const onMessage = vi.fn();
     const { runtime } = createFakeRuntime([
       {
@@ -254,9 +254,9 @@ describe("AcpAgent", () => {
     await agent.run("p", "/w", { onMessage });
 
     const messages = onMessage.mock.calls.map((args) => args[0] as string);
-    expect(messages).toContain("Read file foo.ts");
-    // Status text is metadata that fires frequently and shouldn't flicker
-    // over the assistant message currently on screen.
+    // Tool descriptions and status metadata are noisy and not useful to
+    // surface in the TUI - only assistant text messages should appear.
+    expect(messages).not.toContain("Read file foo.ts");
     expect(messages).not.toContain("usage updated: 100/1000");
   });
 
@@ -473,7 +473,7 @@ describe("AcpAgent", () => {
     expect(calls).toEqual([json]);
   });
 
-  it("flushes the buffered message on a tool_call boundary so each completed message surfaces once", async () => {
+  it("flushes the buffered message on a tool_call boundary so each completed assistant message surfaces once", async () => {
     const onMessage = vi.fn();
     const json = JSON.stringify(VALID_OUTPUT);
     const { runtime } = createFakeRuntime([
@@ -493,7 +493,9 @@ describe("AcpAgent", () => {
     await agent.run("p", "/w", { onMessage });
 
     const calls = onMessage.mock.calls.map((args) => args[0] as string);
-    expect(calls).toEqual(["Let me examine the code.", "Read foo.ts", json]);
+    // The tool_call boundary flushes the buffered prose but the tool_call
+    // text itself is suppressed.
+    expect(calls).toEqual(["Let me examine the code.", json]);
   });
 
   it("parses the last assistant message rather than concatenating intermediate prose with the final JSON", async () => {
@@ -551,6 +553,40 @@ describe("AcpAgent", () => {
     // ACP only reports a cumulative `used` context value (not split
     // input/output), so we estimate output tokens from streamed bytes.
     expect(result.usage.outputTokens).toBeGreaterThan(0);
+  });
+
+  it("counts thought-stream text toward output tokens so reasoning agents don't sit at 0", async () => {
+    // Regression: agents that stream reasoning before answering (Gemini,
+    // GPT-5 reasoning models, etc.) used to leave the renderer at 0 output
+    // tokens for the entire thinking phase because only `output` stream
+    // chars were counted. Reasoning is real generated text that consumes
+    // output tokens, so it must count too.
+    const onUsage = vi.fn();
+    const longReasoning = "thinking ".repeat(200);
+    const { runtime } = createFakeRuntime([
+      {
+        events: [
+          textDelta(longReasoning, "thought"),
+          textDelta(JSON.stringify(VALID_OUTPUT)),
+        ],
+        result: { status: "completed" },
+      },
+    ]);
+    const agent = makeAgent(runtime);
+
+    const result = await agent.run("p", "/w", { onUsage });
+
+    const reportedOutputs = onUsage.mock.calls.map(
+      (args) => (args[0] as { outputTokens: number }).outputTokens,
+    );
+    // The renderer should have seen the output token count rise during the
+    // thinking phase, before the final JSON arrived.
+    const reasoningPhaseMax = Math.max(
+      0,
+      ...reportedOutputs.slice(0, reportedOutputs.length - 1),
+    );
+    expect(reasoningPhaseMax).toBeGreaterThan(0);
+    expect(result.usage.outputTokens).toBeGreaterThan(reasoningPhaseMax);
   });
 
   it("falls back to a prompt-length input-token estimate when no usage_update events are emitted", async () => {

--- a/src/core/agents/acp.ts
+++ b/src/core/agents/acp.ts
@@ -290,19 +290,27 @@ export class AcpAgent implements Agent {
             }
             pendingStream = stream;
             pendingMessage += text;
+            // Count both output and thought streams toward output tokens -
+            // reasoning is real generated text that consumes tokens. Without
+            // this, agents that stream reasoning before answering (Gemini,
+            // GPT-5, etc.) leave the renderer at 0 output tokens for the
+            // entire thinking phase. outputBuf stays output-only because it
+            // is used for JSON parsing and reasoning text would corrupt it.
             if (stream === "output") {
               outputBuf += text;
-              agentOutputChars += text.length;
-              onUsage?.(computeUsage());
             }
+            agentOutputChars += text.length;
+            onUsage?.(computeUsage());
             continue;
           }
 
           if (event.type === "tool_call") {
-            // A tool_call ends the in-flight message - flush whatever the
-            // assistant has said so far, then surface the tool_call summary.
+            // A tool_call ends the in-flight assistant message - flush
+            // whatever prose the assistant streamed so far, but don't surface
+            // the tool_call text itself. Tool descriptions like
+            // "tool call (completed)" are noisy and not useful in the TUI;
+            // the user wants to see assistant prose, not mechanics.
             flushPendingMessage();
-            if (event.text && event.text.length > 0) onMessage?.(event.text);
             continue;
           }
 


### PR DESCRIPTION
## Summary
- Count ACP `thought` text deltas toward output-token usage so reasoning-heavy adapters report generated-token progress instead of staying at zero.
- Keep structured-output parsing limited to `output` stream text while suppressing tool/status metadata from live assistant messages.
- Add unit and ACP e2e coverage for thought-stream output-token accounting.

## Risk Assessment

⚠️ Medium: The token-counting change is small and well-bounded, but the branch also changes ACP live message visibility in a way that may be intentional yet should be explicitly approved.

## Testing

- Summary: Exercised ACP unit coverage for thought-stream token accounting and tool-call message suppression plus the ACP e2e flow against the built CLI; after installing declared dependencies, all relevant tests passed.
- `npx vitest run src/core/agents/acp.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e-acp.test.ts`
- Outcome: ✅ passed across 1 run (1m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/agents/acp.ts:313` - This drops ACP `tool_call` text from `onMessage`, which is a user-visible behavior change unrelated to the output-token fix and leaves adapters that only emit tool events plus final JSON with no live progress text in the TUI. Please confirm this visibility change is intentional before merging it with the token-counting fix.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/agents/acp.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e-acp.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
