### PR TITLE
fix(claude): surface the agent's stdout error on a non-zero exit (#157)

### DIFF
--- a/src/core/agents/claude.test.ts
+++ b/src/core/agents/claude.test.ts
@@ -531,6 +531,38 @@ describe("ClaudeAgent", () => {
     });
   });
 
+  it("surfaces the API error from the stdout result event on a non-zero exit", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const promise = agent.run("prompt", "/cwd");
+
+    // Claude Code reports an API / model error as a stdout `result` event
+    // (is_error + api_error_status + result), writes nothing to stderr, then
+    // exits non-zero. The real cause must reach the rejection, not just the code.
+    emitLine(proc, {
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      api_error_status: 400,
+      result:
+        "API Error (claude-opus-4-8): 400 The provided model identifier is invalid.",
+      usage: {
+        input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+      },
+      structured_output: null,
+    });
+
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(
+      "The provided model identifier is invalid",
+    );
+  });
+
   it("calls onUsage on assistant events", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -32,6 +32,10 @@ interface ClaudeResultEvent {
   type: "result";
   subtype: string;
   is_error?: boolean;
+  // Claude Code surfaces API / model errors HERE on stdout (not stderr): `result`
+  // is the human-readable message, `api_error_status` the HTTP status code.
+  result?: string;
+  api_error_status?: number;
   total_cost_usd: number;
   usage: {
     input_tokens: number;
@@ -391,9 +395,26 @@ export class ClaudeAgent implements Agent {
         }
         logStream?.end();
         if (code !== 0 && !closedAfterFinalCleanup) {
-          const detail = `claude exited with code ${code}: ${stderr}`;
+          // Claude Code writes API / model errors to STDOUT as a `result` event
+          // (is_error / api_error_status / result), not to stderr. So on a non-zero
+          // exit stderr is usually empty and the real cause lives in the captured
+          // result event. Surface it so the failure is diagnosable (e.g. an invalid
+          // --model or a 400 from the provider) instead of a bare exit code.
+          const apiError = resultEvent ?? finalStructuredResultEvent;
+          const apiMessage =
+            apiError?.result ??
+            (apiError?.is_error
+              ? `claude reported an error${
+                  apiError.api_error_status
+                    ? ` (HTTP ${apiError.api_error_status})`
+                    : ""
+                }`
+              : "");
+          const reason =
+            stderr.trim() || apiMessage || "(no stderr or result message)";
+          const detail = `claude exited with code ${code}: ${reason}`;
           reject(
-            isPermanentClaudeError(stderr)
+            isPermanentClaudeError(stderr) || isPermanentClaudeError(apiMessage)
               ? new PermanentAgentError(
                   "claude credit balance too low - see gnhf.log",
                   detail,


### PR DESCRIPTION
Fixes #157.

### Problem
Claude Code writes API / model errors to **stdout** as a stream-json `result` event (`is_error` / `api_error_status` / `result`), not to stderr. The claude adapter's `child.on("close")` built its failure message from `stderr` only, so a non-zero exit produced:

```
claude exited with code 1:
```

with an empty reason. The real cause (e.g. `API Error (claude-opus-4-8): 400 The provided model identifier is invalid.`) was already captured in `resultEvent` but discarded. This made the failure undiagnosable and silently sent the run into the consecutive-failure + exponential-backoff path. (I hit this when a saved model id was invalid for the active provider; every iteration logged a bare `code 1:` for several backoff cycles before aborting.)

### Fix
- Add the two missing fields (`result?`, `api_error_status?`) to `ClaudeResultEvent`.
- On a non-zero exit, surface the captured result event's `result` message (falling back to a status-coded line, then to `(no stderr or result message)`) when stderr is empty.
- Let the `credit balance too low` classifier inspect that message too, since that error can also arrive on the stdout result rather than stderr.

### Test
Adds a regression test: a `result` event with `is_error: true`, `api_error_status: 400`, and a `result` message, followed by a non-zero close, must reject with the API error text (not a bare exit code). All 619 unit tests pass; `tsc`, `eslint`, and `prettier` are clean.

No behaviour change on the success path or for runs that do write to stderr.
