### PR TITLE
feat: add --score-command metric gate with keep/discard and non-improving stop

### DIFF
--- a/e2e/e2e-metric-gate.test.ts
+++ b/e2e/e2e-metric-gate.test.ts
@@ -1,0 +1,295 @@
+import { execFileSync, spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distCliPath = join(repoRoot, "dist", "cli.mjs");
+const fixtureBinDir = join(repoRoot, "e2e", "fixtures");
+
+// Empty gitconfig pointed at by GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM so the
+// developer's real ~/.gitconfig cannot affect these tests.
+const emptyGitConfigDir = mkdtempSync(join(tmpdir(), "gnhf-e2e-gitconfig-"));
+const emptyGitConfigPath = join(emptyGitConfigDir, "gitconfig");
+writeFileSync(emptyGitConfigPath, "", "utf-8");
+
+const sanitizedGitEnv: NodeJS.ProcessEnv = {
+  GIT_CONFIG_GLOBAL: emptyGitConfigPath,
+  GIT_CONFIG_SYSTEM: emptyGitConfigPath,
+  GIT_TERMINAL_PROMPT: "0",
+};
+
+interface RunResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...sanitizedGitEnv },
+  }).trim();
+}
+
+// The score script is committed into the fixture repo so `git reset --hard`
+// after a rejected iteration keeps it around. It scores the workspace by
+// README.md byte length: the mock opencode agent appends one marker line per
+// iteration, so the score strictly increases while changes are kept.
+function createRepo(scoreScript: string): string {
+  const cwd = mkdtempSync(join(tmpdir(), "gnhf-e2e-metric-"));
+  git(["init", "-b", "main"], cwd);
+  git(["config", "user.name", "gnhf tests"], cwd);
+  git(["config", "user.email", "tests@example.com"], cwd);
+  writeFileSync(join(cwd, "README.md"), "# fixture\n", "utf-8");
+  writeFileSync(join(cwd, "score.mjs"), scoreScript, "utf-8");
+  git(["add", "README.md", "score.mjs"], cwd);
+  git(["commit", "-m", "init"], cwd);
+  return cwd;
+}
+
+const README_LENGTH_SCORE = [
+  'import { readFileSync } from "node:fs";',
+  'process.stdout.write(String(readFileSync("README.md", "utf-8").length));',
+  "",
+].join("\n");
+
+const UNPARSEABLE_SCORE = 'process.stdout.write("not-a-number\\n");\n';
+
+function readJsonLines(filePath: string): Record<string, unknown>[] {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf-8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+/** Each test creates a fresh repo, so there is exactly one run dir. */
+function findRunDir(cwd: string): string {
+  const runsDir = join(cwd, ".gnhf", "runs");
+  const runs = existsSync(runsDir) ? readdirSync(runsDir) : [];
+  if (runs.length !== 1) {
+    throw new Error(
+      `Expected exactly one run in ${runsDir}, found ${runs.length}: ${runs.join(", ")}`,
+    );
+  }
+  return join(runsDir, runs[0]!);
+}
+
+function runCli(
+  cwd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<RunResult> {
+  // Promise.withResolvers is unavailable under this repo's TS lib target;
+  // the executor form matches the sibling e2e files.
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [distCliPath, ...args], {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      resolveResult({ code, signal, stdout, stderr });
+    });
+    child.stdin.end();
+  });
+}
+
+function createTestEnv(
+  mockLogPath: string,
+  tempDirs: string[],
+): NodeJS.ProcessEnv {
+  const home = mkdtempSync(join(tmpdir(), "gnhf-e2e-metric-home-"));
+  tempDirs.push(home);
+
+  return {
+    ...process.env,
+    ...sanitizedGitEnv,
+    HOME: home,
+    USERPROFILE: home,
+    PATH: `${fixtureBinDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+    GNHF_MOCK_OPENCODE_LOG_PATH: mockLogPath,
+  };
+}
+
+describe("gnhf metric gate e2e", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      try {
+        rmSync(dir, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 200,
+        });
+      } catch {
+        // Windows: child processes may still hold file locks briefly after exit
+      }
+    }
+  });
+
+  function setup(scoreScript: string): { cwd: string; mockLogPath: string } {
+    const cwd = createRepo(scoreScript);
+    tempDirs.push(cwd);
+    const logDir = mkdtempSync(join(tmpdir(), "gnhf-e2e-metric-logs-"));
+    tempDirs.push(logDir);
+    return { cwd, mockLogPath: join(logDir, "mock-opencode.jsonl") };
+  }
+
+  it("commits each iteration whose score strictly improves and persists the best metric", async () => {
+    const { cwd, mockLogPath } = setup(README_LENGTH_SCORE);
+
+    const result = await runCli(
+      cwd,
+      [
+        "grow the README",
+        "--agent",
+        "opencode",
+        "--max-iterations",
+        "2",
+        "--score-command",
+        "node score.mjs",
+        "--score-direction",
+        "max",
+      ],
+      createTestEnv(mockLogPath, tempDirs),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("max iterations reached (2)");
+    // init + two gated commits
+    expect(git(["rev-list", "--count", "HEAD"], cwd)).toBe("3");
+    expect(git(["log", "-1", "--format=%s"], cwd)).toContain("gnhf 2:");
+
+    const runDir = findRunDir(cwd);
+    const bestMetric = Number(
+      readFileSync(join(runDir, "best-metric"), "utf-8").trim(),
+    );
+    // Best score persisted after iteration 2 equals the committed README size.
+    expect(bestMetric).toBe(readFileSync(join(cwd, "README.md"), "utf-8").length);
+
+    const events = readJsonLines(join(runDir, "gnhf.log")).map(
+      (entry) => entry.event,
+    );
+    expect(events).toContain("metric:gate:accepted");
+    expect(events).not.toContain("metric:gate:rejected");
+  }, 30_000);
+
+  it("rejects non-improving scores: no commit, worktree reset, run stops after N in a row", async () => {
+    const { cwd, mockLogPath } = setup(README_LENGTH_SCORE);
+
+    const result = await runCli(
+      cwd,
+      [
+        "shrink the README",
+        "--agent",
+        "opencode",
+        "--max-iterations",
+        "6",
+        "--score-command",
+        "node score.mjs",
+        // The mock agent only ever grows README.md, so with "min" every
+        // iteration after the first baseline is strictly worse.
+        "--score-direction",
+        "min",
+        "--stop-after-non-improving",
+        "2",
+      ],
+      createTestEnv(mockLogPath, tempDirs),
+    );
+
+    expect(result.code).toBe(0);
+    // Distinct metric-gate stop reason, not max-iterations and not the
+    // consecutive-failures abort.
+    expect(result.stdout).toContain(
+      "metric gate: 2 consecutive non-improving iterations",
+    );
+    expect(result.stdout).not.toContain("max iterations reached");
+
+    // Only the baseline iteration committed: init + 1.
+    expect(git(["rev-list", "--count", "HEAD"], cwd)).toBe("2");
+    // Rejected iterations were reset: the working tree is clean and README
+    // holds exactly the one committed mock change.
+    expect(git(["status", "--porcelain"], cwd)).toBe("");
+    const readme = readFileSync(join(cwd, "README.md"), "utf-8");
+    expect(readme.match(/- mock change /g)).toHaveLength(1);
+
+    const runDir = findRunDir(cwd);
+    // Best metric stays the baseline score from the single committed iteration.
+    const bestMetric = Number(
+      readFileSync(join(runDir, "best-metric"), "utf-8").trim(),
+    );
+    expect(bestMetric).toBe(readme.length);
+
+    const events = readJsonLines(join(runDir, "gnhf.log")).map(
+      (entry) => entry.event,
+    );
+    expect(events).toContain("metric:gate:accepted");
+    expect(events).toContain("metric:gate:rejected");
+  }, 30_000);
+
+  it("treats an unparseable score as non-improving without crashing", async () => {
+    const { cwd, mockLogPath } = setup(UNPARSEABLE_SCORE);
+
+    const result = await runCli(
+      cwd,
+      [
+        "objective with a broken score command",
+        "--agent",
+        "opencode",
+        "--max-iterations",
+        "6",
+        "--score-command",
+        "node score.mjs",
+        "--score-direction",
+        "max",
+        "--stop-after-non-improving",
+        "2",
+      ],
+      createTestEnv(mockLogPath, tempDirs),
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(
+      "metric gate: 2 consecutive non-improving iterations",
+    );
+
+    // Nothing ever committed and no best metric was recorded.
+    expect(git(["rev-list", "--count", "HEAD"], cwd)).toBe("1");
+    expect(git(["status", "--porcelain"], cwd)).toBe("");
+    const runDir = findRunDir(cwd);
+    expect(existsSync(join(runDir, "best-metric"))).toBe(false);
+
+    const events = readJsonLines(join(runDir, "gnhf.log")).map(
+      (entry) => entry.event,
+    );
+    expect(events).toContain("metric:score:parse-failed");
+    expect(events).not.toContain("metric:gate:accepted");
+  }, 30_000);
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -46,6 +46,8 @@ const stubRunInfo: RunInfo = {
   baseCommitPath: "/repo/.gnhf/runs/run-abc/base-commit",
   stopWhenPath: "/repo/.gnhf/runs/run-abc/stop-when",
   stopWhen: undefined,
+  bestMetricPath: "/repo/.gnhf/runs/run-abc/best-metric",
+  bestMetric: undefined,
   commitMessagePath: "/repo/.gnhf/runs/run-abc/commit-message",
   commitMessage: undefined,
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,12 @@ import { Command, InvalidArgumentError } from "commander";
 import {
   AGENT_NAMES,
   isAgentSpec,
+  isScoreDirection,
   loadConfig,
   redactAgentSpecForLogs,
   type AgentName,
   type AgentSpec,
+  type ScoreDirection,
 } from "./core/config.js";
 import {
   appendDebugLog,
@@ -104,6 +106,19 @@ function parseMeteorFrequency(value: string): number {
     );
   }
   return parsed;
+}
+
+function parsePositiveInteger(value: string): number {
+  const parsed = parseNonNegativeInteger(value);
+  if (parsed < 1) {
+    throw new InvalidArgumentError("must be a positive integer");
+  }
+  return parsed;
+}
+
+function parseScoreDirection(value: string): ScoreDirection {
+  if (isScoreDirection(value)) return value;
+  throw new InvalidArgumentError('must be "min" or "max"');
 }
 
 function parseOnOffBoolean(value: string): boolean {
@@ -575,6 +590,20 @@ program
     'End when the agent reports this condition, after any commit-failure repair; resumes reuse it, pass a new value to overwrite or "" to clear',
   )
   .option(
+    "--score-command <command>",
+    "Shell command that prints a single numeric score; a successful iteration is committed only when the score strictly improves",
+  )
+  .option(
+    "--score-direction <direction>",
+    'Direction of score improvement: "min" or "max" (required with --score-command)',
+    parseScoreDirection,
+  )
+  .option(
+    "--stop-after-non-improving <n>",
+    "Stop the run after N consecutive non-improving iterations (default 3)",
+    parsePositiveInteger,
+  )
+  .option(
     "--prevent-sleep <mode>",
     'Prevent system sleep during the run ("on" or "off")',
     parseOnOffBoolean,
@@ -609,6 +638,9 @@ program
         maxIterations?: number;
         maxTokens?: number;
         stopWhen?: string;
+        scoreCommand?: string;
+        scoreDirection?: ScoreDirection;
+        stopAfterNonImproving?: number;
         preventSleep?: boolean;
         worktree: boolean;
         currentBranch: boolean;
@@ -666,10 +698,28 @@ program
         ...(options.preventSleep === undefined
           ? {}
           : { preventSleep: options.preventSleep }),
+        ...(options.scoreCommand === undefined
+          ? {}
+          : { scoreCommand: options.scoreCommand }),
+        ...(options.scoreDirection === undefined
+          ? {}
+          : { scoreDirection: options.scoreDirection }),
+        ...(options.stopAfterNonImproving === undefined
+          ? {}
+          : { stopAfterNonImproving: options.stopAfterNonImproving }),
       };
       if (!isAgentSpec(config.agent)) {
         console.error(
           `Unknown agent: ${config.agent}. Use ${AGENT_SPEC_LIST}.`,
+        );
+        process.exit(1);
+      }
+      if (
+        config.scoreCommand !== undefined &&
+        config.scoreDirection === undefined
+      ) {
+        console.error(
+          '--score-direction ("min" or "max") is required when --score-command is set.',
         );
         process.exit(1);
       }
@@ -941,6 +991,9 @@ program
         maxIterations: options.maxIterations,
         maxTokens: options.maxTokens,
         stopWhen: effectiveStopWhen,
+        scoreCommand: config.scoreCommand,
+        scoreDirection: config.scoreDirection,
+        stopAfterNonImproving: config.stopAfterNonImproving,
         commitMessage: effectiveCommitMessage,
         preventSleep: config.preventSleep,
         agentArgsOverride: getNativeAgentName(config.agent)

--- a/src/core/agents/factory.test.ts
+++ b/src/core/agents/factory.test.ts
@@ -102,6 +102,8 @@ const stubRunInfo: RunInfo = {
   baseCommitPath: "/repo/.gnhf/runs/test-run/base-commit",
   stopWhenPath: "/repo/.gnhf/runs/test-run/stop-when",
   stopWhen: undefined,
+  bestMetricPath: "/repo/.gnhf/runs/test-run/best-metric",
+  bestMetric: undefined,
   commitMessagePath: "/repo/.gnhf/runs/test-run/commit-message",
   commitMessage: undefined,
 };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -71,6 +71,12 @@ export function redactAgentSpecForLogs(spec: string): string {
   return `acp:${redactAcpTargetForLogs(spec.slice("acp:".length))}`;
 }
 
+export type ScoreDirection = "min" | "max";
+
+export function isScoreDirection(value: unknown): value is ScoreDirection {
+  return value === "min" || value === "max";
+}
+
 export interface Config {
   agent: AgentSpec;
   agentPathOverride: Partial<Record<AgentName, string>>;
@@ -79,6 +85,15 @@ export interface Config {
   commitMessage?: CommitMessageConfig;
   maxConsecutiveFailures: number;
   preventSleep: boolean;
+  // Metric gate: shell command that prints a single number on stdout. When
+  // set, a successful iteration is committed only when the score strictly
+  // improves on the run's best (per scoreDirection); otherwise the iteration
+  // is treated as a failure and the worktree is reset.
+  scoreCommand?: string;
+  scoreDirection?: ScoreDirection;
+  // Stop the run after this many consecutive non-improving iterations
+  // (defaults to 3 when unset).
+  stopAfterNonImproving?: number;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -449,6 +464,43 @@ function normalizeConfig(
     }
   } else {
     delete normalized.commitMessage;
+  }
+
+  if (config.scoreCommand === undefined) {
+    delete normalized.scoreCommand;
+  } else if (
+    typeof config.scoreCommand !== "string" ||
+    config.scoreCommand.trim().length === 0
+  ) {
+    throw new InvalidConfigError(
+      `Invalid config value for scoreCommand: ${String(config.scoreCommand)}`,
+    );
+  } else {
+    normalized.scoreCommand = config.scoreCommand;
+  }
+
+  if (config.scoreDirection === undefined) {
+    delete normalized.scoreDirection;
+  } else if (!isScoreDirection(config.scoreDirection)) {
+    throw new InvalidConfigError(
+      `Invalid config value for scoreDirection: ${String(config.scoreDirection)} (use "min" or "max")`,
+    );
+  } else {
+    normalized.scoreDirection = config.scoreDirection;
+  }
+
+  if (config.stopAfterNonImproving === undefined) {
+    delete normalized.stopAfterNonImproving;
+  } else if (
+    typeof config.stopAfterNonImproving !== "number" ||
+    !Number.isInteger(config.stopAfterNonImproving) ||
+    config.stopAfterNonImproving < 1
+  ) {
+    throw new InvalidConfigError(
+      `Invalid config value for stopAfterNonImproving: ${String(config.stopAfterNonImproving)} (use a positive integer)`,
+    );
+  } else {
+    normalized.stopAfterNonImproving = config.stopAfterNonImproving;
   }
 
   return normalized;

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -79,6 +79,8 @@ const runInfo: RunInfo = {
   baseCommitPath: "/repo/.gnhf/runs/run-abc/base-commit",
   stopWhenPath: "/repo/.gnhf/runs/run-abc/stop-when",
   stopWhen: undefined,
+  bestMetricPath: "/repo/.gnhf/runs/run-abc/best-metric",
+  bestMetric: undefined,
   commitMessagePath: "/repo/.gnhf/runs/run-abc/commit-message",
   commitMessage: undefined,
 };

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { join } from "node:path";
 import {
@@ -8,7 +9,7 @@ import {
 } from "./agents/types.js";
 import { redactAgentSpecForLogs, type Config } from "./config.js";
 import type { RunInfo } from "./run.js";
-import { appendNotes, toStringArray } from "./run.js";
+import { appendNotes, toStringArray, writeBestMetric } from "./run.js";
 import { appendDebugLog, serializeError } from "./debug-log.js";
 import {
   CommitFailedError,
@@ -90,6 +91,26 @@ type RunIterationResult =
   | { type: "stopped" }
   | { type: "aborted"; reason: string };
 
+interface MetricGateOutcome {
+  improved: boolean;
+  score: number | undefined;
+  summary: string;
+}
+
+// The score command may print progress noise before the result; the last
+// non-empty stdout line is the score. Anything non-numeric is a parse
+// failure, which the gate treats as non-improving rather than crashing.
+function parseScoreOutput(stdout: string): number | undefined {
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const last = lines[lines.length - 1];
+  if (last === undefined) return undefined;
+  const value = Number(last);
+  return Number.isFinite(value) ? value : undefined;
+}
+
 export class Orchestrator extends EventEmitter<OrchestratorEvents> {
   private config: Config;
   private agent: Agent;
@@ -106,6 +127,8 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
   private activeIterationTokensEstimated = false;
   private loopDone = false;
   private stoppedEventEmitted = false;
+  private bestMetric: number | undefined;
+  private consecutiveNonImproving = 0;
 
   private state: Omit<
     OrchestratorState,
@@ -146,6 +169,7 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
     this.cwd = cwd;
     this.limits = limits;
     this.state.currentIteration = startIteration;
+    this.bestMetric = runInfo.bestMetric;
     this.state.commitCount = getBranchCommitCount(
       this.runInfo.baseCommit,
       this.cwd,
@@ -352,6 +376,17 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
           break;
         }
 
+        const stopAfterNonImproving = this.config.stopAfterNonImproving ?? 3;
+        if (
+          this.config.scoreCommand !== undefined &&
+          this.consecutiveNonImproving >= stopAfterNonImproving
+        ) {
+          this.abort(
+            `metric gate: ${stopAfterNonImproving} consecutive non-improving iterations`,
+          );
+          break;
+        }
+
         const postIterationAbortReason = this.getPostIterationAbortReason();
         if (postIterationAbortReason) {
           this.abort(postIterationAbortReason);
@@ -497,7 +532,42 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
       const shouldFullyStop = result.output.should_fully_stop === true;
 
       if (result.output.success) {
+        // Metric gate: the agent's success claim alone is not enough to
+        // commit. When a score command is configured it is the ground truth;
+        // only a strict improvement over the run's best score may commit.
+        const gate = this.evaluateMetricGate();
+        if (gate !== null && !gate.improved) {
+          this.consecutiveNonImproving++;
+          appendDebugLog("metric:gate:rejected", {
+            iteration: this.state.currentIteration,
+            score: gate.score ?? null,
+            best: this.bestMetric ?? null,
+            consecutiveNonImproving: this.consecutiveNonImproving,
+          });
+          return {
+            type: "completed",
+            record: this.recordFailure(
+              `[METRIC] ${gate.summary}`,
+              gate.summary,
+              toStringArray(result.output.key_learnings),
+              "reported",
+            ),
+            shouldFullyStop: false,
+          };
+        }
         const record = this.recordSuccess(result.output);
+        if (gate !== null && record.success && gate.score !== undefined) {
+          // Persist only after the commit landed: a pending commit failure
+          // must not advance the best score, or the repaired retry would be
+          // gated against its own measurement.
+          this.bestMetric = gate.score;
+          this.consecutiveNonImproving = 0;
+          writeBestMetric(this.runInfo.bestMetricPath, gate.score);
+          appendDebugLog("metric:gate:accepted", {
+            iteration: this.state.currentIteration,
+            score: gate.score,
+          });
+        }
         const abortReason =
           record.success && this.limits.push === true
             ? this.pushAfterSuccess()
@@ -578,6 +648,71 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
       this.activeAbortController = null;
       this.pendingAbortReason = null;
     }
+  }
+
+  /**
+   * Run the configured score command in the (still dirty, uncommitted)
+   * workspace and compare against the run's best score. Returns null when no
+   * score command is configured. Command failure or unparseable output is a
+   * non-improving outcome with a warning, never a crash.
+   */
+  private evaluateMetricGate(): MetricGateOutcome | null {
+    const command = this.config.scoreCommand;
+    if (command === undefined) return null;
+    const direction = this.config.scoreDirection ?? "max";
+
+    let stdout: string;
+    try {
+      stdout = execSync(command, {
+        cwd: this.cwd,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+        maxBuffer: 10 * 1024 * 1024,
+      });
+    } catch (err) {
+      appendDebugLog("metric:score:command-failed", {
+        iteration: this.state.currentIteration,
+        error: serializeError(err),
+      });
+      return {
+        improved: false,
+        score: undefined,
+        summary:
+          "metric gate: score command failed; treating iteration as non-improving",
+      };
+    }
+
+    const score = parseScoreOutput(stdout);
+    if (score === undefined) {
+      appendDebugLog("metric:score:parse-failed", {
+        iteration: this.state.currentIteration,
+        stdout: stdout.slice(0, 500),
+      });
+      return {
+        improved: false,
+        score: undefined,
+        summary:
+          "metric gate: score command output is not a number; treating iteration as non-improving",
+      };
+    }
+
+    const best = this.bestMetric;
+    const improved =
+      best === undefined || (direction === "max" ? score > best : score < best);
+    appendDebugLog("metric:gate", {
+      iteration: this.state.currentIteration,
+      score,
+      best: best ?? null,
+      direction,
+      improved,
+    });
+    return {
+      improved,
+      score,
+      summary: improved
+        ? `metric gate: score ${score} improves on best ${best ?? "(none)"} (${direction})`
+        : `metric gate: score ${score} does not improve on best ${best} (${direction})`,
+    };
   }
 
   private recordSuccess(output: AgentOutput): IterationRecord {

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -281,6 +281,8 @@ describe("setupRun", () => {
       baseCommitPath: join(runDir, "base-commit"),
       stopWhenPath: join(runDir, "stop-when"),
       stopWhen: undefined,
+      bestMetricPath: join(runDir, "best-metric"),
+      bestMetric: undefined,
       commitMessagePath: join(runDir, "commit-message"),
       commitMessage: undefined,
     });

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -31,6 +31,8 @@ export interface RunInfo {
   baseCommitPath: string;
   stopWhenPath: string;
   stopWhen: string | undefined;
+  bestMetricPath: string;
+  bestMetric: number | undefined;
   commitMessagePath: string;
   commitMessage: CommitMessageConfig | undefined;
 }
@@ -47,6 +49,7 @@ export interface RunMetadata {
 const LOG_FILENAME = "gnhf.log";
 const STOP_WHEN_FILENAME = "stop-when";
 const COMMIT_MESSAGE_FILENAME = "commit-message";
+const BEST_METRIC_FILENAME = "best-metric";
 
 function writeSchemaFile(
   schemaPath: string,
@@ -78,6 +81,16 @@ function readStopWhen(stopWhenPath: string): string | undefined {
   if (!existsSync(stopWhenPath)) return undefined;
   const stopWhen = readFileSync(stopWhenPath, "utf-8").trim();
   return stopWhen.length > 0 ? stopWhen : undefined;
+}
+
+function readBestMetric(bestMetricPath: string): number | undefined {
+  if (!existsSync(bestMetricPath)) return undefined;
+  const value = Number(readFileSync(bestMetricPath, "utf-8").trim());
+  return Number.isFinite(value) ? value : undefined;
+}
+
+export function writeBestMetric(bestMetricPath: string, value: number): void {
+  writeFileSync(bestMetricPath, `${value}\n`, "utf-8");
 }
 
 function commitMessageMetadataValue(
@@ -221,6 +234,8 @@ export function setupRun(
   if (stopWhen !== undefined) {
     writeFileSync(stopWhenPath, `${stopWhen}\n`, "utf-8");
   }
+  const bestMetricPath = join(runDir, BEST_METRIC_FILENAME);
+  const bestMetric = readBestMetric(bestMetricPath);
   const commitMessagePath = join(runDir, COMMIT_MESSAGE_FILENAME);
   const commitMessage = schemaOptions.commitMessage;
   writeCommitMessageMetadata(commitMessagePath, commitMessage);
@@ -235,6 +250,8 @@ export function setupRun(
     baseCommit: resolvedBaseCommit,
     baseCommitPath,
     stopWhenPath,
+    bestMetricPath,
+    bestMetric,
     stopWhen,
     commitMessagePath,
     commitMessage,
@@ -260,6 +277,8 @@ export function resumeRun(
     ? readFileSync(baseCommitPath, "utf-8").trim()
     : backfillLegacyBaseCommit(runId, baseCommitPath, cwd);
   const stopWhenPath = join(runDir, STOP_WHEN_FILENAME);
+  const bestMetricPath = join(runDir, BEST_METRIC_FILENAME);
+  const bestMetric = readBestMetric(bestMetricPath);
   let stopWhen = readStopWhen(stopWhenPath);
   if (schemaOptions.clearStopWhen) {
     rmSync(stopWhenPath, { force: true });
@@ -287,6 +306,8 @@ export function resumeRun(
     baseCommit,
     baseCommitPath,
     stopWhenPath,
+    bestMetricPath,
+    bestMetric,
     stopWhen,
     commitMessagePath,
     commitMessage,


### PR DESCRIPTION
## Motivation

gnhf currently commits every iteration the agent reports as successful. The agent's self-report is the only gate, so a run can accumulate commits that make the actual target worse. This PR adds an optional, externally measured keep/discard gate: score the workspace after each successful iteration and keep the commit only if the score strictly improved.

## What it does

New flags (all optional; default behavior is unchanged when --score-command is unset):

- `--score-command <cmd>`: shell command run in the workspace after a successful iteration; its last non-empty stdout line is parsed as a number.
- `--score-direction <min|max>`: required with --score-command; defines improvement.
- `--stop-after-non-improving <N>`: stop the run after N consecutive non-improving iterations (default 3), with a distinct stop reason.

Behavior:

- Strict improvement: commit as usual, then persist the best score to `.gnhf/runs/<id>/best-metric` (only after the commit lands, so a commit failure cannot advance the best). Resume reads it back, following the stop-when file pattern.
- Worse, equal, command failure, or unparseable output: treated as a failed iteration; the existing recordFailure/resetHard path discards the changes. Never crashes the run.
- Debug events: metric:gate, metric:gate:accepted, metric:gate:rejected, metric:score:command-failed, metric:score:parse-failed.

## Tests

- 3 new e2e tests (`e2e/e2e-metric-gate.test.ts`) against dist/cli.mjs + the mock server: improving scores commit and persist best-metric; non-improving scores leave no commit and a clean worktree; unparseable scores stop the run via the metric gate without crashing.
- Full local run: lint, format:check, typecheck clean; 194/194 tests pass on macOS.

Naming and UX are negotiable: happy to rename the flags (e.g. --verify-command) or feed the measured score back into iteration prompts if you'd prefer that direction.