### PR TITLE
fix(agents): filter unrelated OpenCode session errors

### DIFF
--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -386,7 +386,9 @@ describe("gnhf e2e", () => {
       | { message?: string }
       | undefined;
     expect(agentError?.message).toContain("OpenCode provider overloaded");
-    expect(agentError?.message).not.toContain("Failed to parse opencode output");
+    expect(agentError?.message).not.toContain(
+      "Failed to parse opencode output",
+    );
 
     // Iteration is recorded as an error (retryable) - which feeds the
     // orchestrator's backoff streak rather than aborting the run.

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -335,6 +335,68 @@ describe("gnhf e2e", () => {
     expect(debugEvents).not.toContain("git:commit:no-verify-fallback");
   }, 30_000);
 
+  it("reports an OpenCode provider overload as a clear retryable error, not a JSON parse failure", async () => {
+    const cwd = createRepo();
+    tempDirs.push(cwd);
+    const logDir = mkdtempSync(join(tmpdir(), "gnhf-e2e-logs-"));
+    tempDirs.push(logDir);
+    const mockLogPath = join(logDir, "mock-opencode.jsonl");
+
+    const result = await runCli(
+      cwd,
+      [
+        "trigger overload",
+        "--agent",
+        "opencode",
+        "--max-iterations",
+        "1",
+        "--prevent-sleep",
+        "off",
+      ],
+      {
+        env: {
+          ...createTestEnv(mockLogPath, tempDirs),
+          GNHF_MOCK_OPENCODE_OVERLOAD: "1",
+        },
+      },
+    );
+
+    expect(result.code).toBe(0);
+
+    const debugLogPath = findRunLogPath(cwd);
+    const debugEntries = readJsonLines(debugLogPath);
+    const debugEvents = debugEntries.map((entry) => entry.event);
+
+    // The overload event must surface under its own debug-log category so
+    // future investigations land in the right place immediately.
+    expect(debugEvents).toContain("opencode:stream:provider-error");
+    const providerErrorEntry = debugEntries.find(
+      (entry) => entry.event === "opencode:stream:provider-error",
+    );
+    expect(providerErrorEntry?.code).toBe("server_is_overloaded");
+    expect(providerErrorEntry?.type).toBe("service_unavailable_error");
+    expect(providerErrorEntry?.retryable).toBe(true);
+
+    // The agent run must record the actual cause, not a JSON parse failure.
+    const agentRunErrorEntry = debugEntries.find(
+      (entry) => entry.event === "agent:run:error",
+    );
+    expect(agentRunErrorEntry).toBeDefined();
+    const agentError = agentRunErrorEntry?.error as
+      | { message?: string }
+      | undefined;
+    expect(agentError?.message).toContain("OpenCode provider overloaded");
+    expect(agentError?.message).not.toContain("Failed to parse opencode output");
+
+    // Iteration is recorded as an error (retryable) - which feeds the
+    // orchestrator's backoff streak rather than aborting the run.
+    expect(debugEvents).toContain("iteration:end");
+    const iterationEnd = debugEntries.find(
+      (entry) => entry.event === "iteration:end",
+    );
+    expect(iterationEnd?.success).toBe(false);
+  }, 30_000);
+
   it("reads the objective from stdin", async () => {
     const cwd = createRepo();
     tempDirs.push(cwd);

--- a/e2e/fixtures/mock-opencode-server.mjs
+++ b/e2e/fixtures/mock-opencode-server.mjs
@@ -78,6 +78,24 @@ function buildStructuredResponse(summary) {
   };
 }
 
+function emitOverloadError(sessionId) {
+  // Reproduces the SSE event shape that surfaced in issue #141. The error
+  // arrives as a top-level (non-payload-wrapped) frame; the rest of the
+  // stream then falls silent without a session.idle.
+  const event = {
+    type: "error",
+    sequence_number: 2,
+    error: {
+      type: "service_unavailable_error",
+      code: "server_is_overloaded",
+      message: "Our servers are currently overloaded. Please try again later.",
+      param: null,
+    },
+  };
+  appendLog("error:overload", { sessionId });
+  broadcast(event);
+}
+
 function emitCompletedEvents(sessionId, summary) {
   const output = buildStructuredResponse(summary);
   broadcast({
@@ -252,6 +270,13 @@ const server = createServer(async (req, res) => {
       req.on("close", () => {
         appendLog("message:closed", { sessionId });
       });
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (process.env.GNHF_MOCK_OPENCODE_OVERLOAD === "1") {
+      emitOverloadError(sessionId);
       res.writeHead(204);
       res.end();
       return;

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -836,7 +836,7 @@ describe("OpenCodeAgent", () => {
     );
   });
 
-  it("rejects when no text part is returned", async () => {
+  it("rejects with 'OpenCode produced no final answer' when the stream ends with no structured output and no final_answer text", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
@@ -860,7 +860,171 @@ describe("OpenCodeAgent", () => {
       .mockResolvedValueOnce(jsonResponse(true));
 
     await expect(agent.run("test", "/repo")).rejects.toThrow(
-      "opencode returned no text output",
+      "OpenCode produced no final answer",
+    );
+  });
+
+  it("does not fall back to reasoning-phase text when no final_answer text was emitted", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-reasoning","type":"text","text":"**Writing a failing test**","metadata":{"openai":{"phase":"commentary"}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).rejects.toThrow(
+      "OpenCode produced no final answer",
+    );
+  });
+
+  it("does not fall back to echoed user-prompt text when no final_answer text was emitted", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    // Simulates OpenCode echoing the user prompt back as a part with no
+    // phase metadata. This used to leak into the fallback parse path and
+    // got reported as `Failed to parse opencode output:` (issue #141).
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-echo","type":"text","text":"please ship the feature"}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).rejects.toThrow(
+      "OpenCode produced no final answer",
+    );
+  });
+
+  it("prefers structured output from message.updated over final_answer text", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          // final_answer text would be unparseable on its own.
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-final","type":"text","text":"not json","metadata":{"openai":{"phase":"final_answer"}}}}}}\n\n',
+          // But message.updated with `info.structured` should win.
+          'data: {"directory":"/repo","payload":{"type":"message.updated","properties":{"sessionID":"session-123","info":{"id":"msg-1","role":"assistant","structured":{"success":true,"summary":"from-structured","key_changes_made":[],"key_learnings":[]},"tokens":{"input":1,"output":1,"cache":{"read":0,"write":0}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    const result = await agent.run("test", "/repo");
+    expect(result.output.summary).toBe("from-structured");
+  });
+
+  it("surfaces a top-level provider-overload error event as a clear retryable error", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    // Reproduces the SSE shape from issue #141: a top-level error frame
+    // with no payload wrapper.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          `data: ${JSON.stringify({
+            type: "error",
+            sequence_number: 2,
+            error: {
+              type: "service_unavailable_error",
+              code: "server_is_overloaded",
+              message:
+                "Our servers are currently overloaded. Please try again later.",
+              param: null,
+            },
+          })}\n\n`,
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).rejects.toThrow(
+      /OpenCode provider overloaded: Our servers are currently overloaded/,
+    );
+  });
+
+  it("does not throw a JSON parse error when an overload event arrives mid-stream alongside reasoning text", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-reasoning","type":"text","text":"**Writing a failing test**","metadata":{"openai":{"phase":"commentary"}}}}}}\n\n',
+          `data: ${JSON.stringify({
+            type: "error",
+            error: {
+              type: "service_unavailable_error",
+              code: "server_is_overloaded",
+              message: "Our servers are currently overloaded.",
+            },
+          })}\n\n`,
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    const error = await agent.run("test", "/repo").then(
+      () => null,
+      (err: unknown) => err as Error,
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toMatch(/OpenCode provider overloaded/);
+    expect(error?.message).not.toMatch(/Failed to parse opencode output/);
+  });
+
+  it("surfaces a payload-wrapped session.error event as a clear error", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          `data: ${JSON.stringify({
+            payload: {
+              type: "session.error",
+              properties: {
+                sessionID: "session-123",
+                error: {
+                  type: "service_unavailable_error",
+                  code: "server_is_overloaded",
+                  message: "wrapped overload",
+                },
+              },
+            },
+          })}\n\n`,
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).rejects.toThrow(
+      /OpenCode provider overloaded: wrapped overload/,
     );
   });
 

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -1028,6 +1028,39 @@ describe("OpenCodeAgent", () => {
     );
   });
 
+  it("ignores payload-wrapped session.error events for other sessions", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          `data: ${JSON.stringify({
+            payload: {
+              type: "session.error",
+              properties: {
+                sessionID: "other-session",
+                error: {
+                  type: "service_unavailable_error",
+                  code: "server_is_overloaded",
+                  message: "other session overload",
+                },
+              },
+            },
+          })}\n\n`,
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-final","type":"text","text":"{\\"success\\":true,\\"summary\\":\\"done\\",\\"key_changes_made\\":[],\\"key_learnings\\":[]}","metadata":{"openai":{"phase":"final_answer"}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    const result = await agent.run("test", "/repo");
+    expect(result.output.summary).toBe("done");
+  });
+
   it("force terminates opencode if shutdown exceeds the timeout", async () => {
     vi.useFakeTimers();
     const proc = createMockProcess();

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -50,15 +50,25 @@ interface OpenCodeSessionResponse {
   id: string;
 }
 
+interface OpenCodeStreamErrorInfo {
+  type?: string;
+  code?: string;
+  message?: string;
+}
+
 interface OpenCodeStreamEvent {
   directory?: string;
+  type?: string;
+  error?: OpenCodeStreamErrorInfo;
   payload?: {
     type?: string;
+    error?: OpenCodeStreamErrorInfo;
     properties?: {
       sessionID?: string;
       field?: string;
       delta?: string;
       partID?: string;
+      error?: OpenCodeStreamErrorInfo;
       part?: {
         id?: string;
         messageID?: string;
@@ -79,6 +89,43 @@ interface OpenCodeStreamEvent {
       };
     };
   };
+}
+
+const RETRYABLE_PROVIDER_ERROR_CODES = new Set(["server_is_overloaded"]);
+const RETRYABLE_PROVIDER_ERROR_TYPES = new Set([
+  "service_unavailable_error",
+  "overloaded_error",
+]);
+
+function extractStreamError(
+  event: OpenCodeStreamEvent,
+): OpenCodeStreamErrorInfo | null {
+  if (event.type === "error" && event.error) {
+    return event.error;
+  }
+  const payload = event.payload;
+  if (!payload) return null;
+  if (payload.type === "error" || payload.type === "session.error") {
+    return payload.error ?? payload.properties?.error ?? null;
+  }
+  return null;
+}
+
+function isRetryableProviderError(error: OpenCodeStreamErrorInfo): boolean {
+  if (error.code && RETRYABLE_PROVIDER_ERROR_CODES.has(error.code)) return true;
+  if (error.type && RETRYABLE_PROVIDER_ERROR_TYPES.has(error.type)) return true;
+  return false;
+}
+
+function buildProviderErrorMessage(error: OpenCodeStreamErrorInfo): string {
+  const detail = error.message ?? error.type ?? error.code ?? "unknown error";
+  if (error.code === "server_is_overloaded") {
+    return `OpenCode provider overloaded: ${detail}`;
+  }
+  if (isRetryableProviderError(error)) {
+    return `OpenCode provider error: ${detail}`;
+  }
+  return `OpenCode provider error: ${detail}`;
 }
 
 interface OpenCodeDeps {
@@ -634,10 +681,10 @@ export class OpenCodeAgent implements Agent {
     };
     const usageByMessageId = new Map<string, TokenUsage>();
     const textParts = new Map<string, OpenCodeTextPartState>();
-    let lastText: string | null = null;
     let lastFinalAnswerText: string | null = null;
     let lastUsageSignature = "0:0:0:0";
     let structuredOutputFromSSE: AgentOutput | null = null;
+    let streamErrorInfo: OpenCodeStreamErrorInfo | null = null;
 
     // Telemetry: capture "what was happening on the stream right up until
     // the failure" so the debug log can answer questions like "did the
@@ -786,7 +833,10 @@ export class OpenCodeAgent implements Agent {
       textParts.set(partId, { text: nextText, phase });
       notePhase(phase);
       if (!trimmed) return;
-      lastText = nextText;
+      // Reasoning-phase text and echoed user-prompt text used to leak into
+      // the fallback parse path and got reported as JSON parse failures
+      // (issue #141). Only assistant final_answer text is a candidate for
+      // structured output - everything else is just transcript noise.
       if (phase === "final_answer") {
         lastFinalAnswerText = nextText;
       }
@@ -794,6 +844,19 @@ export class OpenCodeAgent implements Agent {
     };
 
     const handleEvent = (event: OpenCodeStreamEvent) => {
+      const errorInfo = extractStreamError(event);
+      if (errorInfo) {
+        streamErrorInfo = errorInfo;
+        appendDebugLog("opencode:stream:provider-error", {
+          sessionId,
+          type: errorInfo.type ?? null,
+          code: errorInfo.code ?? null,
+          message: errorInfo.message ?? null,
+          retryable: isRetryableProviderError(errorInfo),
+        });
+        return true;
+      }
+
       const payload = event.payload;
       const properties = payload?.properties;
       if (!properties || properties.sessionID !== sessionId) return false;
@@ -1005,24 +1068,25 @@ export class OpenCodeAgent implements Agent {
       };
     }
 
-    const outputText =
-      toNonEmptyString(lastFinalAnswerText) ?? toNonEmptyString(lastText);
+    if (streamErrorInfo) {
+      throw new Error(buildProviderErrorMessage(streamErrorInfo));
+    }
 
-    if (outputText === null) {
+    const finalOutputText = toNonEmptyString(lastFinalAnswerText);
+
+    if (finalOutputText === null) {
       appendDebugLog("opencode:output:missing", {
         sessionId,
         hasStructuredOutput: structuredOutputFromSSE !== null,
       });
-      throw new Error("opencode returned no text output");
+      throw new Error("OpenCode produced no final answer");
     }
-
-    const finalOutputText = outputText;
 
     try {
       const output = JSON.parse(finalOutputText) as AgentOutput;
       appendDebugLog("opencode:output:structured", {
         sessionId,
-        source: lastFinalAnswerText ? "final_answer" : "last_text",
+        source: "final_answer",
         outputTextLength: finalOutputText.length,
       });
       return {

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -99,6 +99,7 @@ const RETRYABLE_PROVIDER_ERROR_TYPES = new Set([
 
 function extractStreamError(
   event: OpenCodeStreamEvent,
+  sessionId: string,
 ): OpenCodeStreamErrorInfo | null {
   if (event.type === "error" && event.error) {
     return event.error;
@@ -106,6 +107,7 @@ function extractStreamError(
   const payload = event.payload;
   if (!payload) return null;
   if (payload.type === "error" || payload.type === "session.error") {
+    if (payload.properties?.sessionID !== sessionId) return null;
     return payload.error ?? payload.properties?.error ?? null;
   }
   return null;
@@ -844,7 +846,7 @@ export class OpenCodeAgent implements Agent {
     };
 
     const handleEvent = (event: OpenCodeStreamEvent) => {
-      const errorInfo = extractStreamError(event);
+      const errorInfo = extractStreamError(event, sessionId);
       if (errorInfo) {
         streamErrorInfo = errorInfo;
         appendDebugLog("opencode:stream:provider-error", {


### PR DESCRIPTION
## Summary
- Filter payload-wrapped OpenCode stream errors by matching `sessionID` so errors from other sessions do not fail the current run.
- Preserve handling for top-level provider errors without a session id, including overload reporting.
- Add OpenCode unit coverage and an e2e mock-server scenario for provider overload/error handling.

## Risk Assessment

✅ Low: The changes are narrowly scoped to OpenCode SSE output/error handling and add targeted unit/e2e coverage for the altered behavior, with the prior session-filtering issue addressed.

## Testing

- Summary: Exercised the OpenCode agent stream parsing changes and the targeted provider-overload e2e path; all focused tests passed.
- `npx vitest run "src/core/agents/opencode.test.ts"`
- `npm run build`
- `npx vitest run "e2e/e2e.test.ts" -t "reports an OpenCode provider overload"`
- Outcome: ✅ passed across 1 run (35.6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/core/agents/opencode.ts:847` - Payload-wrapped stream errors can include `properties.sessionID`, but this now extracts and records the error before the existing session filter. Because `/global/event` is a global stream, a `session.error` for another session could fail the current run; accept payload-wrapped errors only when their `sessionID` matches, while still allowing top-level provider errors that have no session id.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `npx vitest run "src/core/agents/opencode.test.ts"`
- `npm run build`
- `npx vitest run "e2e/e2e.test.ts" -t "reports an OpenCode provider overload"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `e2e/e2e.test.ts:386` - Prettier reported a formatting issue in the changed file; auto-formatted the assertion wrapping with `npx prettier --write e2e/e2e.test.ts`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
