### PR TITLE
fix(core): keep exit summary within terminal width

### DIFF
--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -238,7 +238,14 @@ describe("gnhf e2e", () => {
 
     const result = await runCli(
       cwd,
-      ["--agent", "opencode", "--max-iterations", "1"],
+      [
+        "--agent",
+        "opencode",
+        "--max-iterations",
+        "1",
+        "--prevent-sleep",
+        "off",
+      ],
       {
         stdin: "ship it from stdin\n",
         env: createTestEnv(mockLogPath, tempDirs),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1002,6 +1002,7 @@ program
           baseRef: runInfo.baseCommit.slice(0, 12) || runInfo.baseCommit,
           diffStats,
           color: shouldUseColor(),
+          terminalColumns: process.stdout.columns,
         });
 
         appendDebugLog("run:complete", {

--- a/src/core/exit-summary.test.ts
+++ b/src/core/exit-summary.test.ts
@@ -135,4 +135,19 @@ describe("renderExitSummary", () => {
       cardLines.every((line) => line.length === cardLines[0]!.length),
     ).toBe(true);
   });
+
+  it("resets color before the right border when truncating colored content", () => {
+    const summary = renderExitSummary({
+      ...baseSummary,
+      branchName:
+        "gnhf/add-responsive-exit-summary-for-extremely-long-branch-names",
+      color: true,
+      terminalColumns: 50,
+    });
+    const subtitleLine = summary
+      .split("\n")
+      .find((line) => line.includes("worked for"));
+
+    expect(subtitleLine).toContain("…\x1b[0m\x1b[2m │");
+  });
 });

--- a/src/core/exit-summary.test.ts
+++ b/src/core/exit-summary.test.ts
@@ -89,4 +89,50 @@ describe("renderExitSummary", () => {
     expect(summary).toContain("\x1b[");
     expect(stripExitSummaryAnsi(summary)).not.toContain("\x1b[");
   });
+
+  it("widens the top card for long branch names", () => {
+    const summary = stripExitSummaryAnsi(
+      renderExitSummary({
+        ...baseSummary,
+        branchName:
+          "gnhf/add-responsive-exit-summary-for-extremely-long-branch-names",
+        color: false,
+        terminalColumns: 100,
+      }),
+    );
+    const cardLines = summary
+      .split("\n")
+      .filter(
+        (line) =>
+          line.startsWith("╭") || line.startsWith("│") || line.startsWith("╰"),
+      );
+    const cardWidth = cardLines[0]!.length;
+
+    expect(cardWidth).toBeGreaterThan(62);
+    expect(cardLines.every((line) => line.length === cardWidth)).toBe(true);
+  });
+
+  it("keeps the top card within narrow terminal width", () => {
+    const summary = stripExitSummaryAnsi(
+      renderExitSummary({
+        ...baseSummary,
+        branchName:
+          "gnhf/add-responsive-exit-summary-for-extremely-long-branch-names",
+        color: false,
+        terminalColumns: 50,
+      }),
+    );
+    const cardLines = summary
+      .split("\n")
+      .filter(
+        (line) =>
+          line.startsWith("╭") || line.startsWith("│") || line.startsWith("╰"),
+      );
+
+    expect(cardLines.length).toBe(4);
+    expect(cardLines.every((line) => line.length <= 50)).toBe(true);
+    expect(
+      cardLines.every((line) => line.length === cardLines[0]!.length),
+    ).toBe(true);
+  });
 });

