### PR TITLE
fix: add per-request timeout to opencode health check

### DIFF
--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -269,9 +269,9 @@ describe("OpenCodeAgent", () => {
     );
 
     expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
-    expect(requestSignals.every((signal) => signal instanceof AbortSignal)).toBe(
-      true,
-    );
+    expect(
+      requestSignals.every((signal) => signal instanceof AbortSignal),
+    ).toBe(true);
   });
 
   it("strips OpenCode server auth env vars from the spawned child", async () => {

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -240,6 +240,40 @@ describe("OpenCodeAgent", () => {
     expect(agent.name).toBe("opencode");
   });
 
+  it("bounds each health check with a per-request timeout so a hanging fetch honors the readiness deadline", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const requestSignals: Array<AbortSignal | undefined> = [];
+    fetchMock.mockImplementation((_url, init?: RequestInit) => {
+      const signal = init?.signal ?? undefined;
+      requestSignals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(signal.reason ?? new Error("aborted")),
+          { once: true },
+        );
+      });
+    });
+
+    const bounded = new OpenCodeAgent({
+      fetch: fetchMock as typeof fetch,
+      getPort,
+      healthCheckDeadlineMs: 300,
+      healthCheckRequestTimeoutMs: 40,
+    });
+
+    await expect(bounded.run("test prompt", tempDir)).rejects.toThrow(
+      /Timed out waiting for opencode serve to become ready/,
+    );
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    expect(requestSignals.every((signal) => signal instanceof AbortSignal)).toBe(
+      true,
+    );
+  });
+
   it("strips OpenCode server auth env vars from the spawned child", async () => {
     process.env.OPENCODE_SERVER_USERNAME = "local-user";
     process.env.OPENCODE_SERVER_PASSWORD = "local-pass";

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -141,6 +141,8 @@ interface OpenCodeDeps {
   platform?: NodeJS.Platform;
   schema?: AgentOutputSchema;
   spawn?: typeof spawn;
+  healthCheckDeadlineMs?: number;
+  healthCheckRequestTimeoutMs?: number;
 }
 
 interface OpenCodeServer {
@@ -186,6 +188,9 @@ type MessageRequestResult =
 const BLANKET_PERMISSION_RULESET = [
   { permission: "*", pattern: "*", action: "allow" },
 ] as const;
+
+const DEFAULT_HEALTH_CHECK_DEADLINE_MS = 30_000;
+const DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_MS = 5_000;
 
 function buildStructuredOutputFormat(schema: AgentOutputSchema) {
   return {
@@ -351,6 +356,8 @@ export class OpenCodeAgent implements Agent {
   private platform: NodeJS.Platform;
   private schema: AgentOutputSchema;
   private spawnFn: typeof spawn;
+  private healthCheckDeadlineMs: number;
+  private healthCheckRequestTimeoutMs: number;
   private server: OpenCodeServer | null = null;
   private closingPromise: Promise<void> | null = null;
 
@@ -364,6 +371,11 @@ export class OpenCodeAgent implements Agent {
     this.schema =
       deps.schema ?? buildAgentOutputSchema({ includeStopField: false });
     this.spawnFn = deps.spawn ?? spawn;
+    this.healthCheckDeadlineMs =
+      deps.healthCheckDeadlineMs ?? DEFAULT_HEALTH_CHECK_DEADLINE_MS;
+    this.healthCheckRequestTimeoutMs =
+      deps.healthCheckRequestTimeoutMs ??
+      DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_MS;
   }
 
   async run(
@@ -609,7 +621,7 @@ export class OpenCodeAgent implements Agent {
     server: OpenCodeServer,
     signal?: AbortSignal,
   ): Promise<void> {
-    const deadline = Date.now() + 30_000;
+    const deadline = Date.now() + this.healthCheckDeadlineMs;
     let spawnErrorMessage: string | null = null;
 
     server.child.once("error", (error) => {
@@ -635,7 +647,10 @@ export class OpenCodeAgent implements Agent {
       }
 
       try {
-        const perRequestSignal = withTimeoutSignal(signal, 5_000);
+        const perRequestSignal = withTimeoutSignal(
+          signal,
+          this.healthCheckRequestTimeoutMs,
+        );
         const response = await this.fetchFn(`${server.baseUrl}/global/health`, {
           method: "GET",
           signal: perRequestSignal,

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -635,9 +635,10 @@ export class OpenCodeAgent implements Agent {
       }
 
       try {
+        const perRequestSignal = withTimeoutSignal(signal, 5_000);
         const response = await this.fetchFn(`${server.baseUrl}/global/health`, {
           method: "GET",
-          signal,
+          signal: perRequestSignal,
         });
         if (response.ok) return;
       } catch (error) {


### PR DESCRIPTION
## Problem

The health check in `waitForHealthy` calls `fetch()` without a per-request timeout. When the `opencode serve` process accepts the TCP connection but doesn't respond in time, Node.js's built-in fetch (undici) blocks for up to ~300 seconds by default, completely bypassing the 30-second deadline in the while loop.

This causes gnhf to hang for 5 minutes on the first iteration instead of timing out after 30 seconds.

## Fix

Compose a 5-second `AbortSignal.timeout()` with the external signal using the existing `withTimeoutSignal` helper, so each health poll attempt gives up after 5 seconds. This allows the while loop to iterate and properly enforce the 30-second overall deadline.

This is the same pattern already used by the `request()` helper for all other HTTP calls in this file.