### PR TITLE
fix: use parseAgentJson in pi agent to recover JSON from prose-prefixed output

### DIFF
--- a/src/core/agents/pi.ts
+++ b/src/core/agents/pi.ts
@@ -9,6 +9,7 @@ import {
   type AgentRunOptions,
   type TokenUsage,
 } from "./types.js";
+import { parseAgentJson } from "./json-extract.js";
 import {
   parseJSONLStream,
   setupAbortHandler,
@@ -382,13 +383,11 @@ export class PiAgent implements Agent {
           return;
         }
 
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(finalText);
-        } catch (err) {
+        const parsed = parseAgentJson(finalText, isRecord);
+        if (!parsed) {
           reject(
             new Error(
-              `Failed to parse pi output: ${err instanceof Error ? err.message : err}`,
+              `Failed to parse pi output: no valid JSON object found in response`,
             ),
           );
           return;


### PR DESCRIPTION
## Problem

The pi agent uses a raw `JSON.parse()` on the model's final text output. When a model (e.g. kimi-k3) prepends prose before the JSON object, parsing fails with:

```
Failed to parse pi output: Unexpected token 'A', "All 10 acc"... is not valid JSON
```

## Root Cause

`pi.ts` line 387 did `JSON.parse(finalText)` directly. Some models output prose like *"All accounts are clean and synced..."* before the structured JSON, which is not valid JSON.

Other agents (`copilot`, `opencode`, `rovodev`, `acp`) already use `parseAgentJson()` from `json-extract.ts` — a utility that strips markdown fences and scans for balanced `{...}` objects to recover the JSON payload. The pi agent never adopted it.

## Fix

Replaced `JSON.parse(finalText)` with `parseAgentJson(finalText, isRecord)`, which:

1. Tries `JSON.parse` on the whole text first (fast path for well-behaved models)
2. Falls back to scanning for the last balanced `{...}` object (recovery path for prose-prefixed output)

All 20 existing pi agent tests pass.
