### PR TITLE
fix: preserve worktree with commits on force-shutdown

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3214,6 +3214,60 @@ describe("cli", () => {
     expect(removeWorktree).not.toHaveBeenCalled();
   });
 
+  it("does not remove a worktree with commits when exit handler fires before preservation block", async () => {
+    const removeWorktree = vi.fn();
+    const exitHandlers: (() => void)[] = [];
+    const processOnSpy = vi.spyOn(process, "on");
+    processOnSpy.mockImplementation(((event: string, handler: () => void) => {
+      if (event === "exit") {
+        exitHandlers.push(handler);
+      }
+      return process;
+    }) as typeof process.on);
+
+    try {
+      await runCliWithMocks(
+        ["ship it", "--worktree"],
+        {
+          agent: "claude",
+          agentPathOverride: {},
+          agentArgsOverride: {},
+          acpRegistryOverrides: {},
+          maxConsecutiveFailures: 3,
+          preventSleep: false,
+        },
+        {
+          removeWorktree,
+          orchestratorGetState: vi.fn(() => ({
+            status: "completed" as const,
+            gracefulStopRequested: false,
+            currentIteration: 2,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            commitCount: 3,
+            iterations: [],
+            successCount: 2,
+            failCount: 0,
+            consecutiveFailures: 0,
+            startTime: new Date("2026-01-01T00:00:00Z"),
+            waitingUntil: null,
+            lastMessage: null,
+          })),
+        },
+      );
+
+      // Simulate what happens on force-shutdown: exit handlers fire
+      // before the normal preservation block nulls out worktreeCleanup
+      for (const handler of exitHandlers) {
+        handler();
+      }
+
+      expect(removeWorktree).not.toHaveBeenCalled();
+    } finally {
+      processOnSpy.mockRestore();
+    }
+  });
+
   it("resumes a preserved suffixed worktree instead of creating another one", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "gnhf-cli-worktree-resume-"));
     const repoRoot = join(tempDir, "repo");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -695,7 +695,9 @@ program
       let effectiveCwd = cwd;
       let worktreePath: string | null = null;
       let worktreeCleanup: (() => void) | null = null;
-      let getOrchestratorState: (() => ReturnType<Orchestrator["getState"]>) | null = null;
+      let getOrchestratorState:
+        | (() => ReturnType<Orchestrator["getState"]>)
+        | null = null;
 
       const currentBranch = getCurrentBranch(cwd);
       const onGnhfBranch = currentBranch.startsWith("gnhf/");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -695,6 +695,7 @@ program
       let effectiveCwd = cwd;
       let worktreePath: string | null = null;
       let worktreeCleanup: (() => void) | null = null;
+      let getOrchestratorState: (() => ReturnType<Orchestrator["getState"]>) | null = null;
 
       const currentBranch = getCurrentBranch(cwd);
       const onGnhfBranch = currentBranch.startsWith("gnhf/");
@@ -765,11 +766,25 @@ program
           // Ensure worktree cleanup runs even if die() or process.exit() is
           // called before reaching the normal cleanup block (e.g. orchestrator
           // crash to .catch to die to process.exit(1)).
+          // However, preserve worktrees that already have commits — the
+          // normal preservation block (worktreeCleanup = null) may not have
+          // run yet when force-shutdown or timeout triggers process.exit().
           const exitCleanup = worktreeCleanup;
           process.on("exit", () => {
-            if (worktreeCleanup === exitCleanup) {
-              exitCleanup();
+            if (worktreeCleanup !== exitCleanup) return;
+            try {
+              const state = getOrchestratorState?.();
+              if (
+                state &&
+                (state.commitCount > 0 || state.hasPendingCommitFailure)
+              ) {
+                return;
+              }
+            } catch {
+              // Orchestrator not yet created or already torn down — safe to
+              // clean up since no iteration could have committed anything.
             }
+            exitCleanup();
           });
         }
       } else if (options.currentBranch) {
@@ -980,6 +995,7 @@ program
           ...(options.push ? { push: true } : {}),
         },
       );
+      getOrchestratorState = () => orchestrator.getState();
       let shutdownSignal: NodeJS.Signals | null = null;
       let forceShutdownRequested = false;
 


### PR DESCRIPTION
Closes #167

## Problem

When using `--worktree`, if the process exits via force-shutdown (double Ctrl+C or graceful-shutdown timeout), the worktree directory is deleted even though it contains commits that should be preserved.

**Root cause:** The `process.on("exit")` handler at line ~769 unconditionally calls `removeWorktree()` when `worktreeCleanup` hasn't been nulled out. But the force-shutdown path (`process.exit(130)` at line ~1068) fires _before_ the normal preservation block at line ~1158 can set `worktreeCleanup = null`.

## Fix

The exit handler now queries `orchestrator.getState()` before deciding to clean up. If `commitCount > 0` or `hasPendingCommitFailure` is true, the worktree is preserved regardless of whether the normal code path ran.

A `getOrchestratorState` closure variable is introduced to give the early-registered exit handler access to the orchestrator instance that's created later.

## Changes

- **`src/cli.ts`**: Exit handler checks orchestrator state; added `getOrchestratorState` variable
- **`src/cli.test.ts`**: New test verifying exit handler preserves worktree when commits exist

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 56 unit tests pass (e2e tests skipped — require external agent binaries)
- [x] New test: "does not remove a worktree with commits when exit handler fires before preservation block"