### PR TITLE
fix(agents): surface stdout-only CLI errors

### DIFF
--- a/src/core/agents/claude.ts
+++ b/src/core/agents/claude.ts
@@ -11,17 +11,14 @@ import {
   PermanentAgentError,
 } from "./types.js";
 import { shutdownChildProcess } from "./managed-process.js";
-import { parseJSONLStream, setupAbortHandler } from "./stream-utils.js";
+import {
+  appendExitOutputTail,
+  describeChildProcessExit,
+  parseJSONLStream,
+  setupAbortHandler,
+} from "./stream-utils.js";
 
 const DEFAULT_FINAL_RESULT_EXIT_GRACE_MS = 15_000;
-/** Upper bound on the stdout tail kept for non-zero-exit error reporting. */
-const MAX_EXIT_OUTPUT_CHARS = 4_000;
-/**
- * Tighter bound on unstructured stdout quoted back in the failure detail: that
- * text lands in notes.md and is replayed in every later iteration prompt.
- */
-const MAX_RAW_TAIL_CHARS = 400;
-const RAW_TAIL_ELISION = "[...truncated, full output in the iteration log] ";
 
 interface ClaudeAssistantEvent {
   type: "assistant";
@@ -204,103 +201,6 @@ function isPermanentClaudeError(output: string): boolean {
   return /credit balance\s+is\s+too\s+low/i.test(output);
 }
 
-/** Keep only the last `MAX_EXIT_OUTPUT_CHARS` characters so long streams stay bounded. */
-function appendBoundedTail(existing: string, chunk: string): string {
-  const combined = existing + chunk;
-  return combined.length > MAX_EXIT_OUTPUT_CHARS
-    ? combined.slice(combined.length - MAX_EXIT_OUTPUT_CHARS)
-    : combined;
-}
-
-function errorTextFromEvent(event: unknown): string | null {
-  if (!event || typeof event !== "object") return null;
-  const record = event as Record<string, unknown>;
-
-  const error = record.error;
-  if (typeof error === "string" && error.trim()) return error.trim();
-  if (error && typeof error === "object") {
-    const message = (error as Record<string, unknown>).message;
-    if (typeof message === "string" && message.trim()) return message.trim();
-  }
-
-  if (record.is_error === true || record.type === "error") {
-    for (const key of ["result", "message", "subtype"]) {
-      const value = record[key];
-      if (typeof value === "string" && value.trim()) return value.trim();
-    }
-  }
-
-  return null;
-}
-
-/** Quote only the end of unstructured output, marking what was dropped. */
-function elideRawTail(raw: string): string {
-  return raw.length > MAX_RAW_TAIL_CHARS
-    ? `${RAW_TAIL_ELISION}${raw.slice(raw.length - MAX_RAW_TAIL_CHARS)}`
-    : raw;
-}
-
-interface StdoutFailure {
-  /** Error text the CLI itself authored in structured stdout events. */
-  structured: string;
-  /** Text worth reporting: the structured text, or a short raw tail. */
-  reported: string;
-}
-
-/**
- * Pull the CLI's own error text out of its stdout, which is JSONL when the run
- * got far enough to stream events and plain text otherwise. Falls back to a
- * bounded raw tail so the reported detail is never empty when stdout had
- * content.
- */
-function extractStdoutError(stdoutTail: string): StdoutFailure {
-  const messages: string[] = [];
-  for (const line of stdoutTail.split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const message = errorTextFromEvent(JSON.parse(line));
-      if (message) messages.push(message);
-    } catch {
-      // Not JSON: covered by the raw-tail fallback below.
-    }
-  }
-  const structured = messages.join("\n");
-  return {
-    structured,
-    reported: structured || elideRawTail(stdoutTail.trim()),
-  };
-}
-
-interface ExitFailure {
-  detail: string;
-  permanent: boolean;
-}
-
-/**
- * Describe a non-zero exit. `detail` reports everything both streams offered,
- * while `permanent` is decided only from text the CLI itself authored - stderr
- * and structured stdout error fields - so agent output that merely quotes a
- * permanent-failure phrase cannot abort an otherwise retryable run.
- */
-function describeExitFailure(
-  code: number | null,
-  stdoutTail: string,
-  stderr: string,
-): ExitFailure {
-  const trimmedStderr = stderr.trim();
-  const stdoutError = extractStdoutError(stdoutTail);
-  const segments = [trimmedStderr, stdoutError.reported].filter(Boolean);
-  return {
-    detail:
-      segments.length > 0
-        ? `claude exited with code ${code}: ${segments.join("\n")}`
-        : `claude exited with code ${code} and produced no output`,
-    permanent: isPermanentClaudeError(
-      [trimmedStderr, stdoutError.structured].filter(Boolean).join("\n"),
-    ),
-  };
-}
-
 export class ClaudeAgent implements Agent {
   name = "claude";
 
@@ -375,7 +275,7 @@ export class ClaudeAgent implements Agent {
       });
 
       child.stdout!.on("data", (data: Buffer) => {
-        stdoutTail = appendBoundedTail(stdoutTail, data.toString());
+        stdoutTail = appendExitOutputTail(stdoutTail, data.toString());
       });
 
       child.on("error", (err) => {
@@ -501,9 +401,14 @@ export class ClaudeAgent implements Agent {
         }
         logStream?.end();
         if (code !== 0 && !closedAfterFinalCleanup) {
-          const failure = describeExitFailure(code, stdoutTail, stderr);
+          const failure = describeChildProcessExit(
+            "claude",
+            code,
+            stdoutTail,
+            stderr,
+          );
           reject(
-            failure.permanent
+            isPermanentClaudeError(failure.errorOutput)
               ? new PermanentAgentError(
                   "claude credit balance too low - see gnhf.log",
                   failure.detail,

--- a/src/core/agents/codex.test.ts
+++ b/src/core/agents/codex.test.ts
@@ -203,4 +203,21 @@ describe("CodexAgent", () => {
     );
     expect(proc.kill).not.toHaveBeenCalled();
   });
+
+  it("surfaces a structured error emitted on stdout after a non-zero exit", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CodexAgent("/tmp/schema.json");
+
+    const promise = agent.run("test prompt", "/work/dir");
+    proc.stdout.emit(
+      "data",
+      Buffer.from('{"type":"error","error":{"message":"login required"}}\n'),
+    );
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(
+      "codex exited with code 1: login required",
+    );
+  });
 });

--- a/src/core/agents/copilot.test.ts
+++ b/src/core/agents/copilot.test.ts
@@ -332,4 +332,18 @@ describe("CopilotAgent", () => {
 
     await expect(promise).rejects.toThrow("Failed to parse copilot output");
   });
+
+  it("surfaces a structured error emitted on stdout after a non-zero exit", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new CopilotAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, { type: "error", error: { message: "login required" } });
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(
+      "copilot exited with code 1: login required",
+    );
+  });
 });

