### PR TITLE
fix(core): make Windows sleep prevention hold the machine awake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,10 @@ All git invocations go through `execFileSync` with explicit argv. `git.injection
 
 ### Sleep prevention (`src/core/sleep.ts`)
 
-When `preventSleep` is on and the process wasn't already re-exec'd under a sleep-inhibitor, gnhf re-execs itself under `caffeinate` (macOS), `systemd-inhibit` (Linux), or a PowerShell `SetThreadExecutionState` helper (Windows). The re-exec uses `GNHF_SLEEP_INHIBITED=1` as the loop-breaker and `GNHF_REEXEC_STDIN_PROMPT_FILE` to pass piped stdin across the re-exec (the original process writes a 0600 temp file, the child reads and unlinks it).
+When `preventSleep` is on, Linux re-execs gnhf under `systemd-inhibit` unless the process was already re-exec'd; macOS and Windows instead spawn a helper child (`caffeinate`, or a PowerShell `SetThreadExecutionState` helper) that releases the inhibit when gnhf exits.
+The Linux re-exec uses `GNHF_SLEEP_INHIBITED=1` as the loop-breaker and `GNHF_REEXEC_STDIN_PROMPT_FILE` to pass piped stdin across the re-exec (the original process writes a 0600 temp file, the child reads and unlinks it).
+The Windows helper prints a ready marker only after `SetThreadExecutionState` actually succeeds, and that handshake is settled at shutdown rather than on the startup path.
+An inhibitor that never starts or never confirms must never abort the run; it is reported through the exit summary's `sleep` line, whose user-facing contract lives in the README's [Sleep Prevention](./README.md#sleep-prevention) section.
 
 ### Telemetry (`src/core/telemetry.ts`)
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ agentPathOverride:
 
 Paths may be absolute, bare executable names already on your `PATH`, `~`-prefixed, or relative to the config directory (`~/.gnhf/`). The override replaces only the binary name; all standard arguments are preserved, so the replacement must be CLI-compatible with the original agent. On Windows, `.cmd` and `.bat` wrappers are supported, including bare names resolved from `PATH`. For `rovodev`, the override must point to an `acli`-compatible binary since gnhf invokes it as `<bin> rovodev serve ...`.
 
+### Sleep Prevention
+
 When sleep prevention is enabled, `gnhf` uses the native mechanism for your OS: `caffeinate` on macOS, `systemd-inhibit` on Linux, and a small PowerShell helper backed by `SetThreadExecutionState` on Windows.
 A run is never aborted because that mechanism is unavailable; instead the exit summary adds a `sleep` line reporting either that prevention could not be started for the run, or that the helper started but never confirmed it was holding the machine awake, so the machine may have slept.
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,9 @@ agentPathOverride:
 ```
 
 Paths may be absolute, bare executable names already on your `PATH`, `~`-prefixed, or relative to the config directory (`~/.gnhf/`). The override replaces only the binary name; all standard arguments are preserved, so the replacement must be CLI-compatible with the original agent. On Windows, `.cmd` and `.bat` wrappers are supported, including bare names resolved from `PATH`. For `rovodev`, the override must point to an `acli`-compatible binary since gnhf invokes it as `<bin> rovodev serve ...`.
+
 When sleep prevention is enabled, `gnhf` uses the native mechanism for your OS: `caffeinate` on macOS, `systemd-inhibit` on Linux, and a small PowerShell helper backed by `SetThreadExecutionState` on Windows.
+A run is never aborted because that mechanism is unavailable; instead the exit summary adds a `sleep` line reporting either that prevention could not be started for the run, or that the helper started but never confirmed it was holding the machine awake, so the machine may have slept.
 
 ## Debug Logs
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1321,6 +1321,60 @@ describe("cli", () => {
     });
   });
 