--- a/src/core/exit-summary.ts
+++ b/src/core/exit-summary.ts
@@ -68,25 +68,28 @@ function truncateVisible(text: string, width: number): string {
   let output = "";
   let visible = 0;
   let index = 0;
+  let hasActiveStyle = false;
+  const finish = () => `${output}…${hasActiveStyle ? "\x1b[0m" : ""}`;
 
   for (const match of text.matchAll(ANSI_TOKEN_RE)) {
     const chunk = text.slice(index, match.index);
     for (const char of chunk) {
-      if (visible >= targetWidth) return `${output}…`;
+      if (visible >= targetWidth) return finish();
       output += char;
       visible += 1;
     }
     output += match[0];
+    hasActiveStyle = match[0] !== "\x1b[0m";
     index = match.index! + match[0].length;
   }
 
   for (const char of text.slice(index)) {
-    if (visible >= targetWidth) return `${output}…`;
+    if (visible >= targetWidth) return finish();
     output += char;
     visible += 1;
   }
 
-  return `${output}…`;
+  return finish();
 }
 
 function formatDuration(ms: number): string {

--- a/src/core/exit-summary.ts
+++ b/src/core/exit-summary.ts
@@ -22,12 +22,15 @@ export interface ExitSummaryOptions {
   baseRef: string;
   diffStats: BranchDiffStats;
   color: boolean;
+  terminalColumns?: number;
 }
 
-const CARD_WIDTH = 60;
+const MIN_CARD_WIDTH = 62;
 const LABEL_WIDTH = 16;
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
+// eslint-disable-next-line no-control-regex
+const ANSI_TOKEN_RE = /\x1b\[[0-9;]*m/g;
 const NO_MISTAKES_URL = "https://github.com/kunchenguid/no-mistakes";
 
 export function stripExitSummaryAnsi(text: string): string {
@@ -55,6 +58,35 @@ function visibleLength(text: string): number {
 
 function padVisible(text: string, width: number): string {
   return text + " ".repeat(Math.max(0, width - visibleLength(text)));
+}
+
+function truncateVisible(text: string, width: number): string {
+  if (visibleLength(text) <= width) return text;
+  if (width <= 0) return "";
+
+  const targetWidth = Math.max(0, width - 1);
+  let output = "";
+  let visible = 0;
+  let index = 0;
+
+  for (const match of text.matchAll(ANSI_TOKEN_RE)) {
+    const chunk = text.slice(index, match.index);
+    for (const char of chunk) {
+      if (visible >= targetWidth) return `${output}…`;
+      output += char;
+      visible += 1;
+    }
+    output += match[0];
+    index = match.index! + match[0].length;
+  }
+
+  for (const char of text.slice(index)) {
+    if (visible >= targetWidth) return `${output}…`;
+    output += char;
+    visible += 1;
+  }
+
+  return `${output}…`;
 }
 
 function formatDuration(ms: number): string {
@@ -96,8 +128,33 @@ function continuationLine(text: string): string {
   return `  ${"".padEnd(LABEL_WIDTH)}${text}`;
 }
 
-function cardLine(content: string, dim: (text: string) => string): string {
-  return `${dim("│ ")}${padVisible(content, CARD_WIDTH - 2)}${dim(" │")}`;
+function resolveCardWidth(
+  contents: string[],
+  terminalColumns?: number,
+): number {
+  const contentWidth = Math.max(...contents.map(visibleLength));
+  const desiredWidth = Math.max(MIN_CARD_WIDTH, contentWidth + 4);
+  const columns =
+    terminalColumns && terminalColumns > 0 ? terminalColumns : undefined;
+  return Math.max(4, columns ? Math.min(desiredWidth, columns) : desiredWidth);
+}
+
+function cardBorder(
+  left: string,
+  right: string,
+  width: number,
+  dim: (text: string) => string,
+): string {
+  return dim(`${left}${"─".repeat(Math.max(0, width - 2))}${right}`);
+}
+
+function cardLine(
+  content: string,
+  width: number,
+  dim: (text: string) => string,
+): string {
+  const contentWidth = Math.max(0, width - 4);
+  return `${dim("│ ")}${padVisible(truncateVisible(content, contentWidth), contentWidth)}${dim(" │")}`;
 }
 
 export function renderExitSummary(options: ExitSummaryOptions): string {
@@ -110,6 +167,8 @@ export function renderExitSummary(options: ExitSummaryOptions): string {
   const subtitle = stopped
     ? `${s.cyan(options.agentName)} ran for ${s.yellow(elapsed)} before: ${options.abortReason ?? options.status}`
     : `${s.cyan(options.agentName)} worked for ${s.yellow(elapsed)} on ${s.magenta(options.branchName)}`;
+  const cardContents = [title, `  ${subtitle}`];
+  const cardWidth = resolveCardWidth(cardContents, options.terminalColumns);
   const rolledBack = `${options.failCount} rolled back`;
   const inputTokens = formatTokenCount(
     options.totalInputTokens,
@@ -126,10 +185,10 @@ export function renderExitSummary(options: ExitSummaryOptions): string {
   const linesDeleted = `-${formatNumber(options.diffStats.linesDeleted)}`;
 
   const lines = [
-    s.dim(`╭${"─".repeat(CARD_WIDTH)}╮`),
-    cardLine(title, s.dim),
-    cardLine(`  ${subtitle}`, s.dim),
-    s.dim(`╰${"─".repeat(CARD_WIDTH)}╯`),
+    cardBorder("╭", "╮", cardWidth, s.dim),
+    cardLine(title, cardWidth, s.dim),
+    cardLine(`  ${subtitle}`, cardWidth, s.dim),
+    cardBorder("╰", "╯", cardWidth, s.dim),
     "",
     metricLine(s.dim("iterations"), [
       `${s.bold(String(options.iterations))} total`,


### PR DESCRIPTION
## Summary
- Clamp exit summary rendering to the current terminal width so final cards do not overflow narrow terminals.
- Add ANSI-aware visible-width truncation and padding so colored content remains aligned with card borders.
- Reset color when truncating colored summaries to prevent ellipses, padding, or borders from inheriting the truncated text color.

## Risk Assessment

✅ Low: The change is narrowly scoped to exit-summary card width and ANSI-safe truncation, with no material issues found in the changed code.

## Testing

- Summary: Exercised the exit summary width/truncation unit coverage and a built successful CLI run through the changed stdout summary call site; all selected tests passed.
- `npx vitest run src/core/exit-summary.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e-cli.test.ts -t "uses config.agent when --agent flag is omitted"`
- Outcome: ✅ passed across 1 run (48.6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/exit-summary.ts:75` - When `truncateVisible` cuts a colored segment, it returns before copying the segment&#39;s closing ANSI reset, so narrow colored summaries can render the ellipsis, padding, and right border with the truncated content color instead of the intended card styling. Append a reset before returning from truncated colored content, or track/replay active styles safely.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/exit-summary.test.ts`
- `npm run build`
- `npx vitest run e2e/e2e-cli.test.ts -t "uses config.agent when --agent flag is omitted"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
