### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Intent

Roll out only the captain-authorized canonical two-hunk PR-body compliance-event policy from kunchenguid/no-mistakes#558 to gnhf's .github/workflows/no-mistakes-required.yml. Add the exact canonical run-name and immutable opened/edited concurrency grouping while preserving synchronize/reopened head-change coalescing, cancel-in-progress true, pull_request fork boundary, contents read permissions, no secrets/checkout/write permissions, stable check name, signature marker, all three bot exemptions, and every repository-specific line outside those hunks. The only tracked diff must be that workflow. Create an unmerged PR titled exactly 'fix: execute every PR body compliance event' and drive review, tests, lint, push, PR, and CI green without merging.

## What Changed

- Adds a descriptive run name that identifies the PR, event action, run number, and run ID.
- Gives each `opened` and `edited` event an immutable concurrency group so every PR body compliance check executes, while preserving coalescing for `synchronize` and `reopened` head-change events.

## Risk Assessment

✅ Low: The one-file change exactly matches the canonical two-hunk workflow policy from kunchenguid/no-mistakes#558 while preserving all required repository-specific behavior and security boundaries.

## Testing

The exact canonical two-hunk change passed a focused same-head success/failure/success replay plus trigger, concurrency, permission, marker, check-name, and bot-exemption checks; transcript evidence was saved and temporary dependencies cleaned up. No screenshot was applicable because this is a non-rendered GitHub workflow. The branch is not pushed and no PR or CI run exists, so rollout validation remains blocked.

<details>
<summary>Evidence: Three-event PR body compliance replay</summary>

```text
# PR body compliance event replay - gnhf

Parsed and executed the real shell step from `.github/workflows/no-mistakes-required.yml`.
All events use PR #549 and the same unchanged head.

| Run ID | Run number | Action | Concurrency group | Terminal result |
| ---: | ---: | --- | --- | --- |
| 41001 | 901 | opened | `no-mistakes-required-549-41001` | success |
| 41002 | 902 | edited | `no-mistakes-required-549-41002` | failure |
| 41003 | 903 | edited | `no-mistakes-required-549-41003` | success |

Head-change groups:

- synchronize: `no-mistakes-required-549-head-change`
- reopened: `no-mistakes-required-549-head-change`

## Reviewer-visible run titles

- PR #549 body compliance - opened - event 901 (run 41001)
- PR #549 body compliance - edited - event 902 (run 41002)
- PR #549 body compliance - edited - event 903 (run 41003)

## Actual compliance-step output

### opened / success

`` `text
Found no-mistakes signature in PR #549 body.
`` `

### edited / failure

`` `text
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: first-time-fork-contributor
`` `

### edited / success

`` `text
Found no-mistakes signature in PR #549 body.
`` `

## Contract checks

- exact `pull_request` event boundary for opened, edited, synchronize, and reopened on main
- contents read only, with no secrets, checkout, or write permissions
- stable check name and exact signature marker
- all three bot exemptions
- immutable opened/edited groups, preserved head-change coalescing, and `cancel-in-progress: true`
```
</details>
- Outcome: ⚠️ 1 error across 1 run (3m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 The required rollout is incomplete: the branch is absent from origin and GitHub reports no PR for it. Therefore, the required unmerged PR and green PR CI cannot be validated.
- `git diff --stat 6bfdcca98cfc227dec0cbe2a51b007e4252287f2..1bea27ed0e66acb04cadd6e5633bcf26e1c1d21e`
- `git diff --unified=80 6bfdcca98cfc227dec0cbe2a51b007e4252287f2..1bea27ed0e66acb04cadd6e5633bcf26e1c1d21e -- .github/workflows/no-mistakes-required.yml`
- `gh-axi pr diff 558 --repo kunchenguid/no-mistakes`
- <code>`git hash-object .github/workflows/no-mistakes-required.yml` compared with canonical blob `f61f96f9bdc2ae63c8fe33229e439c17e529267e`</code>
- <code>`pnpm install --frozen-lockfile` to restore locked harness dependencies</code>
- `Focused Node/js-yaml contract harness executing the workflow's real shell step for signed opened, unsigned edited, and signed edited events on one unchanged head`
- `git ls-remote --heads origin fm/gnhf-body-compliance-events-rollout-p1`
- `gh-axi pr list --repo kunchenguid/gnhf --head kunchenguid:fm/gnhf-body-compliance-events-rollout-p1`
- <code>Removed the transient `node_modules` directory and confirmed the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
