### PR TITLE
feat: add --sign-commits flag for optional git commit signing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -595,6 +595,11 @@ program
     false,
   )
   .option(
+    "--sign-commits",
+    "Allow git commit signing (default: off to avoid pinentry prompts)",
+    false,
+  )
+  .option(
     "--meteor-frequency <n>",
     "Meteor frequency from 0 to 5 (0 disables, 3 is default)",
     parseMeteorFrequency,
@@ -613,6 +618,7 @@ program
         worktree: boolean;
         currentBranch: boolean;
         push: boolean;
+        signCommits: boolean;
         meteorFrequency: number;
         mock: boolean;
       },
@@ -950,6 +956,7 @@ program
         worktreePath,
         currentBranch: options.currentBranch,
         push: options.push,
+        signCommits: options.signCommits,
         platform: process.platform,
         nodeVersion: process.version,
         gnhfVersion: packageVersion,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -79,6 +79,7 @@ export interface Config {
   commitMessage?: CommitMessageConfig;
   maxConsecutiveFailures: number;
   preventSleep: boolean;
+  signCommits?: boolean;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -88,6 +89,7 @@ const DEFAULT_CONFIG: Config = {
   acpRegistryOverrides: {},
   maxConsecutiveFailures: 3,
   preventSleep: true,
+  signCommits: false,
 };
 
 const ACP_TARGET_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -235,16 +235,16 @@ export function getBranchDiffStats(
   return stats;
 }
 
-export function commitAll(message: string, cwd: string): void {
+export function commitAll(message: string, cwd: string, signCommits?: boolean): void {
   // -c commit.gpgsign=false / tag.gpgsign=false: a user with global
   // signing enabled would otherwise have every gnhf iteration spawn gpg
   // and (for a locked agent) wait on a pinentry passphrase prompt that
-  // never arrives in the alt-screen TUI.
+  // never arrives in the alt-screen TUI. When signCommits is true,
+  // these flags are omitted so the user's git config is honored.
+  const useSign = signCommits === true;
   const commitArgs = [
-    "-c",
-    "commit.gpgsign=false",
-    "-c",
-    "tag.gpgsign=false",
+    ...(useSign ? [] : ["-c", "commit.gpgsign=false"]),
+    ...(useSign ? [] : ["-c", "tag.gpgsign=false"]),
     "commit",
     "-m",
     message,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -76,6 +76,7 @@ export interface RunLimits {
   maxTokens?: number;
   stopWhen?: string;
   push?: boolean;
+  signCommits?: boolean;
 }
 
 const STOP_CLOSE_AGENT_GRACE_MS = 250;
@@ -589,6 +590,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           iteration: this.state.currentIteration,
         }),
         this.cwd,
+        this.limits.signCommits,
       );
     } catch (error) {
       if (error instanceof CommitFailedError) {


### PR DESCRIPTION
Fixes #151

Adds a `--sign-commits` CLI flag and `signCommits` config field. When enabled, gnhf omits the `-c commit.gpgsign=false` / `-c tag.gpgsign=false` flags so the user's git signing config is honored.

**Changes:**
- `src/core/config.ts`: added `signCommits` field (default `false`)
- `src/core/git.ts`: `commitAll()` accepts optional `signCommits` param
- `src/core/orchestrator.ts`: passes `RunLimits.signCommits` to `commitAll`
- `src/cli.ts`: added `--sign-commits` flag