### PR TITLE
fix(agents): recover Copilot and OpenCode JSON output

### DIFF
--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -205,6 +205,52 @@ describe("CopilotAgent", () => {
     });
   });
 
+  it("recovers JSON when copilot prepends prose before the final object", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, {
+      type: "assistant.message",
+      data: {
+        content:
+          'Good - all tests pass.\n\n{"success":true,"summary":"ok","key_changes_made":[],"key_learnings":[]}',
+      },
+    });
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      output: {
+        success: true,
+        summary: "ok",
+      },
+    });
+  });
+
+  it("recovers fenced JSON when copilot writes prose before the fence", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, {
+      type: "assistant.message",
+      data: {
+        content:
+          'Done.\n\n```json\n{"success":true,"summary":"ok","key_changes_made":[],"key_learnings":[]}\n```',
+      },
+    });
+    proc.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      output: {
+        success: true,
+        summary: "ok",
+      },
+    });
+  });
+
   it("includes should_fully_stop in the prompt contract when the schema requires it", () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/copilot.ts
+++ b/src/core/agents/copilot.ts
@@ -4,11 +4,13 @@ import {
   buildAgentOutputSchema,
   validateAgentOutput,
   type Agent,
+  type AgentOutput,
   type AgentOutputSchema,
   type AgentResult,
   type AgentRunOptions,
   type TokenUsage,
 } from "./types.js";
+import { parseAgentJson } from "./json-extract.js";
 import {
   parseJSONLStream,
   setupAbortHandler,
@@ -144,12 +146,6 @@ function buildCopilotArgs(
   ];
 }
 
-function stripJsonFence(text: string): string {
-  const trimmed = text.trim();
-  const match = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/i);
-  return match?.[1]?.trim() ?? trimmed;
-}
-
 function numberField(
   usage: Record<string, unknown>,
   names: string[],
@@ -194,6 +190,32 @@ function usageFromRecord(usage: Record<string, unknown>): TokenUsage | null {
     cacheReadTokens: cacheReadTokens ?? 0,
     cacheCreationTokens: cacheCreationTokens ?? 0,
   };
+}
+
+function parseCopilotOutput(
+  text: string,
+  schema: AgentOutputSchema,
+): AgentOutput {
+  const parsed = parseAgentJson(text, (value) => {
+    try {
+      validateAgentOutput(value, schema);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (parsed !== null) {
+    return validateAgentOutput(parsed, schema);
+  }
+
+  const fallbackParsed = parseAgentJson(text);
+  if (fallbackParsed !== null) {
+    return validateAgentOutput(fallbackParsed, schema);
+  }
+
+  throw new SyntaxError(
+    "copilot output did not contain a parseable JSON object",
+  );
 }
 
 export class CopilotAgent implements Agent {
@@ -285,10 +307,7 @@ export class CopilotAgent implements Agent {
         }
 
         try {
-          const output = validateAgentOutput(
-            JSON.parse(stripJsonFence(lastAgentMessage)),
-            this.schema,
-          );
+          const output = parseCopilotOutput(lastAgentMessage, this.schema);
           resolve({ output, usage: cumulative });
         } catch (err) {
           reject(

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -836,6 +836,54 @@ describe("OpenCodeAgent", () => {
     );
   });
 
+  it("recovers JSON when final_answer text has a prose preamble", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-final","type":"text","text":"Good - all tests pass.\\n\\n{\\"success\\":true,\\"summary\\":\\"done\\",\\"key_changes_made\\":[],\\"key_learnings\\":[]}","metadata":{"openai":{"phase":"final_answer"}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).resolves.toMatchObject({
+      output: {
+        success: true,
+        summary: "done",
+      },
+    });
+  });
+
+  it("recovers fenced JSON when final_answer text has prose before the fence", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"part-final","type":"text","text":"Done.\\n\\n```json\\n{\\"success\\":true,\\"summary\\":\\"done\\",\\"key_changes_made\\":[],\\"key_learnings\\":[]}\\n```","metadata":{"openai":{"phase":"final_answer"}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ]),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).resolves.toMatchObject({
+      output: {
+        success: true,
+        summary: "done",
+      },
+    });
+  });
+
   it("rejects with 'OpenCode produced no final answer' when the stream ends with no structured output and no final_answer text", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -7,6 +7,7 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { createServer } from "node:net";
 import {
   buildAgentOutputSchema,
+  validateAgentOutput,
   type Agent,
   type AgentOutput,
   type AgentOutputSchema,
@@ -15,6 +16,7 @@ import {
   type TokenUsage,
 } from "./types.js";
 import { appendDebugLog, serializeError } from "../debug-log.js";
+import { parseAgentJson } from "./json-extract.js";
 import { shutdownChildProcess } from "./managed-process.js";
 
 interface OpenCodeMessagePart {
@@ -209,6 +211,32 @@ function buildPrompt(prompt: string, schema: AgentOutputSchema): string {
     "Do not include any prose before or after the JSON.",
     `The JSON must match this schema exactly: ${JSON.stringify(schema)}`,
   ].join("\n");
+}
+
+function parseOpenCodeOutput(
+  text: string,
+  schema: AgentOutputSchema,
+): AgentOutput {
+  const parsed = parseAgentJson(text, (value) => {
+    try {
+      validateAgentOutput(value, schema);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (parsed !== null) {
+    return validateAgentOutput(parsed, schema);
+  }
+
+  const fallbackParsed = parseAgentJson(text);
+  if (fallbackParsed !== null) {
+    return validateAgentOutput(fallbackParsed, schema);
+  }
+
+  throw new SyntaxError(
+    "opencode output did not contain a parseable JSON object",
+  );
 }
 
 /**
@@ -1085,7 +1113,7 @@ export class OpenCodeAgent implements Agent {
     }
 
     try {
-      const output = JSON.parse(finalOutputText) as AgentOutput;
+      const output = parseOpenCodeOutput(finalOutputText, this.schema);
       appendDebugLog("opencode:output:structured", {
         sessionId,
         source: "final_answer",


### PR DESCRIPTION
## Summary
- switch Copilot final-message parsing from raw `JSON.parse` to the shared `parseAgentJson(...)` recovery path
- switch OpenCode `final_answer` fallback parsing to the same shared recovery path
- add Copilot/OpenCode coverage for prose-prefixed JSON and prose-prefixed fenced JSON

## Scope
This intentionally only fixes Copilot and OpenCode, matching the owner suggestion on #147. I did not move `parseAgentJson(...)` outside adapter implementations in this PR. Long-term, that could make sense as a shared post-adapter normalization layer, but it would be a broader abstraction change than this fix needs.

## Local validation
- `npx vitest run src/core/agents/copilot.test.ts src/core/agents/opencode.test.ts`
- I also used the `parseAgentJson(...)`-based local build with GLM 5.1 and deep-v4-flash, and both worked as expected.

Addresses #147

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Local no-mistakes gate ran review, test, document, and lint for this branch. The final upstream push step was blocked by fork permissions, so the branch remains published from Arcadia822/gnhf.