### PR TITLE
fix: preserve worktree on force-shutdown timeout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1065,6 +1065,11 @@ program
           console.error(
             `\n  gnhf: shutdown timed out after ${FORCE_EXIT_TIMEOUT_MS / 1000}s, forcing exit\n`,
           );
+          // Preserve worktree on forced exit — the normal commitCount check
+          // at line ~1152 never runs from this code path.
+          if (worktreePath) {
+            worktreeCleanup = null;
+          }
           process.exit(getSignalExitCode(shutdownSignal ?? "SIGINT"));
         }
       } finally {


### PR DESCRIPTION
Fixes #167

On force-shutdown (double Ctrl+C or shutdown timeout), `process.exit(130)` was called at line 1067 before the worktree preservation check (commitCount > 0) at line 1152 ever ran. This caused the worktree to be deleted even when it contained commits.

Fix: set `worktreeCleanup = null` before the early exit path so the worktree is always preserved on forced shutdown. Users can manually clean up with `git worktree remove`.