--- a/src/core/agents/pi.test.ts
+++ b/src/core/agents/pi.test.ts
@@ -509,4 +509,18 @@ describe("PiAgent", () => {
 
     await expect(promise).rejects.toThrow("pi exited with code 2: bad things");
   });
+
+  it("surfaces a structured error emitted on stdout after a non-zero exit", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const agent = new PiAgent();
+
+    const promise = agent.run("test prompt", "/work/dir");
+    emitJson(proc, { type: "error", error: { message: "login required" } });
+    proc.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(
+      "pi exited with code 1: login required",
+    );
+  });
 });

--- a/src/core/agents/stream-utils.test.ts
+++ b/src/core/agents/stream-utils.test.ts
@@ -8,9 +8,11 @@ import {
 
 function createMockChild() {
   const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
     stderr: EventEmitter;
     kill: ReturnType<typeof vi.fn>;
   };
+  child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.kill = vi.fn();
   return child;
@@ -90,6 +92,35 @@ describe("setupChildProcessHandlers", () => {
     expect(onSuccess).not.toHaveBeenCalled();
     expect(reject).toHaveBeenCalledWith(
       new Error("codex exited with code 2: boom"),
+    );
+  });
+
+  it("rejects with a structured stdout error when stderr is empty", () => {
+    const child = createMockChild();
+    const reject = vi.fn();
+
+    setupChildProcessHandlers(child as never, "codex", null, reject, vi.fn());
+
+    child.stdout.emit(
+      "data",
+      Buffer.from('{"type":"error","error":{"message":"login required"}}\n'),
+    );
+    child.emit("close", 1);
+
+    expect(reject).toHaveBeenCalledWith(
+      new Error("codex exited with code 1: login required"),
+    );
+  });
+
+  it("says so when a non-zero exit produced no output", () => {
+    const child = createMockChild();
+    const reject = vi.fn();
+
+    setupChildProcessHandlers(child as never, "pi", null, reject, vi.fn());
+    child.emit("close", 1);
+
+    expect(reject).toHaveBeenCalledWith(
+      new Error("pi exited with code 1 and produced no output"),
     );
   });
 

--- a/src/core/agents/stream-utils.ts
+++ b/src/core/agents/stream-utils.ts
@@ -2,8 +2,105 @@ import type { ChildProcess } from "node:child_process";
 import type { Readable } from "node:stream";
 import type { WriteStream } from "node:fs";
 
+/** Upper bound on the stdout tail kept for non-zero-exit error reporting. */
+const MAX_EXIT_OUTPUT_CHARS = 4_000;
 /**
- * Wire stderr collection, spawn-error handling, and the common close-handler
+ * Tighter bound on unstructured stdout quoted back in the failure detail: that
+ * text lands in notes.md and is replayed in every later iteration prompt.
+ */
+const MAX_RAW_TAIL_CHARS = 400;
+const RAW_TAIL_ELISION = "[...truncated, full output in the iteration log] ";
+
+/** Keep only the end of a stream so long-running processes stay bounded. */
+export function appendExitOutputTail(existing: string, chunk: string): string {
+  const combined = existing + chunk;
+  return combined.length > MAX_EXIT_OUTPUT_CHARS
+    ? combined.slice(combined.length - MAX_EXIT_OUTPUT_CHARS)
+    : combined;
+}
+
+function errorTextFromEvent(event: unknown): string | null {
+  if (!event || typeof event !== "object") return null;
+  const record = event as Record<string, unknown>;
+
+  const error = record.error;
+  if (typeof error === "string" && error.trim()) return error.trim();
+  if (error && typeof error === "object") {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === "string" && message.trim()) return message.trim();
+  }
+
+  if (record.is_error === true || record.type === "error") {
+    for (const key of ["result", "message", "subtype"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function elideRawTail(raw: string): string {
+  return raw.length > MAX_RAW_TAIL_CHARS
+    ? `${RAW_TAIL_ELISION}${raw.slice(raw.length - MAX_RAW_TAIL_CHARS)}`
+    : raw;
+}
+
+interface StdoutFailure {
+  structured: string;
+  reported: string;
+}
+
+function extractStdoutError(stdoutTail: string): StdoutFailure {
+  const messages: string[] = [];
+  for (const line of stdoutTail.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const message = errorTextFromEvent(JSON.parse(line));
+      if (message) messages.push(message);
+    } catch {
+      // Not JSON: covered by the raw-tail fallback below.
+    }
+  }
+  const structured = messages.join("\n");
+  return {
+    structured,
+    reported: structured || elideRawTail(stdoutTail.trim()),
+  };
+}
+
+export interface ChildProcessExitFailure {
+  detail: string;
+  /** CLI-authored error text suitable for permanent-error classification. */
+  errorOutput: string;
+}
+
+/**
+ * Describe a non-zero exit. The detail reports both streams, while
+ * `errorOutput` excludes unstructured stdout that may merely quote an error.
+ */
+export function describeChildProcessExit(
+  agentName: string,
+  code: number | null,
+  stdoutTail: string,
+  stderr: string,
+): ChildProcessExitFailure {
+  const trimmedStderr = stderr.trim();
+  const stdoutError = extractStdoutError(stdoutTail);
+  const segments = [trimmedStderr, stdoutError.reported].filter(Boolean);
+  return {
+    detail:
+      segments.length > 0
+        ? `${agentName} exited with code ${code}: ${segments.join("\n")}`
+        : `${agentName} exited with code ${code} and produced no output`,
+    errorOutput: [trimmedStderr, stdoutError.structured]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+/**
+ * Wire output collection, spawn-error handling, and the common close-handler
  * prefix (logStream.end + non-zero exit code rejection) for a child process.
  * Calls `onSuccess` only when the process exits with code 0.
  */
@@ -15,6 +112,11 @@ export function setupChildProcessHandlers(
   onSuccess: () => void,
 ): void {
   let stderr = "";
+  let stdoutTail = "";
+
+  child.stdout!.on("data", (data: Buffer) => {
+    stdoutTail = appendExitOutputTail(stdoutTail, data.toString());
+  });
 
   child.stderr!.on("data", (data: Buffer) => {
     stderr += data.toString();
@@ -27,7 +129,13 @@ export function setupChildProcessHandlers(
   child.on("close", (code) => {
     logStream?.end();
     if (code !== 0) {
-      reject(new Error(`${agentName} exited with code ${code}: ${stderr}`));
+      const failure = describeChildProcessExit(
+        agentName,
+        code,
+        stdoutTail,
+        stderr,
+      );
+      reject(new Error(failure.detail));
       return;
     }
     onSuccess();


### PR DESCRIPTION
## Intent

Fix the shared child-process error-reporting defect in src/core/agents/stream-utils.ts used by the Codex, Copilot, and Pi adapters. Build on the established PR #190 behavior: a non-zero CLI exit may carry the real error on stdout while stderr is empty. Include a bounded stdout tail when stderr alone lacks the error, parse structured JSON error fields, classify permanent errors from the relevant combined output, and clearly report when both streams are empty. Require behavioral adapter coverage for Codex, Copilot, and Pi stdout-only non-zero exits. Reuse the corrected shared helper for Claude only if it reduces duplication without broadening behavior or risk. Remain compatible with the fully green Pi JSON recovery PR #195 and do not modify its branch. Deliver a review-ready upstream contribution PR with all canonical checks green. The captain explicitly authorizes unattended --yes validation of preserved commit 055f17b46bb6709f42af5e93220561baee792808 under no-mistakes v1.48.0. Do not merge, publish, deploy, change policy, waive checks, alter credentials, reset, force, or discard preserved work.

## What Changed

- Capture a bounded stdout tail for non-zero agent exits, extract structured JSON errors, and fall back to truncated raw output or an explicit no-output message.
- Share exit reporting with Claude while keeping permanent-error classification limited to stderr and structured stdout error fields.
- Add stdout-only failure coverage for the Codex, Copilot, and Pi adapters, plus shared handler coverage for empty output.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the established Claude semantics, fixes all shared adapter paths, and adds behavior-level coverage for each required adapter without conflicting with Pi JSON recovery.

## Testing

Focused shared-helper and adapter tests, the Claude stdout/empty-stream regression, and built-CLI stdout-only failures for Codex, Copilot, and Pi all passed; after correcting and cleaning an initial harness working-directory mistake, the final transcript directly demonstrates the user-visible CLI behavior. No screenshot was needed because this changes process-error text rather than graphical layout.

<details>
<summary>Evidence: Stdout-only adapter failure transcript</summary>

`Codex, Copilot, and Pi child processes each exited 1 with zero stderr bytes and a structured stdout error. The built gnhf CLI displayed and persisted the exact error for every adapter.`

```text
=== codex: child CLI stimulus ===
exit code: 1
stderr bytes: 0
stdout:
{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Invalid model name: claude-nonexistent-5"}

=== codex: gnhf end-user terminal result ===
                                                                                
╭───────────────────────────────────────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                                                                │
│   codex ran for 0s before: codex exited with code 1: Invalid model name: claude-nonexistent-5 │
╰───────────────────────────────────────────────────────────────────────────────────────────────╯

  iterations      1 total       0 good       1 failed
  tokens          0 in          0 out        
  branch diff     0 commits     +0           -0
  files           0 added       0 updated    0 deleted

  notes           /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/codex-repo/.gnhf/runs/surface-codex-stdout-e8eab2/notes.md
  debug log       /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/codex-repo/.gnhf/runs/surface-codex-stdout-e8eab2/gnhf.log

  next steps      git log --oneline 1a5fdba75199..HEAD
                  git diff --stat 1a5fdba75199..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

=== codex: persisted notes.md ===
**Summary:** [ERROR] codex exited with code 1: Invalid model name: claude-nonexistent-5

=== copilot: child CLI stimulus ===
exit code: 1
stderr bytes: 0
stdout:
{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Invalid model name: claude-nonexistent-5"}

=== copilot: gnhf end-user terminal result ===
                                                                                
╭───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                                                                    │
│   copilot ran for 0s before: copilot exited with code 1: Invalid model name: claude-nonexistent-5 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯

  iterations      1 total       0 good       1 failed
  tokens          0 in          0 out        
  branch diff     0 commits     +0           -0
  files           0 added       0 updated    0 deleted

  notes           /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/copilot-repo/.gnhf/runs/surface-copilot-stdo-5c9af3/notes.md
  debug log       /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/copilot-repo/.gnhf/runs/surface-copilot-stdo-5c9af3/gnhf.log

  next steps      git log --oneline 1a5fdba75199..HEAD
                  git diff --stat 1a5fdba75199..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

=== copilot: persisted notes.md ===
**Summary:** [ERROR] copilot exited with code 1: Invalid model name: claude-nonexistent-5

=== pi: child CLI stimulus ===
exit code: 1
stderr bytes: 0
stdout:
{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Invalid model name: claude-nonexistent-5"}

=== pi: gnhf end-user terminal result ===
                                                                                
╭─────────────────────────────────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                                                          │
│   pi ran for 0s before: pi exited with code 1: Invalid model name: claude-nonexistent-5 │
╰─────────────────────────────────────────────────────────────────────────────────────────╯

  iterations      1 total       0 good       1 failed
  tokens          0 in          0 out        
  branch diff     0 commits     +0           -0
  files           0 added       0 updated    0 deleted

  notes           /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/pi-repo/.gnhf/runs/surface-pi-stdout-fa-fef76d/notes.md
  debug log       /tmp/no-mistakes-evidence/01KZVSXH8QZZFSDG7YNWDKGHY6/pi-repo/.gnhf/runs/surface-pi-stdout-fa-fef76d/gnhf.log

  next steps      git log --oneline 1a5fdba75199..HEAD
                  git diff --stat 1a5fdba75199..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

=== pi: persisted notes.md ===
**Summary:** [ERROR] pi exited with code 1: Invalid model name: claude-nonexistent-5
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"59543108740c4a375d9749f63d15a16f705a0f62","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run src/core/agents/stream-utils.test.ts src/core/agents/codex.test.ts src/core/agents/copilot.test.ts src/core/agents/pi.test.ts src/core/agents/claude.test.ts`
- `pnpm run build`
- <code>Built CLI runs in isolated repositories using `node dist/cli.mjs &#34;surface &lt;agent&gt; stdout failure&#34; --agent &lt;codex|copilot|pi&gt; --max-iterations 1 --prevent-sleep off`</code>
- `Direct child-process checks confirming exit code 1, structured JSON on stdout, and zero stderr bytes for Codex, Copilot, and Pi fixtures`
- `pnpm exec vitest run e2e/e2e.test.ts -t "surfaces the claude CLI's own failure text"`
- <code>Verified the terminal summaries and persisted `notes.md` errors for all three required adapters</code>
- `Initial CLI evidence attempt used the wrong working directory; its results were discarded, and all resulting branch, metadata, build, and dependency artifacts were removed`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
