### PR TITLE
ci: update Release Please action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,12 +13,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- update googleapis/release-please-action from v4 to v5
- update the release publish checkout step from actions/checkout@v4 to @v6 for current GitHub Actions runtime hygiene

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-please.yml'); puts 'ok'"
- pnpm exec prettier --check .github/workflows/release-please.yml
- pnpm run build
- git diff --check