+  it("warns when sleep prevention was requested but is unavailable", async () => {
+    const startSleepPrevention = vi.fn(() =>
+      Promise.resolve({
+        type: "skipped" as const,
+        reason: "unavailable" as const,
+      }),
+    );
+
+    const { consoleErrorCalls, orchestratorCtor } = await runCliWithMocks(
+      ["ship it"],
+      {
+        agent: "claude",
+        agentPathOverride: {},
+        agentArgsOverride: {},
+        acpRegistryOverrides: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: true,
+      },
+      { startSleepPrevention },
+    );
+
+    expect(startSleepPrevention).toHaveBeenCalledTimes(1);
+    expect(consoleErrorCalls.flat().join("\n")).toContain(
+      "sleep prevention is unavailable",
+    );
+    expect(orchestratorCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet about sleep prevention when the helper is active", async () => {
+    const startSleepPrevention = vi.fn(() =>
+      Promise.resolve({
+        type: "active" as const,
+        cleanup: () => Promise.resolve(),
+      }),
+    );
+
+    const { consoleErrorCalls } = await runCliWithMocks(
+      ["ship it"],
+      {
+        agent: "claude",
+        agentPathOverride: {},
+        agentArgsOverride: {},
+        acpRegistryOverrides: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: true,
+      },
+      { startSleepPrevention },
+    );
+
+    expect(consoleErrorCalls.flat().join("\n")).not.toContain(
+      "sleep prevention",
+    );
+  });
+
   it("does not emit run:start from the Linux sleep-prevention wrapper process", async () => {
     const appendDebugLog = vi.fn();
     const startSleepPrevention = vi.fn(() =>

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -13,6 +13,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CONVENTIONAL_COMMIT_MESSAGE } from "./core/commit-message.js";
 import type { Config } from "./core/config.js";
+import { stripExitSummaryAnsi } from "./core/exit-summary.js";
 import type { RunInfo } from "./core/run.js";
 
 const TEST_AGENT_NAMES = [
@@ -1321,7 +1322,7 @@ describe("cli", () => {
     });
   });
 
-  it("warns when sleep prevention was requested but is unavailable", async () => {
+  it("reports unavailable sleep prevention in the permanent exit summary", async () => {
     const startSleepPrevention = vi.fn(() =>
       Promise.resolve({
         type: "skipped" as const,
@@ -1329,7 +1330,7 @@ describe("cli", () => {
       }),
     );
 
-    const { consoleErrorCalls, orchestratorCtor } = await runCliWithMocks(
+    const { stdoutWriteCalls, orchestratorCtor } = await runCliWithMocks(
       ["ship it"],
       {
         agent: "claude",
@@ -1343,8 +1344,10 @@ describe("cli", () => {
     );
 
     expect(startSleepPrevention).toHaveBeenCalledTimes(1);
-    expect(consoleErrorCalls.flat().join("\n")).toContain(
-      "sleep prevention is unavailable",
+    // The summary survives the alt screen the renderer owns for the whole
+    // run, so this is the notice the user actually gets to read.
+    expect(stripExitSummaryAnsi(stdoutWriteCalls.flat().join(""))).toContain(
+      "prevention unavailable; this machine may have slept",
     );
     expect(orchestratorCtor).toHaveBeenCalledTimes(1);
   });
@@ -1357,7 +1360,7 @@ describe("cli", () => {
       }),
     );
 
-    const { consoleErrorCalls } = await runCliWithMocks(
+    const { consoleErrorCalls, stdoutWriteCalls } = await runCliWithMocks(
       ["ship it"],
       {
         agent: "claude",
@@ -1370,9 +1373,10 @@ describe("cli", () => {
       { startSleepPrevention },
     );
 
-    expect(consoleErrorCalls.flat().join("\n")).not.toContain(
-      "sleep prevention",
+    const output = stripExitSummaryAnsi(
+      [...stdoutWriteCalls.flat(), ...consoleErrorCalls.flat()].join(""),
     );
+    expect(output).not.toContain("prevention unavailable");
   });
 
   it("does not emit run:start from the Linux sleep-prevention wrapper process", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1322,6 +1322,33 @@ describe("cli", () => {
     });
   });
 
+  it("reports an unconfirmed sleep helper in the permanent exit summary", async () => {
+    const startSleepPrevention = vi.fn(() =>
+      Promise.resolve({
+        type: "active" as const,
+        cleanup: () => Promise.resolve(),
+        confirmed: Promise.resolve(false),
+      }),
+    );
+
+    const { stdoutWriteCalls } = await runCliWithMocks(
+      ["ship it"],
+      {
+        agent: "claude",
+        agentPathOverride: {},
+        agentArgsOverride: {},
+        acpRegistryOverrides: {},
+        maxConsecutiveFailures: 3,
+        preventSleep: true,
+      },
+      { startSleepPrevention },
+    );
+
+    expect(stripExitSummaryAnsi(stdoutWriteCalls.flat().join(""))).toContain(
+      "prevention unavailable; this machine may have slept",
+    );
+  });
+
   it("reports unavailable sleep prevention in the permanent exit summary", async () => {
     const startSleepPrevention = vi.fn(() =>
       Promise.resolve({
@@ -1352,11 +1379,12 @@ describe("cli", () => {
     expect(orchestratorCtor).toHaveBeenCalledTimes(1);
   });
 
-  it("stays quiet about sleep prevention when the helper is active", async () => {
+  it("stays quiet about sleep prevention when the helper is confirmed", async () => {
     const startSleepPrevention = vi.fn(() =>
       Promise.resolve({
         type: "active" as const,
         cleanup: () => Promise.resolve(),
+        confirmed: Promise.resolve(true),
       }),
     );
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1372,10 +1372,13 @@ describe("cli", () => {
 
     expect(startSleepPrevention).toHaveBeenCalledTimes(1);
     // The summary survives the alt screen the renderer owns for the whole
-    // run, so this is the notice the user actually gets to read.
-    expect(stripExitSummaryAnsi(stdoutWriteCalls.flat().join(""))).toContain(
-      "prevention unavailable; this machine may have slept",
-    );
+    // run, so this is the notice the user actually gets to read. An inhibitor
+    // that never started says nothing about whether the machine could sleep,
+    // which matters on the systemd-less Linux hosts that hit this path on
+    // every run.
+    const output = stripExitSummaryAnsi(stdoutWriteCalls.flat().join(""));
+    expect(output).toContain("prevention could not be started for this run");
+    expect(output).not.toContain("may have slept");
     expect(orchestratorCtor).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -934,6 +934,7 @@ program
       }
 
       let sleepPreventionCleanup: (() => Promise<void>) | null = null;
+      let sleepPreventionConfirmed: Promise<boolean> | null = null;
       let sleepPreventionUnavailable = false;
       if (config.preventSleep) {
         const persistedPrompt =
@@ -960,6 +961,7 @@ program
           }
           if (sleepPrevention.type === "active") {
             sleepPreventionCleanup = sleepPrevention.cleanup;
+            sleepPreventionConfirmed = sleepPrevention.confirmed;
           }
           if (
             sleepPrevention.type === "skipped" &&
@@ -1139,6 +1141,9 @@ program
         process.off("SIGINT", handleSigInt);
         process.off("SIGTERM", handleSigTerm);
         await sleepPreventionCleanup?.();
+        if (sleepPreventionConfirmed && !(await sleepPreventionConfirmed)) {
+          sleepPreventionUnavailable = true;
+        }
       }
 
       {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -934,6 +934,7 @@ program
       }
 
       let sleepPreventionCleanup: (() => Promise<void>) | null = null;
+      let sleepPreventionUnavailable = false;
       if (config.preventSleep) {
         const persistedPrompt =
           promptFromStdin && prompt !== undefined
@@ -964,10 +965,7 @@ program
             sleepPrevention.type === "skipped" &&
             sleepPrevention.reason === "unavailable"
           ) {
-            console.error(
-              "\n  gnhf: sleep prevention is unavailable on this machine;" +
-                " it may sleep during the run.\n",
-            );
+            sleepPreventionUnavailable = true;
           }
         } finally {
           if (!reexeced) {
@@ -1183,6 +1181,7 @@ program
           color: shouldUseColor(),
           terminalColumns: process.stdout.columns,
           hasPendingCommitFailure: finalState.hasPendingCommitFailure,
+          sleepPreventionUnavailable,
         });
 
         appendDebugLog("run:complete", {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,10 @@ import {
   type CommitMessageConfig,
 } from "./core/commit-message.js";
 import { Orchestrator } from "./core/orchestrator.js";
-import { renderExitSummary } from "./core/exit-summary.js";
+import {
+  renderExitSummary,
+  type SleepPreventionNotice,
+} from "./core/exit-summary.js";
 import { MockOrchestrator } from "./mock-orchestrator.js";
 import { Renderer } from "./renderer.js";
 import { slugifyPrompt } from "./utils/slugify.js";
@@ -935,7 +938,7 @@ program
 
       let sleepPreventionCleanup: (() => Promise<void>) | null = null;
       let sleepPreventionConfirmed: Promise<boolean> | null = null;
-      let sleepPreventionUnavailable = false;
+      let sleepPreventionNotice: SleepPreventionNotice | undefined;
       if (config.preventSleep) {
         const persistedPrompt =
           promptFromStdin && prompt !== undefined
@@ -967,7 +970,7 @@ program
             sleepPrevention.type === "skipped" &&
             sleepPrevention.reason === "unavailable"
           ) {
-            sleepPreventionUnavailable = true;
+            sleepPreventionNotice = "unstarted";
           }
         } finally {
           if (!reexeced) {
@@ -1142,7 +1145,7 @@ program
         process.off("SIGTERM", handleSigTerm);
         await sleepPreventionCleanup?.();
         if (sleepPreventionConfirmed && !(await sleepPreventionConfirmed)) {
-          sleepPreventionUnavailable = true;
+          sleepPreventionNotice = "unconfirmed";
         }
       }
 
@@ -1186,7 +1189,7 @@ program
           color: shouldUseColor(),
           terminalColumns: process.stdout.columns,
           hasPendingCommitFailure: finalState.hasPendingCommitFailure,
-          sleepPreventionUnavailable,
+          sleepPreventionNotice,
         });
 
         appendDebugLog("run:complete", {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -960,6 +960,15 @@ program
           if (sleepPrevention.type === "active") {
             sleepPreventionCleanup = sleepPrevention.cleanup;
           }
+          if (
+            sleepPrevention.type === "skipped" &&
+            sleepPrevention.reason === "unavailable"
+          ) {
+            console.error(
+              "\n  gnhf: sleep prevention is unavailable on this machine;" +
+                " it may sleep during the run.\n",
+            );
+          }
         } finally {
           if (!reexeced) {
             persistedPrompt?.cleanup();

--- a/src/core/exit-summary.test.ts
+++ b/src/core/exit-summary.test.ts
@@ -100,6 +100,28 @@ describe("renderExitSummary", () => {
     );
   });
 
+  it("warns when sleep prevention was unavailable for the run", () => {
+    const summary = stripExitSummaryAnsi(
+      renderExitSummary({
+        ...baseSummary,
+        sleepPreventionUnavailable: true,
+        color: false,
+      }),
+    );
+
+    expect(summary).toContain(
+      "sleep           prevention unavailable; this machine may have slept",
+    );
+  });
+
+  it("omits the sleep warning when prevention held for the run", () => {
+    const summary = stripExitSummaryAnsi(
+      renderExitSummary({ ...baseSummary, color: false }),
+    );
+
+    expect(summary).not.toContain("prevention unavailable");
+  });
+
   it("adds ANSI color when requested", () => {
     const summary = renderExitSummary({ ...baseSummary, color: true });
 

--- a/src/core/exit-summary.test.ts
+++ b/src/core/exit-summary.test.ts
@@ -100,11 +100,11 @@ describe("renderExitSummary", () => {
     );
   });
 
-  it("warns when sleep prevention was unavailable for the run", () => {
+  it("warns that the machine may have slept when the inhibitor was never confirmed", () => {
     const summary = stripExitSummaryAnsi(
       renderExitSummary({
         ...baseSummary,
-        sleepPreventionUnavailable: true,
+        sleepPreventionNotice: "unconfirmed",
         color: false,
       }),
     );
@@ -112,6 +112,21 @@ describe("renderExitSummary", () => {
     expect(summary).toContain(
       "sleep           prevention unavailable; this machine may have slept",
     );
+  });
+
+  it("does not claim the machine may have slept when no inhibitor started", () => {
+    const summary = stripExitSummaryAnsi(
+      renderExitSummary({
+        ...baseSummary,
+        sleepPreventionNotice: "unstarted",
+        color: false,
+      }),
+    );
+
+    expect(summary).toContain(
+      "sleep           prevention could not be started for this run",
+    );
+    expect(summary).not.toContain("may have slept");
   });
 
   it("omits the sleep warning when prevention held for the run", () => {

--- a/src/core/exit-summary.ts
+++ b/src/core/exit-summary.ts
@@ -24,6 +24,7 @@ export interface ExitSummaryOptions {
   color: boolean;
   terminalColumns?: number;
   hasPendingCommitFailure?: boolean;
+  sleepPreventionUnavailable?: boolean;
 }
 
 const MIN_CARD_WIDTH = 62;
@@ -218,6 +219,14 @@ export function renderExitSummary(options: ExitSummaryOptions): string {
           commandLine(
             s.yellow("uncommitted"),
             "commit failed; changes were left for repair",
+          ),
+        ]
+      : []),
+    ...(options.sleepPreventionUnavailable
+      ? [
+          commandLine(
+            s.yellow("sleep"),
+            "prevention unavailable; this machine may have slept",
           ),
         ]
       : []),

--- a/src/core/exit-summary.ts
+++ b/src/core/exit-summary.ts
@@ -4,6 +4,13 @@ import { formatTokens } from "../utils/tokens.js";
 
 type RunStatus = OrchestratorState["status"];
 
+/**
+ * "unstarted": no inhibitor could be launched at all, so nothing about the
+ * machine's sleep behavior is known. "unconfirmed": an inhibitor was launched
+ * but never reported that it holds the machine awake.
+ */
+export type SleepPreventionNotice = "unstarted" | "unconfirmed";
+
 export interface ExitSummaryOptions {
   agentName: string;
   branchName: string;
@@ -24,7 +31,7 @@ export interface ExitSummaryOptions {
   color: boolean;
   terminalColumns?: number;
   hasPendingCommitFailure?: boolean;
-  sleepPreventionUnavailable?: boolean;
+  sleepPreventionNotice?: SleepPreventionNotice;
 }
 
 const MIN_CARD_WIDTH = 62;
@@ -222,11 +229,13 @@ export function renderExitSummary(options: ExitSummaryOptions): string {
           ),
         ]
       : []),
-    ...(options.sleepPreventionUnavailable
+    ...(options.sleepPreventionNotice
       ? [
           commandLine(
             s.yellow("sleep"),
-            "prevention unavailable; this machine may have slept",
+            options.sleepPreventionNotice === "unstarted"
+              ? "prevention could not be started for this run"
+              : "prevention unavailable; this machine may have slept",
           ),
         ]
       : []),

--- a/src/core/sleep.test.ts
+++ b/src/core/sleep.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
@@ -31,6 +32,17 @@ function createChildProcess(pid = 1234): ChildProcess {
     signalCode: null,
   });
   return child as unknown as ChildProcess;
+}
+
+function createWindowsChildProcess(pid = 1234): ChildProcess {
+  const child = createChildProcess(pid) as ChildProcess & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  return Object.assign(child, {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  });
 }
 
 describe("startSleepPrevention", () => {
@@ -540,9 +552,12 @@ describe("startSleepPrevention", () => {
   });
 
   it("starts a PowerShell helper on Windows", async () => {
-    const child = createChildProcess();
+    const child = createWindowsChildProcess();
     mockSpawn.mockImplementation(() => {
-      queueMicrotask(() => child.emit("spawn"));
+      queueMicrotask(() => {
+        child.emit("spawn");
+        child.stdout?.push("gnhf-sleep-ready\n");
+      });
       return child as never;
     });
 
@@ -569,5 +584,50 @@ describe("startSleepPrevention", () => {
     expect(String(mockSpawn.mock.calls[0]?.[1]?.at(-1))).toContain("\n'@;");
     expect(String(mockSpawn.mock.calls[0]?.[1]?.at(-1))).toContain("42");
     expect(result.type).toBe("active");
+  });
+
+  it("skips sleep prevention when the Windows helper exits before it is ready", async () => {
+    const child = createWindowsChildProcess();
+    mockSpawn.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.emit("spawn");
+        child.stderr?.push('Cannot convert argument "flags"\n');
+        queueMicrotask(() => {
+          Object.assign(child, { exitCode: 1 });
+          child.emit("exit", 1, null);
+        });
+      });
+      return child as never;
+    });
+
+    const result = await startSleepPrevention(["ship it"], {
+      pid: 42,
+      platform: "win32",
+    });
+
+    expect(result).toEqual({ type: "skipped", reason: "unavailable" });
+  });
+
+  it("skips sleep prevention when the Windows helper never reports ready", async () => {
+    vi.useFakeTimers();
+    const child = createWindowsChildProcess();
+    mockSpawn.mockImplementation(() => {
+      queueMicrotask(() => child.emit("spawn"));
+      return child as never;
+    });
+
+    const resultPromise = startSleepPrevention(["ship it"], {
+      pid: 42,
+      platform: "win32",
+    });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    await expect(resultPromise).resolves.toEqual({
+      type: "skipped",
+      reason: "unavailable",
+    });
+    expect(child.kill).toHaveBeenCalled();
   });
 });

--- a/src/core/sleep.test.ts
+++ b/src/core/sleep.test.ts
@@ -597,6 +597,32 @@ describe("startSleepPrevention", () => {
     expect(String(mockSpawn.mock.calls[0]?.[1]?.at(-1))).toContain("\n'@;");
     expect(String(mockSpawn.mock.calls[0]?.[1]?.at(-1))).toContain("42");
     expect(result.type).toBe("active");
+    if (result.type !== "active") return;
+    await expect(result.confirmed).resolves.toBe(true);
+  });
+
+  it("does not wait for the Windows handshake before the run can start", async () => {
+    const child = createWindowsChildProcess();
+    let readyEmitted = false;
+    mockSpawn.mockImplementation(() => {
+      queueMicrotask(() => child.emit("spawn"));
+      return child as never;
+    });
+
+    const result = await startSleepPrevention(["ship it"], {
+      pid: 42,
+      platform: "win32",
+    });
+
+    // Returning before the helper has said anything is the point: the run
+    // must not be blocked behind the PowerShell compile.
+    expect(readyEmitted).toBe(false);
+    expect(result.type).toBe("active");
+    if (result.type !== "active") return;
+
+    readyEmitted = true;
+    child.stdout?.push("gnhf-sleep-ready\n");
+    await expect(result.confirmed).resolves.toBe(true);
   });
 
   it("records the Windows helper's stderr when it exits before reporting ready", async () => {
@@ -630,7 +656,10 @@ describe("startSleepPrevention", () => {
         platform: "win32",
       });
 
-      expect(result).toEqual({ type: "skipped", reason: "unavailable" });
+      expect(result.type).toBe("active");
+      if (result.type !== "active") return;
+      await expect(result.confirmed).resolves.toBe(false);
+
       const logged = readDebugLogEvents(logPath, "sleep:unavailable");
       expect(logged).toHaveLength(1);
       expect(logged[0]).toEqual(
@@ -646,7 +675,7 @@ describe("startSleepPrevention", () => {
     }
   });
 
-  it("skips sleep prevention when the Windows helper never reports ready", async () => {
+  it("reports the Windows helper as unconfirmed when it never reports ready", async () => {
     vi.useFakeTimers();
     const child = createWindowsChildProcess();
     mockSpawn.mockImplementation(() => {
@@ -654,18 +683,42 @@ describe("startSleepPrevention", () => {
       return child as never;
     });
 
-    const resultPromise = startSleepPrevention(["ship it"], {
+    const result = await startSleepPrevention(["ship it"], {
       pid: 42,
       platform: "win32",
     });
 
+    expect(result.type).toBe("active");
+    if (result.type !== "active") return;
+
     await vi.advanceTimersByTimeAsync(15_000);
     await vi.advanceTimersByTimeAsync(1_100);
 
-    await expect(resultPromise).resolves.toEqual({
-      type: "skipped",
-      reason: "unavailable",
-    });
+    await expect(result.confirmed).resolves.toBe(false);
     expect(child.kill).toHaveBeenCalled();
+  });
+
+  it("does not blame a Windows helper that cleanup tore down before it was ready", async () => {
+    vi.useFakeTimers();
+    const child = createWindowsChildProcess();
+    mockSpawn.mockImplementation(() => {
+      queueMicrotask(() => child.emit("spawn"));
+      return child as never;
+    });
+
+    const result = await startSleepPrevention(["ship it"], {
+      pid: 42,
+      platform: "win32",
+    });
+
+    expect(result.type).toBe("active");
+    if (result.type !== "active") return;
+
+    const cleanupPromise = result.cleanup();
+    child.emit("exit", 0, null);
+    await vi.advanceTimersByTimeAsync(1_100);
+    await cleanupPromise;
+
+    await expect(result.confirmed).resolves.toBe(true);
   });
 });

--- a/src/core/sleep.test.ts
+++ b/src/core/sleep.test.ts
@@ -603,24 +603,21 @@ describe("startSleepPrevention", () => {
 
   it("does not wait for the Windows handshake before the run can start", async () => {
     const child = createWindowsChildProcess();
-    let readyEmitted = false;
     mockSpawn.mockImplementation(() => {
       queueMicrotask(() => child.emit("spawn"));
       return child as never;
     });
 
+    // Resolving before the helper has said anything is the point: the run
+    // must not be blocked behind the PowerShell compile.
     const result = await startSleepPrevention(["ship it"], {
       pid: 42,
       platform: "win32",
     });
 
-    // Returning before the helper has said anything is the point: the run
-    // must not be blocked behind the PowerShell compile.
-    expect(readyEmitted).toBe(false);
     expect(result.type).toBe("active");
     if (result.type !== "active") return;
 
-    readyEmitted = true;
     child.stdout?.push("gnhf-sleep-ready\n");
     await expect(result.confirmed).resolves.toBe(true);
   });
@@ -677,6 +674,50 @@ describe("startSleepPrevention", () => {
 
   it("reports the Windows helper as unconfirmed when it never reports ready", async () => {
     vi.useFakeTimers();
+    const tempDir = mkdtempSync(join(tmpdir(), "gnhf-sleep-"));
+    const logPath = join(tempDir, "gnhf.log");
+    initDebugLog(logPath);
+
+    const child = createWindowsChildProcess();
+    mockSpawn.mockImplementation(() => {
+      queueMicrotask(() => child.emit("spawn"));
+      return child as never;
+    });
+
+    try {
+      const result = await startSleepPrevention(["ship it"], {
+        pid: 42,
+        platform: "win32",
+      });
+
+      expect(result.type).toBe("active");
+      if (result.type !== "active") return;
+
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      // The deadline is a reporting deadline: a helper that is only slow to
+      // start must be left alive, or the run loses its inhibitor for good.
+      expect(child.kill).not.toHaveBeenCalled();
+
+      const cleanupPromise = result.cleanup();
+      await vi.advanceTimersByTimeAsync(1_100);
+      await cleanupPromise;
+
+      await expect(result.confirmed).resolves.toBe(false);
+      expect(readDebugLogEvents(logPath, "sleep:unavailable")).toEqual([
+        expect.objectContaining({
+          command: "powershell.exe",
+          reason: "ready-timeout",
+          timeoutMs: 15_000,
+        }),
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still confirms a Windows helper that reports ready after the deadline", async () => {
+    vi.useFakeTimers();
     const child = createWindowsChildProcess();
     mockSpawn.mockImplementation(() => {
       queueMicrotask(() => child.emit("spawn"));
@@ -692,10 +733,11 @@ describe("startSleepPrevention", () => {
     if (result.type !== "active") return;
 
     await vi.advanceTimersByTimeAsync(15_000);
-    await vi.advanceTimersByTimeAsync(1_100);
+    child.stdout?.push("gnhf-sleep-ready\n");
+    await vi.advanceTimersByTimeAsync(0);
 
-    await expect(result.confirmed).resolves.toBe(false);
-    expect(child.kill).toHaveBeenCalled();
+    await expect(result.confirmed).resolves.toBe(true);
+    expect(child.kill).not.toHaveBeenCalled();
   });
 
   it("does not blame a Windows helper that cleanup tore down before it was ready", async () => {

--- a/src/core/sleep.test.ts
+++ b/src/core/sleep.test.ts
@@ -17,7 +17,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { spawn } from "node:child_process";
-import { initDebugLog } from "./debug-log.js";
+import { initDebugLog, resetDebugLogForTests } from "./debug-log.js";
 import { startSleepPrevention } from "./sleep.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -61,6 +61,7 @@ describe("startSleepPrevention", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+    resetDebugLogForTests();
   });
 
   it("starts caffeinate on macOS and returns a cleanup handle", async () => {
@@ -630,7 +631,9 @@ describe("startSleepPrevention", () => {
       });
 
       expect(result).toEqual({ type: "skipped", reason: "unavailable" });
-      expect(readDebugLogEvents(logPath, "sleep:unavailable").at(-1)).toEqual(
+      const logged = readDebugLogEvents(logPath, "sleep:unavailable");
+      expect(logged).toHaveLength(1);
+      expect(logged[0]).toEqual(
         expect.objectContaining({
           command: "powershell.exe",
           reason: "early-exit",

--- a/src/core/sleep.test.ts
+++ b/src/core/sleep.test.ts
@@ -17,6 +17,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { spawn } from "node:child_process";
+import { initDebugLog } from "./debug-log.js";
 import { startSleepPrevention } from "./sleep.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -32,6 +33,17 @@ function createChildProcess(pid = 1234): ChildProcess {
     signalCode: null,
   });
   return child as unknown as ChildProcess;
+}
+
+function readDebugLogEvents(
+  logPath: string,
+  event: string,
+): Array<Record<string, unknown>> {
+  return readFileSync(logPath, "utf-8")
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+    .filter((entry) => entry.event === event);
 }
 
 function createWindowsChildProcess(pid = 1234): ChildProcess {
@@ -586,26 +598,49 @@ describe("startSleepPrevention", () => {
     expect(result.type).toBe("active");
   });
 
-  it("skips sleep prevention when the Windows helper exits before it is ready", async () => {
+  it("records the Windows helper's stderr when it exits before reporting ready", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "gnhf-sleep-"));
+    const logPath = join(tempDir, "gnhf.log");
+    initDebugLog(logPath);
+
     const child = createWindowsChildProcess();
     mockSpawn.mockImplementation(() => {
       queueMicrotask(() => {
         child.emit("spawn");
-        child.stderr?.push('Cannot convert argument "flags"\n');
-        queueMicrotask(() => {
-          Object.assign(child, { exitCode: 1 });
-          child.emit("exit", 1, null);
+        Object.assign(child, { exitCode: 1 });
+        child.emit("exit", 1, null);
+        // Real pipes deliver their buffered output on a later loop turn,
+        // after "exit" and before "close", so the diagnostic is only
+        // complete once the stream has actually ended.
+        setImmediate(() => {
+          child.stderr?.once("end", () => {
+            child.emit("close", 1, null);
+          });
+          child.stderr?.push('Cannot convert argument "flags"\n');
+          child.stderr?.push(null);
         });
       });
       return child as never;
     });
 
-    const result = await startSleepPrevention(["ship it"], {
-      pid: 42,
-      platform: "win32",
-    });
+    try {
+      const result = await startSleepPrevention(["ship it"], {
+        pid: 42,
+        platform: "win32",
+      });
 
-    expect(result).toEqual({ type: "skipped", reason: "unavailable" });
+      expect(result).toEqual({ type: "skipped", reason: "unavailable" });
+      expect(readDebugLogEvents(logPath, "sleep:unavailable").at(-1)).toEqual(
+        expect.objectContaining({
+          command: "powershell.exe",
+          reason: "early-exit",
+          exitCode: 1,
+          stderr: 'Cannot convert argument "flags"',
+        }),
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("skips sleep prevention when the Windows helper never reports ready", async () => {

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -214,6 +214,11 @@ function buildPowerShellCommand(parentPid: number): string {
     "  public static extern uint SetThreadExecutionState(uint flags);",
     "}",
     "'@;",
+    // ES_CONTINUOUS (0x80000000) and ES_SYSTEM_REQUIRED (0x00000001), written
+    // as [uint32]-typed decimals on purpose: Windows PowerShell parses the hex
+    // literal 0x80000000 as a signed Int32, so the P/Invoke uint conversion
+    // throws while the helper stays alive, silently leaving the machine free to
+    // sleep. Covered by sleep.windows.test.ts.
     "[uint32]$ES_CONTINUOUS = 2147483648;",
     "[uint32]$ES_SYSTEM_REQUIRED = 1;",
     "[SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS -bor $ES_SYSTEM_REQUIRED) | Out-Null;",

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -12,6 +12,12 @@ export type SleepPreventionResult =
   | {
       type: "active";
       cleanup: () => Promise<void>;
+      /**
+       * Resolves false once the helper is positively known not to be holding
+       * the machine awake. Readiness is settled off the startup path so the
+       * run is not blocked behind it; the answer is only needed at shutdown.
+       */
+      confirmed: Promise<boolean>;
     }
   | {
       type: "reexeced";
@@ -50,6 +56,12 @@ const WINDOWS_HELPER_READY_MARKER = "gnhf-sleep-ready";
 interface HelperReadiness {
   marker: string;
   timeoutMs: number;
+}
+
+interface HelperProcess {
+  child: ChildProcess;
+  confirmed: Promise<boolean>;
+  markStopping: () => void;
 }
 
 function getSignalExitCode(signal: NodeJS.Signals | null): number {
@@ -322,31 +334,26 @@ async function waitForHelperReady(
   });
 }
 
-async function startHelperProcess(
-  command: string,
-  args: string[],
-  spawnFn: typeof spawn,
-  env: NodeJS.ProcessEnv,
-  readiness?: HelperReadiness,
-): Promise<ChildProcess | null> {
-  const child = spawnFn(command, args, {
-    env,
-    stdio: readiness ? ["ignore", "pipe", "pipe"] : "ignore",
-  });
-  const stderrTail = collectStderrTail(child);
-  const closed = trackStdioClose(child);
+async function confirmHelperReadiness(options: {
+  child: ChildProcess;
+  closed: Promise<void>;
+  command: string;
+  isStopping: () => boolean;
+  readiness: HelperReadiness;
+  stderrTail: () => string;
+}): Promise<boolean> {
+  const { child, closed, command, isStopping, readiness, stderrTail } = options;
 
-  const spawned = await waitForSpawn(child);
-  if (!spawned) {
-    appendDebugLog("sleep:unavailable", { command });
-    return null;
-  }
-
-  if (readiness) {
+  try {
     if (await waitForHelperReady(child, readiness)) {
       child.stdout?.resume();
-      return child;
+      appendDebugLog("sleep:ready", { command });
+      return true;
     }
+
+    // A helper torn down by our own cleanup never failed; only a helper that
+    // gave up on its own counts as a failure worth reporting.
+    if (isStopping()) return true;
 
     const exited = child.exitCode != null || child.signalCode != null;
     const exitCode = child.exitCode;
@@ -368,7 +375,53 @@ async function startHelperProcess(
       ...(exitCode != null ? { exitCode } : {}),
       ...(stderr ? { stderr } : {}),
     });
+    return false;
+  } catch (error) {
+    appendDebugLog("sleep:unavailable", {
+      command,
+      reason: "confirm-failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+async function startHelperProcess(
+  command: string,
+  args: string[],
+  spawnFn: typeof spawn,
+  env: NodeJS.ProcessEnv,
+  readiness?: HelperReadiness,
+): Promise<HelperProcess | null> {
+  const child = spawnFn(command, args, {
+    env,
+    stdio: readiness ? ["ignore", "pipe", "pipe"] : "ignore",
+  });
+  const stderrTail = collectStderrTail(child);
+  const closed = trackStdioClose(child);
+
+  const spawned = await waitForSpawn(child);
+  if (!spawned) {
+    appendDebugLog("sleep:unavailable", { command });
     return null;
+  }
+
+  if (readiness) {
+    let stopping = false;
+    return {
+      child,
+      confirmed: confirmHelperReadiness({
+        child,
+        closed,
+        command,
+        isStopping: () => stopping,
+        readiness,
+        stderrTail,
+      }),
+      markStopping: () => {
+        stopping = true;
+      },
+    };
   }
 
   const stable = await waitForHelperStability(child, HELPER_STARTUP_GRACE_MS);
@@ -380,7 +433,11 @@ async function startHelperProcess(
     return null;
   }
 
-  return child;
+  return {
+    child,
+    confirmed: Promise.resolve(true),
+    markStopping: () => {},
+  };
 }
 
 export async function startSleepPrevention(
@@ -534,20 +591,22 @@ export async function startSleepPrevention(
   }
 
   if (platform === "darwin") {
-    const child = await startHelperProcess(
+    const helper = await startHelperProcess(
       "caffeinate",
       ["-i", "-w", String(pid)],
       spawnFn,
       env,
     );
-    if (!child) return { type: "skipped", reason: "unavailable" };
+    if (!helper) return { type: "skipped", reason: "unavailable" };
 
     appendDebugLog("sleep:active", { command: "caffeinate" });
     return {
       type: "active",
+      confirmed: helper.confirmed,
       cleanup: async () => {
+        helper.markStopping();
         appendDebugLog("sleep:cleanup", { command: "caffeinate" });
-        await shutdownChildProcess(child, {
+        await shutdownChildProcess(helper.child, {
           detached: false,
           timeoutMs: 1_000,
         });
@@ -556,7 +615,7 @@ export async function startSleepPrevention(
   }
 
   if (platform === "win32") {
-    const child = await startHelperProcess(
+    const helper = await startHelperProcess(
       "powershell.exe",
       [
         "-NoLogo",
@@ -574,14 +633,16 @@ export async function startSleepPrevention(
         timeoutMs: HELPER_READY_TIMEOUT_MS,
       },
     );
-    if (!child) return { type: "skipped", reason: "unavailable" };
+    if (!helper) return { type: "skipped", reason: "unavailable" };
 
     appendDebugLog("sleep:active", { command: "powershell.exe" });
     return {
       type: "active",
+      confirmed: helper.confirmed,
       cleanup: async () => {
+        helper.markStopping();
         appendDebugLog("sleep:cleanup", { command: "powershell.exe" });
-        await shutdownChildProcess(child, {
+        await shutdownChildProcess(helper.child, {
           detached: false,
           timeoutMs: 1_000,
         });

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -42,6 +42,14 @@ const GNHF_SLEEP_REEXEC_READY_PATH = "GNHF_SLEEP_REEXEC_READY_PATH";
 const GNHF_SLEEP_REEXEC_READY_DIR_PREFIX = "gnhf-sleep-";
 const GNHF_SLEEP_REEXEC_READY_FILENAME = "reexec-ready";
 const HELPER_STARTUP_GRACE_MS = 100;
+const HELPER_READY_TIMEOUT_MS = 15_000;
+const HELPER_STDERR_TAIL_LIMIT = 2_000;
+const WINDOWS_HELPER_READY_MARKER = "gnhf-sleep-ready";
+
+interface HelperReadiness {
+  marker: string;
+  timeoutMs: number;
+}
 
 function getSignalExitCode(signal: NodeJS.Signals | null): number {
   if (signal === "SIGINT") return 130;
@@ -206,6 +214,15 @@ function forwardTerminationSignalsToChild(
 
 function buildPowerShellCommand(parentPid: number): string {
   return [
+    "$ErrorActionPreference = 'Stop';",
+    // ES_CONTINUOUS (0x80000000) and ES_SYSTEM_REQUIRED (0x00000001), written
+    // as [uint32]-typed decimals on purpose: Windows PowerShell parses the hex
+    // literal 0x80000000 as a signed Int32, so the P/Invoke uint conversion
+    // throws while the helper stays alive, silently leaving the machine free to
+    // sleep. Covered by sleep.windows.test.ts.
+    "[uint32]$ES_CONTINUOUS = 2147483648;",
+    "[uint32]$ES_SYSTEM_REQUIRED = 1;",
+    "try {",
     "Add-Type @'",
     "using System;",
     "using System.Runtime.InteropServices;",
@@ -214,16 +231,71 @@ function buildPowerShellCommand(parentPid: number): string {
     "  public static extern uint SetThreadExecutionState(uint flags);",
     "}",
     "'@;",
-    // ES_CONTINUOUS (0x80000000) and ES_SYSTEM_REQUIRED (0x00000001), written
-    // as [uint32]-typed decimals on purpose: Windows PowerShell parses the hex
-    // literal 0x80000000 as a signed Int32, so the P/Invoke uint conversion
-    // throws while the helper stays alive, silently leaving the machine free to
-    // sleep. Covered by sleep.windows.test.ts.
-    "[uint32]$ES_CONTINUOUS = 2147483648;",
-    "[uint32]$ES_SYSTEM_REQUIRED = 1;",
-    "[SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS -bor $ES_SYSTEM_REQUIRED) | Out-Null;",
+    "if ([SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS -bor $ES_SYSTEM_REQUIRED) -eq 0) { throw 'SetThreadExecutionState returned 0'; }",
+    "} catch {",
+    "[Console]::Error.WriteLine($_.Exception.Message);",
+    "exit 1;",
+    "}",
+    // Only reachable once the execution state is actually held, so a helper
+    // that fails for any reason is reported as unavailable rather than
+    // silently counted as active.
+    `[Console]::Out.WriteLine('${WINDOWS_HELPER_READY_MARKER}');`,
+    "[Console]::Out.Flush();",
     `try { Wait-Process -Id ${parentPid} } catch { } finally { [SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS) | Out-Null }`,
   ].join("\n");
+}
+
+function collectStderrTail(child: ChildProcess): () => string {
+  let tail = "";
+  const stderr = child.stderr;
+  if (!stderr) return () => tail;
+
+  stderr.setEncoding("utf-8");
+  stderr.on("data", (chunk: string) => {
+    tail = (tail + chunk).slice(-HELPER_STDERR_TAIL_LIMIT);
+  });
+  return () => tail.trim();
+}
+
+async function waitForHelperReady(
+  child: ChildProcess,
+  readiness: HelperReadiness,
+): Promise<boolean> {
+  const stdout = child.stdout;
+  if (!stdout) return false;
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let buffered = "";
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdout.off("data", onData);
+      child.off("exit", onEnd);
+      child.off("error", onEnd);
+      resolve(value);
+    };
+    const onData = (chunk: string) => {
+      buffered = (buffered + chunk).slice(-HELPER_STDERR_TAIL_LIMIT);
+      if (buffered.includes(readiness.marker)) settle(true);
+    };
+    const onEnd = () => {
+      settle(false);
+    };
+
+    const timer = setTimeout(() => {
+      settle(false);
+    }, readiness.timeoutMs);
+    timer.unref?.();
+
+    stdout.setEncoding("utf-8");
+    stdout.on("data", onData);
+    child.once("exit", onEnd);
+    child.once("error", onEnd);
+
+    if (child.exitCode != null || child.signalCode != null) settle(false);
+  });
 }
 
 async function startHelperProcess(
@@ -231,15 +303,38 @@ async function startHelperProcess(
   args: string[],
   spawnFn: typeof spawn,
   env: NodeJS.ProcessEnv,
+  readiness?: HelperReadiness,
 ): Promise<ChildProcess | null> {
   const child = spawnFn(command, args, {
     env,
-    stdio: "ignore",
+    stdio: readiness ? ["ignore", "pipe", "pipe"] : "ignore",
   });
+  const stderrTail = collectStderrTail(child);
 
   const spawned = await waitForSpawn(child);
   if (!spawned) {
     appendDebugLog("sleep:unavailable", { command });
+    return null;
+  }
+
+  if (readiness) {
+    if (await waitForHelperReady(child, readiness)) {
+      child.stdout?.resume();
+      return child;
+    }
+
+    const exited = child.exitCode != null || child.signalCode != null;
+    const stderr = stderrTail();
+    appendDebugLog("sleep:unavailable", {
+      command,
+      reason: exited ? "early-exit" : "ready-timeout",
+      ...(child.exitCode != null ? { exitCode: child.exitCode } : {}),
+      ...(stderr ? { stderr } : {}),
+    });
+    await shutdownChildProcess(child, {
+      detached: false,
+      timeoutMs: 1_000,
+    });
     return null;
   }
 
@@ -441,6 +536,10 @@ export async function startSleepPrevention(
       ],
       spawnFn,
       env,
+      {
+        marker: WINDOWS_HELPER_READY_MARKER,
+        timeoutMs: HELPER_READY_TIMEOUT_MS,
+      },
     );
     if (!child) return { type: "skipped", reason: "unavailable" };
 

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -293,24 +293,31 @@ function collectStderrTail(child: ChildProcess): () => string {
   return () => tail.trim();
 }
 
+interface HelperReadyOutcome {
+  ready: boolean;
+  timedOut: boolean;
+}
+
 async function waitForHelperReady(
   child: ChildProcess,
   readiness: HelperReadiness,
-): Promise<boolean> {
+  stopped: Promise<void>,
+): Promise<HelperReadyOutcome> {
   const stdout = child.stdout;
-  if (!stdout) return false;
+  if (!stdout) return { ready: false, timedOut: false };
 
   return await new Promise((resolve) => {
     let settled = false;
+    let timedOut = false;
     let buffered = "";
-    const settle = (value: boolean) => {
+    const settle = (ready: boolean) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       stdout.off("data", onData);
       child.off("exit", onEnd);
       child.off("error", onEnd);
-      resolve(value);
+      resolve({ ready, timedOut });
     };
     const onData = (chunk: string) => {
       buffered = (buffered + chunk).slice(-HELPER_STDERR_TAIL_LIMIT);
@@ -320,8 +327,11 @@ async function waitForHelperReady(
       settle(false);
     };
 
+    // The deadline only decides what gets reported. A helper that is merely
+    // slow to compile still holds the machine awake once it catches up, so it
+    // is left running until it exits on its own or cleanup tears it down.
     const timer = setTimeout(() => {
-      settle(false);
+      timedOut = true;
     }, readiness.timeoutMs);
     timer.unref?.();
 
@@ -329,6 +339,7 @@ async function waitForHelperReady(
     stdout.on("data", onData);
     child.once("exit", onEnd);
     child.once("error", onEnd);
+    void stopped.then(() => settle(false));
 
     if (child.exitCode != null || child.signalCode != null) settle(false);
   });
@@ -341,37 +352,40 @@ async function confirmHelperReadiness(options: {
   isStopping: () => boolean;
   readiness: HelperReadiness;
   stderrTail: () => string;
+  stopped: Promise<void>;
 }): Promise<boolean> {
-  const { child, closed, command, isStopping, readiness, stderrTail } = options;
+  const { child, closed, command, isStopping, readiness, stderrTail, stopped } =
+    options;
 
   try {
-    if (await waitForHelperReady(child, readiness)) {
-      child.stdout?.resume();
+    const { ready, timedOut } = await waitForHelperReady(
+      child,
+      readiness,
+      stopped,
+    );
+    child.stdout?.resume();
+
+    if (ready) {
       appendDebugLog("sleep:ready", { command });
       return true;
     }
 
-    // A helper torn down by our own cleanup never failed; only a helper that
-    // gave up on its own counts as a failure worth reporting.
-    if (isStopping()) return true;
+    // A helper torn down by our own cleanup before the deadline never failed;
+    // only a helper that gave up on its own, or that stayed silent past the
+    // deadline, counts as a failure worth reporting.
+    if (isStopping() && !timedOut) return true;
 
     const exited = child.exitCode != null || child.signalCode != null;
     const exitCode = child.exitCode;
     // The pipes are only guaranteed to have drained once "close" fires, so
     // the helper's stderr is read after the stream is done, not on "exit".
-    child.stdout?.resume();
-    if (!exited) {
-      await shutdownChildProcess(child, {
-        detached: false,
-        timeoutMs: 1_000,
-      });
-    }
     await waitForStdioFlush(closed, HELPER_STDIO_FLUSH_TIMEOUT_MS);
 
     const stderr = stderrTail();
     appendDebugLog("sleep:unavailable", {
       command,
       reason: exited ? "early-exit" : "ready-timeout",
+      ...(exited ? {} : { timeoutMs: readiness.timeoutMs }),
       ...(exitCode != null ? { exitCode } : {}),
       ...(stderr ? { stderr } : {}),
     });
@@ -408,6 +422,10 @@ async function startHelperProcess(
 
   if (readiness) {
     let stopping = false;
+    let resolveStopped = () => {};
+    const stopped = new Promise<void>((resolve) => {
+      resolveStopped = resolve;
+    });
     return {
       child,
       confirmed: confirmHelperReadiness({
@@ -417,9 +435,11 @@ async function startHelperProcess(
         isStopping: () => stopping,
         readiness,
         stderrTail,
+        stopped,
       }),
       markStopping: () => {
         stopping = true;
+        resolveStopped();
       },
     };
   }

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -214,8 +214,8 @@ function buildPowerShellCommand(parentPid: number): string {
     "  public static extern uint SetThreadExecutionState(uint flags);",
     "}",
     "'@;",
-    "$ES_CONTINUOUS = 0x80000000;",
-    "$ES_SYSTEM_REQUIRED = 0x00000001;",
+    "[uint32]$ES_CONTINUOUS = 2147483648;",
+    "[uint32]$ES_SYSTEM_REQUIRED = 1;",
     "[SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS -bor $ES_SYSTEM_REQUIRED) | Out-Null;",
     `try { Wait-Process -Id ${parentPid} } catch { } finally { [SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS) | Out-Null }`,
   ].join("\n");

--- a/src/core/sleep.ts
+++ b/src/core/sleep.ts
@@ -43,6 +43,7 @@ const GNHF_SLEEP_REEXEC_READY_DIR_PREFIX = "gnhf-sleep-";
 const GNHF_SLEEP_REEXEC_READY_FILENAME = "reexec-ready";
 const HELPER_STARTUP_GRACE_MS = 100;
 const HELPER_READY_TIMEOUT_MS = 15_000;
+const HELPER_STDIO_FLUSH_TIMEOUT_MS = 1_000;
 const HELPER_STDERR_TAIL_LIMIT = 2_000;
 const WINDOWS_HELPER_READY_MARKER = "gnhf-sleep-ready";
 
@@ -245,6 +246,29 @@ function buildPowerShellCommand(parentPid: number): string {
   ].join("\n");
 }
 
+function trackStdioClose(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    child.once("close", () => resolve());
+  });
+}
+
+async function waitForStdioFlush(
+  closed: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    await Promise.race([closed, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function collectStderrTail(child: ChildProcess): () => string {
   let tail = "";
   const stderr = child.stderr;
@@ -310,6 +334,7 @@ async function startHelperProcess(
     stdio: readiness ? ["ignore", "pipe", "pipe"] : "ignore",
   });
   const stderrTail = collectStderrTail(child);
+  const closed = trackStdioClose(child);
 
   const spawned = await waitForSpawn(child);
   if (!spawned) {
@@ -324,16 +349,24 @@ async function startHelperProcess(
     }
 
     const exited = child.exitCode != null || child.signalCode != null;
+    const exitCode = child.exitCode;
+    // The pipes are only guaranteed to have drained once "close" fires, so
+    // the helper's stderr is read after the stream is done, not on "exit".
+    child.stdout?.resume();
+    if (!exited) {
+      await shutdownChildProcess(child, {
+        detached: false,
+        timeoutMs: 1_000,
+      });
+    }
+    await waitForStdioFlush(closed, HELPER_STDIO_FLUSH_TIMEOUT_MS);
+
     const stderr = stderrTail();
     appendDebugLog("sleep:unavailable", {
       command,
       reason: exited ? "early-exit" : "ready-timeout",
-      ...(child.exitCode != null ? { exitCode: child.exitCode } : {}),
+      ...(exitCode != null ? { exitCode } : {}),
       ...(stderr ? { stderr } : {}),
-    });
-    await shutdownChildProcess(child, {
-      detached: false,
-      timeoutMs: 1_000,
     });
     return null;
   }

--- a/src/core/sleep.windows.test.ts
+++ b/src/core/sleep.windows.test.ts
@@ -183,7 +183,7 @@ describeWindows("Windows sleep prevention helper", () => {
   );
 
   it(
-    "reports sleep prevention as active only once the helper holds the state",
+    "confirms the real helper is holding the execution state",
     { timeout: 90_000 },
     async () => {
       const parent = await spawnParent();
@@ -194,7 +194,14 @@ describeWindows("Windows sleep prevention helper", () => {
 
       expect(result.type).toBe("active");
       if (result.type !== "active") return;
-      await result.cleanup();
+
+      try {
+        // Confirmation is resolved off the startup path, so this awaits the
+        // real PowerShell handshake rather than a value gnhf assumed.
+        await expect(result.confirmed).resolves.toBe(true);
+      } finally {
+        await result.cleanup();
+      }
     },
   );
 });

--- a/src/core/sleep.windows.test.ts
+++ b/src/core/sleep.windows.test.ts
@@ -101,12 +101,13 @@ function waitForReadyOrExit(
   });
 }
 
-function waitForClose(child: ChildProcess): Promise<number | null> {
+/**
+ * Registered before the helper can emit anything, so awaiting it is a real
+ * flush guarantee: "close" fires only after every stdio pipe has drained,
+ * whereas "exit" can arrive while stderr is still buffered.
+ */
+function trackClose(child: ChildProcess): Promise<number | null> {
   return new Promise((resolveCode) => {
-    if (child.exitCode != null) {
-      resolveCode(child.exitCode);
-      return;
-    }
     child.once("close", (code) => resolveCode(code));
   });
 }
@@ -150,6 +151,7 @@ describeWindows("Windows sleep prevention helper", () => {
         windowsHide: true,
       });
       started.push(helper);
+      const closed = trackClose(helper);
       await waitForSpawn(helper);
 
       const state = { stdout: "", stderr: "" };
@@ -166,7 +168,7 @@ describeWindows("Windows sleep prevention helper", () => {
       const outcome = await waitForReadyOrExit(helper, state);
       // On the failure path, close flushes the helper's stderr so the
       // assertion below reports the actual PowerShell error.
-      if (outcome === "exit") await waitForClose(helper);
+      if (outcome === "exit") await closed;
       expect(state.stderr).toBe("");
       expect(outcome).toBe("ready");
 
@@ -174,8 +176,7 @@ describeWindows("Windows sleep prevention helper", () => {
       expect(helper.exitCode).toBeNull();
 
       parent.kill("SIGKILL");
-      // Waiting for close (not exit) guarantees stderr has been fully flushed.
-      const exitCode = await waitForClose(helper);
+      const exitCode = await closed;
       expect(state.stderr).toBe("");
       expect(exitCode).toBe(0);
     },

--- a/src/core/sleep.windows.test.ts
+++ b/src/core/sleep.windows.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { startSleepPrevention } from "./sleep.js";
@@ -10,7 +11,8 @@ import { startSleepPrevention } from "./sleep.js";
 // prevention is on while the machine still sleeps mid-run.
 const describeWindows = describe.skipIf(process.platform !== "win32");
 
-const SETTLE_MS = 5_000;
+const READY_MARKER = "gnhf-sleep-ready";
+const HELPER_TIMEOUT_MS = 45_000;
 
 interface CapturedSpawn {
   command: string;
@@ -18,11 +20,15 @@ interface CapturedSpawn {
 }
 
 function createStubChild(): ChildProcess {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
   const child = Object.assign(new EventEmitter(), {
     exitCode: null,
     pid: 4321,
     kill: () => true as const,
     signalCode: null,
+    stdout,
+    stderr,
   });
   return child as unknown as ChildProcess;
 }
@@ -33,7 +39,10 @@ async function captureHelperSpawn(parentPid: number): Promise<CapturedSpawn> {
   const stubSpawn = ((command: string, args: string[]) => {
     captured = { command, args };
     const child = createStubChild();
-    queueMicrotask(() => child.emit("spawn"));
+    queueMicrotask(() => {
+      child.emit("spawn");
+      child.stdout?.push(`${READY_MARKER}\n`);
+    });
     return child;
   }) as unknown as typeof spawn;
 
@@ -55,6 +64,53 @@ function waitForSpawn(child: ChildProcess): Promise<number> {
   });
 }
 
+/**
+ * Resolves as soon as the helper reports ready or exits, so the assertions
+ * never depend on a fixed settle window: a helper that fails the flag
+ * conversion exits and is observed, however slowly PowerShell got there.
+ */
+function waitForReadyOrExit(
+  child: ChildProcess,
+  state: { stdout: string },
+): Promise<"ready" | "exit"> {
+  return new Promise((resolveOutcome, rejectOutcome) => {
+    let settled = false;
+    const settle = (outcome: "ready" | "exit") => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveOutcome(outcome);
+    };
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      rejectOutcome(
+        new Error("helper neither reported ready nor exited in time"),
+      );
+    }, HELPER_TIMEOUT_MS);
+
+    child.stdout?.on("data", () => {
+      if (state.stdout.includes(READY_MARKER)) settle("ready");
+    });
+    child.once("exit", () => settle("exit"));
+    child.once("error", rejectOutcome);
+
+    if (state.stdout.includes(READY_MARKER)) settle("ready");
+    else if (child.exitCode != null || child.signalCode != null) settle("exit");
+  });
+}
+
+function waitForClose(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolveCode) => {
+    if (child.exitCode != null) {
+      resolveCode(child.exitCode);
+      return;
+    }
+    child.once("close", (code) => resolveCode(code));
+  });
+}
+
 describeWindows("Windows sleep prevention helper", () => {
   const started: ChildProcess[] = [];
 
@@ -68,51 +124,76 @@ describeWindows("Windows sleep prevention helper", () => {
     }
   });
 
+  function spawnParent(): Promise<ChildProcess> {
+    const parent = spawn(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 60000)"],
+      {
+        stdio: "ignore",
+      },
+    );
+    started.push(parent);
+    return waitForSpawn(parent).then(() => parent);
+  }
+
   it(
-    "applies SetThreadExecutionState without a flag conversion error",
-    { timeout: 60_000 },
+    "applies SetThreadExecutionState and reports ready without an error",
+    { timeout: 90_000 },
     async () => {
       // A live parent keeps the helper in its Wait-Process stage, which is the
       // same shape as a real gnhf run.
-      const parent = spawn(
-        process.execPath,
-        ["-e", "setTimeout(() => {}, 60000)"],
-        {
-          stdio: "ignore",
-        },
-      );
-      started.push(parent);
-      const parentPid = await waitForSpawn(parent);
+      const parent = await spawnParent();
 
-      const captured = await captureHelperSpawn(parentPid);
+      const captured = await captureHelperSpawn(parent.pid ?? 0);
       const helper = spawn(captured.command, captured.args, {
-        stdio: ["ignore", "ignore", "pipe"],
+        stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
       });
       started.push(helper);
       await waitForSpawn(helper);
 
-      let stderr = "";
-      let helperExited = false;
+      const state = { stdout: "", stderr: "" };
+      helper.stdout?.on("data", (chunk) => {
+        state.stdout += String(chunk);
+      });
       helper.stderr?.on("data", (chunk) => {
-        stderr += String(chunk);
-      });
-      helper.once("exit", () => {
-        helperExited = true;
+        state.stderr += String(chunk);
       });
 
-      // Windows PowerShell parses 0x80000000 as a signed Int32, so with the old
-      // flag literals the uint P/Invoke argument conversion throws here, within
-      // a second of Add-Type finishing. The helper survives that error and
-      // keeps waiting, which is exactly why the failure is invisible to gnhf.
-      const deadline = Date.now() + SETTLE_MS;
-      while (Date.now() < deadline && stderr === "" && !helperExited) {
-        await new Promise((r) => setTimeout(r, 100));
-      }
+      // Windows PowerShell parses 0x80000000 as a signed Int32, so with the
+      // old flag literals the uint P/Invoke argument conversion fails and the
+      // helper reports the error instead of reaching its ready marker.
+      const outcome = await waitForReadyOrExit(helper, state);
+      // On the failure path, close flushes the helper's stderr so the
+      // assertion below reports the actual PowerShell error.
+      if (outcome === "exit") await waitForClose(helper);
+      expect(state.stderr).toBe("");
+      expect(outcome).toBe("ready");
 
-      expect(stderr).toBe("");
       // Still holding the execution state on behalf of the live parent.
-      expect(helperExited).toBe(false);
+      expect(helper.exitCode).toBeNull();
+
+      parent.kill("SIGKILL");
+      // Waiting for close (not exit) guarantees stderr has been fully flushed.
+      const exitCode = await waitForClose(helper);
+      expect(state.stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  it(
+    "reports sleep prevention as active only once the helper holds the state",
+    { timeout: 90_000 },
+    async () => {
+      const parent = await spawnParent();
+
+      const result = await startSleepPrevention(["ship it"], {
+        pid: parent.pid,
+      });
+
+      expect(result.type).toBe("active");
+      if (result.type !== "active") return;
+      await result.cleanup();
     },
   );
 });

--- a/src/core/sleep.windows.test.ts
+++ b/src/core/sleep.windows.test.ts
@@ -1,0 +1,118 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { startSleepPrevention } from "./sleep.js";
+
+// These tests execute the real PowerShell helper gnhf spawns on Windows, so
+// they only make sense on win32. A helper that gnhf reports as active but that
+// never applies SetThreadExecutionState is a silent failure: gnhf claims sleep
+// prevention is on while the machine still sleeps mid-run.
+const describeWindows = describe.skipIf(process.platform !== "win32");
+
+const SETTLE_MS = 5_000;
+
+interface CapturedSpawn {
+  command: string;
+  args: string[];
+}
+
+function createStubChild(): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    pid: 4321,
+    kill: () => true as const,
+    signalCode: null,
+  });
+  return child as unknown as ChildProcess;
+}
+
+/** Captures the exact command line gnhf hands to the OS for a given parent. */
+async function captureHelperSpawn(parentPid: number): Promise<CapturedSpawn> {
+  let captured: CapturedSpawn | null = null;
+  const stubSpawn = ((command: string, args: string[]) => {
+    captured = { command, args };
+    const child = createStubChild();
+    queueMicrotask(() => child.emit("spawn"));
+    return child;
+  }) as unknown as typeof spawn;
+
+  const result = await startSleepPrevention(["ship it"], {
+    pid: parentPid,
+    platform: "win32",
+    spawn: stubSpawn,
+  });
+
+  expect(result.type).toBe("active");
+  if (!captured) throw new Error("no helper process was spawned");
+  return captured;
+}
+
+function waitForSpawn(child: ChildProcess): Promise<number> {
+  return new Promise((resolvePid, rejectSpawn) => {
+    child.once("spawn", () => resolvePid(child.pid ?? 0));
+    child.once("error", rejectSpawn);
+  });
+}
+
+describeWindows("Windows sleep prevention helper", () => {
+  const started: ChildProcess[] = [];
+
+  afterEach(() => {
+    for (const child of started.splice(0)) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  });
+
+  it(
+    "applies SetThreadExecutionState without a flag conversion error",
+    { timeout: 60_000 },
+    async () => {
+      // A live parent keeps the helper in its Wait-Process stage, which is the
+      // same shape as a real gnhf run.
+      const parent = spawn(
+        process.execPath,
+        ["-e", "setTimeout(() => {}, 60000)"],
+        {
+          stdio: "ignore",
+        },
+      );
+      started.push(parent);
+      const parentPid = await waitForSpawn(parent);
+
+      const captured = await captureHelperSpawn(parentPid);
+      const helper = spawn(captured.command, captured.args, {
+        stdio: ["ignore", "ignore", "pipe"],
+        windowsHide: true,
+      });
+      started.push(helper);
+      await waitForSpawn(helper);
+
+      let stderr = "";
+      let helperExited = false;
+      helper.stderr?.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      helper.once("exit", () => {
+        helperExited = true;
+      });
+
+      // Windows PowerShell parses 0x80000000 as a signed Int32, so with the old
+      // flag literals the uint P/Invoke argument conversion throws here, within
+      // a second of Add-Type finishing. The helper survives that error and
+      // keeps waiting, which is exactly why the failure is invisible to gnhf.
+      const deadline = Date.now() + SETTLE_MS;
+      while (Date.now() < deadline && stderr === "" && !helperExited) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+
+      expect(stderr).toBe("");
+      // Still holding the execution state on behalf of the live parent.
+      expect(helperExited).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## What Changed

- Rewrote the Windows PowerShell sleep helper in `src/core/sleep.ts` to use `[uint32]`-typed decimal constants instead of the `0x80000000` hex literal (which Windows PowerShell parses as a signed `Int32`, throwing on the P/Invoke `uint` conversion while the helper stayed alive and left the machine free to sleep), and to fail fast with a nonzero exit and a stderr message when `SetThreadExecutionState` does not succeed.
- Added a readiness handshake: the helper prints a ready marker only after the execution state is actually held, and `startSleepPrevention` now returns a `confirmed` promise that is settled at shutdown rather than on the startup path, so a slow helper is left running instead of killed and an unavailable one logs `sleep:unavailable` with the exit code and stderr tail without aborting the run.
- Surfaced the outcome to users via a new `sleep` line in `src/core/exit-summary.ts` distinguishing `unstarted` (no inhibitor launched) from `unconfirmed` (launched but never confirmed), wired through `src/cli.ts`, documented in the README's new Sleep Prevention section and AGENTS.md, and covered by a new `src/core/sleep.windows.test.ts` plus additions to the sleep, CLI, and exit-summary tests.

## Risk Assessment

✅ Low: The change is tightly scoped to the sleep-prevention module plus one optional exit-summary field, closes the authorized silent-failure path at its source with a handshake the Windows CI job exercises against real PowerShell, never aborts a run on failure, and leaves macOS/Linux behavior unchanged; the only findings are informational wording and clarity items.

## Testing

Installed deps and built the CLI, then ran the four unit suites the change touches (sleep, sleep.windows, exit-summary, cli) - all green. Confirmed the regression is genuinely caught by temporarily restoring the pre-fix hex flag literals, which makes both real-PowerShell tests in sleep.windows.test.ts fail with the exact `Cannot convert argument "flags" ... to type "System.UInt32"` error, then restoring the source and watching them pass. For product-level proof I ran the old and new helper command lines against the real Windows PowerShell host with a read-back probe: the old form leaves the execution state at 0x00000000 (machine free to sleep) while the new form reports ready and shows ES_CONTINUOUS|ES_SYSTEM_REQUIRED (0x80000001) actually held. Finally I drove the built CLI through three real console runs - helper confirmed, powershell.exe missing from PATH, and a helper that starts but never confirms - and captured terminal screenshots plus the run-log `sleep:*` events; the confirmed run shows sleep:active/sleep:ready/sleep:cleanup and no notice, the other two show the yellow `sleep` line with the "could not be started" and "may have slept" wording, and all three exit 0 so an unavailable inhibitor never aborts a run, exactly as the new README section states. Worktree left clean; build output and node_modules are git-ignored and one OS temp scratch directory remained file-locked after cleanup.

- Evidence: [Exit summary when sleep prevention could not be started (real Windows console)](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/gnhf-exit-summary-sleep-notice.png)
- Evidence: [Exit summary when the helper started but never confirmed (real Windows console)](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/gnhf-exit-summary-sleep-unconfirmed.png)
- Evidence: [Exit summary when sleep prevention held the machine awake - no sleep line (real Windows console)](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/gnhf-exit-summary-sleep-held.png)
<details>
<summary>Evidence: Pre-fix vs post-fix helper run against the real PowerShell host</summary>

Source: [Pre-fix vs post-fix helper run against the real PowerShell host](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/windows-sleep-helper-before-after.txt)

<code>BEFORE (0x80000000 hex literal)&#10;stdout: PROBE previous-execution-state=0x00000000&#10;stderr: Cannot convert argument &#34;flags&#34;, with value: &#34;-2147483647&#34;, for &#34;SetThreadExecutionState&#34; to type &#34;System.UInt32&#34;: &#34;Value was either too large or too small for a UInt32.&#34;&#10;&#10;AFTER ([uint32] decimal literals)&#10;stdout: gnhf-sleep-ready&#10;PROBE previous-execution-state=0x80000001&#10;stderr: (empty)</code>

```text
========================================================================
BEFORE (0x80000000 hex literal)
========================================================================
exit code: 0
--- stdout ---
PROBE previous-execution-state=0x00000000
--- stderr ---
Cannot convert argument "flags", with value: "-2147483647", for "SetThreadExecutionState" to type "System.UInt32": 
"Cannot convert value "-2147483647" to type "System.UInt32". Error: "Value was either too large or too small for a 
UInt32.""
At line:11 char:1
+ [SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS -bor $ES_SYSTEM_ ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodException
    + FullyQualifiedErrorId : MethodArgumentConversionInvalidCastArgument
 
Cannot convert argument "flags", with value: "-2147483648", for "SetThreadExecutionState" to type "System.UInt32": 
"Cannot convert value "-2147483648" to type "System.UInt32". Error: "Value was either too large or too small for a 
UInt32.""
At line:12 char:1
+ $prev = [SleepBlock]::SetThreadExecutionState($ES_CONTINUOUS);
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodException
    + FullyQualifiedErrorId : MethodArgumentConversionInvalidCastArgument

========================================================================
AFTER  ([uint32] decimal literals)
========================================================================
exit code: 0
--- stdout ---
gnhf-sleep-ready
PROBE previous-execution-state=0x80000001
--- stderr ---
(empty)
```
</details>
<details>
<summary>Evidence: gnhf CLI transcript - three sleep-prevention states with run-log events</summary>

Source: [gnhf CLI transcript - three sleep-prevention states with run-log events](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/gnhf-sleep-prevention-cli-transcript.txt)

<code>SCENARIO 1 (real helper): no `sleep` line in the exit summary&#10;{&#34;event&#34;:&#34;sleep:active&#34;,&#34;command&#34;:&#34;powershell.exe&#34;}&#10;{&#34;event&#34;:&#34;sleep:ready&#34;,&#34;command&#34;:&#34;powershell.exe&#34;}&#10;{&#34;event&#34;:&#34;sleep:cleanup&#34;,&#34;command&#34;:&#34;powershell.exe&#34;}&#10;&#10;SCENARIO 2 (powershell.exe off PATH): sleep prevention could not be started for this run&#10;{&#34;event&#34;:&#34;sleep:unavailable&#34;,&#34;command&#34;:&#34;powershell.exe&#34;}&#10;&#10;SCENARIO 3 (helper never confirms): sleep prevention unavailable; this machine may have slept&#10;{&#34;event&#34;:&#34;sleep:active&#34;,...}&#10;{&#34;event&#34;:&#34;sleep:unavailable&#34;,&#34;reason&#34;:&#34;early-exit&#34;,&#34;exitCode&#34;:9,&#34;stderr&#34;:&#34;powershell.exe: bad option: -NoLogo...&#34;}&#10;{&#34;event&#34;:&#34;sleep:cleanup&#34;,...}&#10;&#10;All three runs exited 0.</code>

```text
command: gnhf "ship it" --agent opencode --max-iterations 12 --prevent-sleep on

==============================================================================
SCENARIO 1  normal Windows run - real PowerShell SetThreadExecutionState helper
==============================================================================
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
╭────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                             │
│   opencode ran for 2s before: max iterations reached (12)  │
╰────────────────────────────────────────────────────────────╯

  iterations      12 total      12 good      0 failed
  tokens          120 in        60 out       
  branch diff     12 commits    +12          -0
  files           0 added       1 updated    0 deleted

  notes           C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-4hL3FH\.gnhf\runs\ship-it-bef426\notes.md
  debug log       C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-4hL3FH\.gnhf\runs\ship-it-bef426\gnhf.log

  next steps      git log --oneline f4f0da768dd9..HEAD
                  git diff --stat f4f0da768dd9..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

exit code: 0
sleep events in .gnhf/runs/<id>/gnhf.log:
  {"timestamp":"2026-08-20T19:54:46.382Z","pid":42900,"event":"sleep:active","command":"powershell.exe"}
  {"timestamp":"2026-08-20T19:54:47.196Z","pid":42900,"event":"sleep:ready","command":"powershell.exe"}
  {"timestamp":"2026-08-20T19:54:49.176Z","pid":42900,"event":"sleep:cleanup","command":"powershell.exe"}

=> exit summary has no `sleep` line: gnhf held the machine awake for the whole run.

==============================================================================
SCENARIO 2  powershell.exe not on PATH - prevention never starts
==============================================================================
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
╭────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                             │
│   opencode ran for 2s before: max iterations reached (12)  │
╰────────────────────────────────────────────────────────────╯

  iterations      12 total      12 good      0 failed
  tokens          120 in        60 out       
  branch diff     12 commits    +12          -0
  files           0 added       1 updated    0 deleted

  notes           C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-XbEd6k\.gnhf\runs\ship-it-bef426\notes.md
  debug log       C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-XbEd6k\.gnhf\runs\ship-it-bef426\gnhf.log
  sleep           prevention could not be started for this run

  next steps      git log --oneline 40ebdfe20871..HEAD
                  git diff --stat 40ebdfe20871..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

exit code: 0
sleep events:
  {"timestamp":"2026-08-20T19:54:49.818Z","pid":31044,"event":"sleep:unavailable","command":"powershell.exe"}

==============================================================================
SCENARIO 3  helper starts but never confirms it holds the execution state
==============================================================================
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
╭────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                             │
│   opencode ran for 2s before: max iterations reached (12)  │
╰────────────────────────────────────────────────────────────╯

  iterations      12 total      12 good      0 failed
  tokens          120 in        60 out       
  branch diff     12 commits    +12          -0
  files           0 added       1 updated    0 deleted

  notes           C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-MmJczt\.gnhf\runs\ship-it-bef426\notes.md
  debug log       C:\Users\tfmcm\AppData\Local\Temp\gnhf-man-MmJczt\.gnhf\runs\ship-it-bef426\gnhf.log
  sleep           prevention unavailable; this machine may have slept

  next steps      git log --oneline dbe9d9b8897b..HEAD
                  git diff --stat dbe9d9b8897b..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

exit code: 0
sleep events:
  {"timestamp":"2026-08-20T19:54:53.716Z","pid":38548,"event":"sleep:active","command":"powershell.exe"}
  {"timestamp":"2026-08-20T19:54:53.872Z","pid":38548,"event":"sleep:unavailable","command":"powershell.exe","reason":"early-exit","exitCode":9,"stderr":"powershell.exe: bad option: -NoLogo\r\npowershell.exe: bad option: -NoProfile\r\npowershell.exe: bad option: -NonInteractive\r\npowershell.exe: bad option: -ExecutionPolicy"}
  {"timestamp":"2026-08-20T19:54:56.492Z","pid":38548,"event":"sleep:cleanup","command":"powershell.exe"}
```
</details>
<details>
<summary>Evidence: Regression check: sleep.windows.test.ts fails on pre-fix literals, passes on the fix</summary>

Source: [Regression check: sleep.windows.test.ts fails on pre-fix literals, passes on the fix](https://github.com/tfmcmahon/gnhf/blob/78398c55db4949da306f06514346f957a14fc869/.no-mistakes/evidence/tfmcmahon/fix-windows-sleep/regression-fail-before-pass-after.txt)

```text
Regression check: src/core/sleep.windows.test.ts (runs the real Windows PowerShell helper)

--- WITH THE PRE-FIX FLAG LITERALS (src/core/sleep.ts temporarily reverted to
    "$ES_CONTINUOUS = 0x80000000;" / "$ES_SYSTEM_REQUIRED = 0x00000001;") ---

 FAIL  Windows sleep prevention helper > applies SetThreadExecutionState and reports ready without an error
 AssertionError: expected 'Cannot convert argument "flags", with…' to be ''
 + Cannot convert argument "flags", with value: "-2147483647", for "SetThreadExecutionState"
   to type "System.UInt32": "Cannot convert value "-2147483647" to type "System.UInt32".
   Error: "Value was either too large or too small for a UInt32.""

 FAIL  Windows sleep prevention helper > confirms the real helper is holding the execution state
 AssertionError: expected false to be true

 Test Files  1 failed (1)
      Tests  2 failed (2)

--- WITH THE FIX IN PLACE (working tree restored to 8ce5512) ---

 ✓ Windows sleep prevention helper > applies SetThreadExecutionState and reports ready without an error 513ms
 ✓ Windows sleep prevention helper > confirms the real helper is holding the execution state 499ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8a33da011a6142b0dc67afabee991cb31e87456d","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 infos</summary>

- ℹ️ `src/core/sleep.ts:340` - waitForHelperReady settles on the child&#39;s `exit` event, but Node can emit `exit` while buffered stdout is still pending, so a helper that prints the ready marker and then exits immediately is recorded as never-ready. This is the exact ordering hazard the same function already guards against for stderr (it waits for `close` before reading stderrTail, per the comment at sleep.ts:380). In practice the Windows helper blocks on `Wait-Process -Id &lt;gnhf pid&gt;` and only exits once gnhf is already tearing down (where isStopping() suppresses the blame), so I could not construct a reachable production path that produces a wrong user-visible notice - flagging only because the asymmetry with the stderr path is in newly added code and the fix is small (settle readiness on `close`, or re-check `buffered` after the stdio flush before reporting failure).
- ℹ️ `src/core/exit-summary.ts:238` - The &#34;unconfirmed&#34; notice renders as &#34;prevention unavailable; this machine may have slept&#34;, but the code&#39;s own reasoning (sleep.ts:330-332) is that a helper past the 15s deadline is deliberately left running because it may well be holding the machine awake once it catches up. So for the ready-timeout case the summary asserts &#34;unavailable&#34; for a state the implementation treats as unknown. Since commit 17b7c41 explicitly split unstarted from unconfirmed to avoid exactly this kind of overclaim, wording closer to &#34;prevention never confirmed; this machine may have slept&#34; would match the actual state. Product wording, so this is the author&#39;s call.
- ℹ️ `src/core/sleep.ts:323` - The stdout readiness buffer is capped with HELPER_STDERR_TAIL_LIMIT, which is the stderr diagnostic tail budget, not a marker-matching window. No behavioral impact (the marker is 16 chars), but the shared constant makes the two independent buffers look coupled; a dedicated constant sized to the marker, or reusing readiness.marker.length, would read more clearly.
- ℹ️ `src/core/sleep.ts:658` - On Windows, `sleep:active` is now logged unconditionally right after spawn because the readiness path skips waitForHelperStability, so a helper that fails instantly emits both `sleep:active` and a later `sleep:unavailable` in gnhf.log. The exit summary stays correct, but the debug log&#39;s `sleep:active` event no longer means &#34;prevention is holding&#34; on win32 the way it still does on darwin. Worth keeping in mind when reading logs; noting rather than requesting a change since the pairing is unambiguous in a JSONL trace.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` then `npx tsdown` to build `dist/cli.mjs` (node_modules was empty in this worktree)</code>
- <code>`npx vitest run src/core/sleep.windows.test.ts src/core/sleep.test.ts src/core/exit-summary.test.ts src/cli.test.ts` - the four suites touched by the change</code>
- <code>Fail-before/pass-after: temporarily reverted only the two flag literals in `src/core/sleep.ts` to `$ES_CONTINUOUS = 0x80000000` / `$ES_SYSTEM_REQUIRED = 0x00000001`, re-ran `npx vitest run src/core/sleep.windows.test.ts` (both cases fail with the PowerShell UInt32 conversion error), then restored the file and re-ran (both pass); `git status --porcelain` clean afterwards</code>
- <code>Manual OS-level probe: spawned the pre-fix and post-fix helper command lines through real `powershell.exe`, appending `SetThreadExecutionState($ES_CONTINUOUS)` to read back the previous execution state (pre-fix `0x00000000`, post-fix `0x80000001`)</code>
- <code>Manual e2e: `node dist/cli.mjs &#34;ship it&#34; --agent opencode --max-iterations 12 --prevent-sleep on` in three throwaway git repos - normal PATH, PATH with every `powershell.exe` directory removed, and PATH fronted by a stand-in `powershell.exe` that starts but never reports ready - capturing stdout and the `sleep:*` entries from `.gnhf/runs/&lt;id&gt;/gnhf.log`</code>
- <code>Screenshots of the same three runs in real Windows console windows (stdin from `NUL` so the TUI hands off to the permanent exit summary) via `Start-Process cmd` plus `GetWindowRect` + `Graphics.CopyFromScreen`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Closes #206 
