### PR TITLE
chore: store no-mistakes test evidence in repo

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,7 +1,7 @@
 # Per-repo no-mistakes overrides.
 
-# Keep pipeline test evidence (transcripts, screenshots, fixture homes) out of
-# this repo; it stays in a temp dir instead and can be linked from PR bodies.
+# Keep pipeline test evidence (transcripts, screenshots, fixture homes) in
+# this repo so runs can attach it from the checkout instead of a temp dir.
 test:
   evidence:
-    store_in_repo: false
+    store_in_repo: true


### PR DESCRIPTION
## Intent

PR https://github.com/kunchenguid/gnhf/pull/204 is red on "PR must be raised via no-mistakes". Convert this to a no-mistakes ship: run /no-mistakes on the same branch, keep the one-line store_in_repo true change, drive the pipeline to green. Do not merge. Report the full PR URL when checks are green. The committed change only sets test.evidence.store_in_repo to true in .no-mistakes.yaml and updates the comment so evidence is described as living in the checkout rather than a temp dir.

## What Changed

- Configure no-mistakes to store test evidence in the repository checkout.
- Update the configuration comment to describe the new evidence location.

## Risk Assessment

✅ Low: The change is limited to the required no-mistakes evidence-storage setting and accurately updates its explanatory comment.

## Testing

Parsed the configuration as YAML, compared its normalized semantics against the base commit, confirmed the requested comment and one-setting patch, and captured reviewer-visible evidence. No visual artifact applies because this is a configuration-only change.

<details>
<summary>Evidence: Semantic configuration verification</summary>

Source: [Semantic configuration verification](https://github.com/kunchenguid/gnhf/blob/d0d75dc611d3914afa8c027735d11c539cce912f/.no-mistakes/evidence/fm/nm-evidence-store-gnhf-r1/store-in-repo-config-verification.txt)

```text
{
  "result": "PASS",
  "changedFiles": [
    ".no-mistakes.yaml"
  ],
  "semanticChanges": [
    {
      "key": "test.evidence.store_in_repo",
      "before": false,
      "after": true
    }
  ],
  "effectiveSetting": {
    "test.evidence.store_in_repo": true
  }
}
```
</details>
<details>
<summary>Evidence: Requested configuration patch</summary>

Source: [Requested configuration patch](https://github.com/kunchenguid/gnhf/blob/d0d75dc611d3914afa8c027735d11c539cce912f/.no-mistakes/evidence/fm/nm-evidence-store-gnhf-r1/requested-config-change.patch)

```text
diff --git a/.no-mistakes.yaml b/.no-mistakes.yaml
index bdef7f8..020d3f7 100644
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,7 +1,7 @@
 # Per-repo no-mistakes overrides.
 
-# Keep pipeline test evidence (transcripts, screenshots, fixture homes) out of
-# this repo; it stays in a temp dir instead and can be linked from PR bodies.
+# Keep pipeline test evidence (transcripts, screenshots, fixture homes) in
+# this repo so runs can attach it from the checkout instead of a temp dir.
 test:
   evidence:
-    store_in_repo: false
+    store_in_repo: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"80b6f6bd528043d7be22c4405e47ad793fa8481a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 60f9aa5667fe57aeb2ad3615ae2947345f1b6dc0..80b6f6bd528043d7be22c4405e47ad793fa8481a -- .no-mistakes.yaml`
- <code>`pnpm install --frozen-lockfile` to restore test dependencies</code>
- <code>Node semantic YAML verification asserting the only changed file is `.no-mistakes.yaml`, the only semantic change is `test.evidence.store_in_repo: false -&gt; true`, and the effective value is `true`</code>
- <code>`git status --short` after removing transient `node_modules`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
