### PR TITLE
fix(core): clarify review link in exit summary

### DIFF
--- a/src/core/exit-summary.test.ts
+++ b/src/core/exit-summary.test.ts
@@ -50,8 +50,9 @@ describe("renderExitSummary", () => {
       "files           7 added       9 updated    2 deleted",
     );
     expect(summary).toContain("next steps      git log --oneline main..HEAD");
-    expect(summary).toContain("too much?       git push no-mistakes:");
-    expect(summary).toContain("https://github.com/kunchenguid/no-mistakes");
+    expect(summary).toContain(
+      "too much        git push no-mistakes:\n  to review?      https://github.com/kunchenguid/no-mistakes",
+    );
     expect(summary).not.toContain("moon log");
   });
 

--- a/src/core/exit-summary.ts
+++ b/src/core/exit-summary.ts
@@ -220,8 +220,8 @@ export function renderExitSummary(options: ExitSummaryOptions): string {
     continuationLine(s.cyan(`git diff --stat ${options.baseRef}..HEAD`)),
     continuationLine(s.cyan("gh pr create")),
     "",
-    commandLine(s.dim("too much?"), `${s.cyan("git push no-mistakes")}:`),
-    continuationLine(s.blueUnderline(NO_MISTAKES_URL)),
+    commandLine(s.dim("too much"), `${s.cyan("git push no-mistakes")}:`),
+    commandLine(s.dim("to review?"), s.blueUnderline(NO_MISTAKES_URL)),
   ];
 
   return `\n${lines.join("\n")}\n`;


### PR DESCRIPTION
## Summary
- Clarify the exit summary wording for no-mistakes review links so users understand where to find the review result.
- Update the exit summary test expectation to match the revised link text.

## Risk Assessment

✅ Low: The change is narrowly scoped to exit-summary wording and its matching assertion, with no substantive control-flow or data-handling risk.

## Testing

- Summary: Exercised the exit summary renderer unit tests covering the revised no-mistakes review link formatting, and the focused suite passed.
- `npx vitest run src/core/exit-summary.test.ts`
- Outcome: ✅ passed across 1 run (22.6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run src/core/exit-summary.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
