### PR TITLE
fix(core): remove issue marker from default commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ agent: claude
 #   staging: "node /opt/staging/agent.mjs"
 
 # Commit message convention (optional)
-# Defaults to: gnhf #<iteration>: <summary>
+# Defaults to: gnhf <iteration>: <summary>
 # Use the conventional preset for semantic-release compatible headers:
 # commitMessage:
 #   preset: conventional
@@ -253,7 +253,7 @@ You can also pass a raw custom ACP server command directly as a quoted `acp:` sp
 
 `commitMessage` controls the subject line that gnhf uses for each successful iteration commit.
 
-- Omit it to keep the default `gnhf #<iteration>: <summary>` format.
+- Omit it to keep the default `gnhf <iteration>: <summary>` format.
 - Set `preset: conventional` to ask the agent for `type` and optional `scope`, then commit as `type(scope): summary` for semantic-release style workflows. Valid types are `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `test`, and `chore`; invalid or missing types fall back to `chore`, and empty scopes are omitted.
 - The resolved commit-message convention is saved per run, so resuming a `gnhf/` branch keeps the original subject format even if `config.yml` changes later.
 

--- a/e2e/e2e-acp.test.ts
+++ b/e2e/e2e-acp.test.ts
@@ -235,7 +235,7 @@ describe("gnhf acp e2e", () => {
 
       expect(result.code).toBe(0);
       expect(git(["rev-list", "--count", "HEAD"], cwd)).toBe("2");
-      expect(git(["log", "-1", "--format=%s"], cwd)).toContain("gnhf #1:");
+      expect(git(["log", "-1", "--format=%s"], cwd)).toContain("gnhf 1:");
 
       const mockEvents = readJsonLines(mockLogPath).map((e) => e.event);
       expect(mockEvents).toContain("agent:initialize");

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -204,7 +204,7 @@ describe("gnhf e2e", () => {
 
     expect(result.code).toBe(0);
     expect(git(["rev-list", "--count", "HEAD"], cwd)).toBe("2");
-    expect(git(["log", "-1", "--format=%s"], cwd)).toContain("gnhf #1:");
+    expect(git(["log", "-1", "--format=%s"], cwd)).toContain("gnhf 1:");
 
     const startEvent = await waitForLogEvent(mockLogPath, "server:start");
     expect(startEvent.command).toBe("serve");
@@ -317,7 +317,7 @@ describe("gnhf e2e", () => {
 
       // The commit message should follow gnhf format
       expect(git(["log", "-1", "--format=%s"], worktreePath)).toContain(
-        "gnhf #1:",
+        "gnhf 1:",
       );
 
       // Debug log should record worktree info
@@ -397,7 +397,7 @@ describe("gnhf e2e", () => {
       );
       expect(commitsAfterSecond).toBe(commitsAfterFirst + 1);
       expect(git(["log", "-1", "--format=%s"], worktreePath)).toContain(
-        "gnhf #2:",
+        "gnhf 2:",
       );
     },
     60_000,

--- a/src/core/commit-message.test.ts
+++ b/src/core/commit-message.test.ts
@@ -12,7 +12,7 @@ function commitMessageOutput(output: CommitMessageTestOutput): AgentOutput {
 }
 
 describe("buildCommitMessage", () => {
-  it("renders the pre-existing gnhf commit subject when config is omitted", () => {
+  it("renders the default gnhf commit subject without GitHub issue markers", () => {
     const message = buildCommitMessage(
       undefined,
       {
@@ -24,7 +24,7 @@ describe("buildCommitMessage", () => {
       { iteration: 3 },
     );
 
-    expect(message).toBe("gnhf #3: add retry coverage");
+    expect(message).toBe("gnhf 3: add retry coverage");
   });
 
   it("renders a Conventional Commits header with a scope", () => {

--- a/src/core/commit-message.ts
+++ b/src/core/commit-message.ts
@@ -96,7 +96,7 @@ export function buildCommitMessage(
   context: CommitMessageContext,
 ): string {
   if (config === undefined) {
-    return collapseHeader(`gnhf #${context.iteration}: ${output.summary}`);
+    return collapseHeader(`gnhf ${context.iteration}: ${output.summary}`);
   }
 
   const commitOutput = output as AgentOutputWithCommitMessageFields;

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -65,7 +65,7 @@ const BOOTSTRAP_CONFIG_TEMPLATE = (agent: string) =>
     '#   staging: "node /opt/staging/agent.mjs"',
     "",
     "# Commit message convention (optional)",
-    "# Defaults to: gnhf #<iteration>: <summary>",
+    "# Defaults to: gnhf <iteration>: <summary>",
     "# Use Conventional Commits semantic-release headers:",
     "# commitMessage:",
     "#   preset: conventional",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -553,7 +553,7 @@ function serializeConfig(config: Config): string {
     '#   staging: "node /opt/staging/agent.mjs"',
     "",
     "# Commit message convention (optional)",
-    "# Defaults to: gnhf #<iteration>: <summary>",
+    "# Defaults to: gnhf <iteration>: <summary>",
     "# Use Conventional Commits semantic-release headers:",
     "# commitMessage:",
     "#   preset: conventional",

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -168,7 +168,7 @@ describe("Orchestrator output normalization", () => {
       ["learning"],
     );
     expect(mockCommitAll).toHaveBeenCalledTimes(1);
-    expect(mockCommitAll).toHaveBeenCalledWith("gnhf #1: done", "/repo");
+    expect(mockCommitAll).toHaveBeenCalledWith("gnhf 1: done", "/repo");
     expect(orchestrator.getState().status).toBe("aborted");
   });
 


### PR DESCRIPTION
## Summary

- Remove the `#` issue marker from default gnhf iteration commit subjects, changing `gnhf #<iteration>:` to `gnhf <iteration>`.
- Update generated config comments, README docs, and affected unit/e2e expectations to match the new default format.

## Risk Assessment

✅ Low: The change is a small, well-scoped default commit message format update with matching docs and expectations.

## Testing

- Summary: After installing missing dependencies, I exercised default commit message generation plus CLI and ACP e2e commit subjects; the relevant tests passed.
- `npx vitest run src/core/commit-message.test.ts src/core/config.test.ts src/core/orchestrator.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e.test.ts e2e/e2e-acp.test.ts -t "runs one iteration from an argv prompt|runs one iteration in --worktree mode and preserves the worktree with commits|resumes into a preserved worktree on a second invocation with the same prompt|runs one iteration against an ACP target registered via acpRegistryOverrides"`
- Outcome: ✅ passed across 1 run (1m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/commit-message.test.ts src/core/config.test.ts src/core/orchestrator.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e.test.ts e2e/e2e-acp.test.ts -t "runs one iteration from an argv prompt|runs one iteration in --worktree mode and preserves the worktree with commits|resumes into a preserved worktree on a second invocation with the same prompt|runs one iteration against an ACP target registered via acpRegistryOverrides"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
