### PR TITLE
ci: migrate no-mistakes enforcement to shared action

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -4,12 +4,14 @@ run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ git
 on:
   pull_request:
     # The verdict is a pure function of pull_request.body, so a push carries no
-    # new body to judge but does move the head SHA. The pipeline pushes before
-    # it writes the deterministic Pipeline section, so a synchronize trigger
-    # pinned a FAILURE check run to the new head for a body the same run was
-    # about to fix. GitHub keeps that failure next to the later edited SUCCESS,
-    # and gh pr checks collapses same-named check runs by startedAt alone, so the
-    # CI monitor could park the run red forever (PR #773).
+    # new body to judge but does move the head SHA. This repository has no
+    # required status check that needs a run on every head SHA; keep synchronize
+    # excluded only while that remains true. The pipeline pushes before it
+    # writes the deterministic Pipeline section, so a synchronize trigger pinned
+    # a FAILURE check run to the new head for a body the same run was about to
+    # fix. GitHub keeps that failure next to the later edited SUCCESS, and gh pr
+    # checks collapses same-named check runs by startedAt alone, so the CI monitor
+    # could park the run red forever (kunchenguid/no-mistakes#773).
     types: [opened, edited, reopened]
     branches:
       - main
@@ -53,4 +55,4 @@ jobs:
       # pull request this gate is judging. Bumping the pin is a separate,
       # deliberate pull request.
       - name: Verify no-mistakes signature and pipeline attestation in PR body
-        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in kunchenguid/no-mistakes#819)

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -3,7 +3,14 @@ run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ git
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    # The verdict is a pure function of pull_request.body, so a push carries no
+    # new body to judge but does move the head SHA. The pipeline pushes before
+    # it writes the deterministic Pipeline section, so a synchronize trigger
+    # pinned a FAILURE check run to the new head for a body the same run was
+    # about to fix. GitHub keeps that failure next to the later edited SUCCESS,
+    # and gh pr checks collapses same-named check runs by startedAt alone, so the
+    # CI monitor could park the run red forever (PR #773).
+    types: [opened, edited, reopened]
     branches:
       - main
     # Never create a run for a release-please PR. The job-level author exemption
@@ -20,7 +27,7 @@ permissions:
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
 # an immutable per-event group so first-time-fork approvals can never collapse
-# opened/edited checks. Keep synchronize/reopened coalescing as before.
+# opened/edited checks. Keep reopened coalescing as before.
 concurrency:
   group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
@@ -38,133 +45,12 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -eu
-          marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            {
-              echo "::error::This PR was not raised through no-mistakes."
-              echo
-              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-              echo "deterministic '## Pipeline' section into the PR body containing:"
-              echo
-              echo "    $marker"
-              echo
-              echo "See CONTRIBUTING.md for setup and the full workflow."
-              echo
-              echo "PR author: ${PR_AUTHOR}"
-            } >&2
-            exit 1
-          fi
-          echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          PREFIX = "<!-- no-mistakes-pipeline-attestation:v1"
-          REQUIRED_STEPS = ("review", "test", "document")
-          VERSION_FLOOR = (
-              "This repository requires no-mistakes >= 1.46.0 "
-              "(https://github.com/kunchenguid/no-mistakes/pull/670)."
-          )
-
-
-          def fail(annotation, details):
-              print(f"::error::{annotation}", file=sys.stderr)
-              print(file=sys.stderr)
-              for line in details:
-                  print(line, file=sys.stderr)
-              sys.exit(1)
-
-
-          def fail_attestation(reason):
-              fail(
-                  VERSION_FLOOR
-                  + " The PR body is missing a parseable pipeline step attestation.",
-                  [
-                      VERSION_FLOOR,
-                      reason,
-                      "An older no-mistakes that only writes the signature line is not enough.",
-                      "Upgrade and re-submit via 'git push no-mistakes'. See CONTRIBUTING.md.",
-                  ],
-              )
-
-
-          body = os.environ.get("PR_BODY") or ""
-          idx = body.find(PREFIX)
-          if idx < 0:
-              fail_attestation(
-                  "The PR body has the no-mistakes signature but no "
-                  "'<!-- no-mistakes-pipeline-attestation:v1 ... -->' comment."
-              )
-
-          rest = body[idx + len(PREFIX) :].lstrip()
-          end = rest.find("-->")
-          if end < 0:
-              fail_attestation(
-                  "The attestation comment is present but was not closed with '-->'."
-              )
-
-          try:
-              data = json.loads(rest[:end].strip())
-          except json.JSONDecodeError:
-              fail_attestation(
-                  "The attestation comment is present but its JSON payload is not parseable."
-              )
-
-          if not isinstance(data, dict):
-              fail_attestation(
-                  "The attestation JSON must be an object with 'head_sha' and 'steps'."
-              )
-
-          head_sha = data.get("head_sha")
-          steps = data.get("steps")
-          if not isinstance(head_sha, str) or not head_sha.strip():
-              fail_attestation(
-                  "The attestation JSON is missing a non-empty 'head_sha' string."
-              )
-          if not isinstance(steps, list):
-              fail_attestation("The attestation JSON is missing a 'steps' array.")
-
-          by_name = {}
-          for item in steps:
-              if not isinstance(item, dict):
-                  continue
-              name = item.get("step")
-              if not isinstance(name, str) or not name:
-                  continue
-              status = item.get("status")
-              if not isinstance(status, str) or not status:
-                  status = "missing"
-              by_name[name] = status
-
-          incomplete = []
-          for name in REQUIRED_STEPS:
-              status = by_name.get(name, "missing")
-              if status != "completed":
-                  incomplete.append(f"{name}={status}")
-
-          if incomplete:
-              listed = ", ".join(incomplete)
-              fail(
-                  f"Required no-mistakes steps are not completed: {listed}.",
-                  [
-                      f"Required pipeline steps are not completed: {listed}.",
-                      "review, test, and document must each have status=completed.",
-                      "skipped, failed, pending, running, or missing steps fail this check.",
-                      "Quota skips and agent skips are non-compliant.",
-                      "Re-run via 'git push no-mistakes' without skipping those steps. See CONTRIBUTING.md.",
-                  ],
-              )
-
-          print(
-              "Found parseable pipeline attestation with review, test, and document completed."
-          )
-          PY
+      # The enforcement itself now lives in the shared composite action in the
+      # no-mistakes repository, so this repository no longer carries its own
+      # copy of the script to drift.
+      #
+      # Pinned to an immutable commit, never @main: main is editable by the very
+      # pull request this gate is judging. Bumping the pin is a separate,
+      # deliberate pull request.
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We require this to reduce the maintainer's burden of reviewing and merging contr
 
 `no-mistakes` puts a local git proxy in front of your real remote. Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
-A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes. The release and dependency bots are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+The GitHub Actions check `PR must be raised via no-mistakes` validates the deterministic signature and completed pipeline attestation that no-mistakes writes to PRs targeting `main`. Release and dependency bots are exempt so their automation keeps working, but regular contributor PRs without valid no-mistakes output will not be reviewed or merged.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -203,19 +203,19 @@ If you run `gnhf` on an existing `gnhf/` branch with a different prompt, gnhf as
 
 ### Flags
 
-| Flag                     | Description                                                                                        | Default                |
-| ------------------------ | -------------------------------------------------------------------------------------------------- | ---------------------- |
-| `--agent <agent>`        | Agent to use: a native agent name or `acp:<target-or-command>`; see [Agents](#agents)              | config file (`claude`) |
-| `--max-iterations <n>`   | Abort after `n` total iterations                                                                   | unlimited              |
-| `--max-tokens <n>`       | Abort after `n` total input+output tokens                                                          | unlimited              |
-| `--max-rate-limit-wait <duration>` | Abort after this much total Claude usage-limit wait (`30m`, `2h`, or `0`)                     | 24h safety cap          |
-| `--stop-when <cond>`     | End when the agent reports this condition, after any commit-failure repair; persists across resume | unlimited              |
-| `--prevent-sleep <mode>` | Prevent system sleep during the run (`on`/`off` or `true`/`false`)                                 | config file (`on`)     |
-| `--worktree`             | Run in a separate git worktree (enables multiple agents concurrently)                              | `false`                |
-| `--current-branch`       | Run on the current branch instead of creating a `gnhf/` branch                                     | `false`                |
-| `--push`                 | Push the current branch after each successful iteration                                            | `false`                |
-| `--meteor-frequency <n>` | Set TUI meteor frequency from 0 to 5 (`0` disables meteors)                                        | `3`                    |
-| `--version`              | Show version                                                                                       |                        |
+| Flag                               | Description                                                                                        | Default                |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------- |
+| `--agent <agent>`                  | Agent to use: a native agent name or `acp:<target-or-command>`; see [Agents](#agents)              | config file (`claude`) |
+| `--max-iterations <n>`             | Abort after `n` total iterations                                                                   | unlimited              |
+| `--max-tokens <n>`                 | Abort after `n` total input+output tokens                                                          | unlimited              |
+| `--max-rate-limit-wait <duration>` | Abort after this much total Claude usage-limit wait (`30m`, `2h`, or `0`)                          | 24h safety cap         |
+| `--stop-when <cond>`               | End when the agent reports this condition, after any commit-failure repair; persists across resume | unlimited              |
+| `--prevent-sleep <mode>`           | Prevent system sleep during the run (`on`/`off` or `true`/`false`)                                 | config file (`on`)     |
+| `--worktree`                       | Run in a separate git worktree (enables multiple agents concurrently)                              | `false`                |
+| `--current-branch`                 | Run on the current branch instead of creating a `gnhf/` branch                                     | `false`                |
+| `--push`                           | Push the current branch after each successful iteration                                            | `false`                |
+| `--meteor-frequency <n>`           | Set TUI meteor frequency from 0 to 5 (`0` disables meteors)                                        | `3`                    |
+| `--version`                        | Show version                                                                                       |                        |
 
 ## Configuration
 
@@ -352,7 +352,7 @@ Set `GNHF_TELEMETRY=0` to turn it off.
 
 ## Development
 
-If you want to contribute changes back to this repo, see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the workflow, the dev commands, and repo conventions. Human-authored PRs targeting `main` must be opened via `git push no-mistakes` so the required `Require no-mistakes` check passes.
+If you want to contribute changes back to this repo, see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the required workflow, dev commands, and repo conventions.
 
 ## Star History
 


### PR DESCRIPTION
## Intent

Migrate this repository from its DUPLICATED inline no-mistakes PR-enforcement workflow to the SHARED composite action require-no-mistakes that lives in the no-mistakes repository. This is part of an approved fleet-wide migration: 22 kunchenguid repositories each carried their own copy of the 'PR must be raised via no-mistakes' gate, in four implementation families that had already drifted apart. no-mistakes itself migrated first (no-mistakes#821, merged) and rough-cut-axi was the validated pilot consumer (rough-cut-axi#4).

Goal: replace the inline enforcement script in .github/workflows/no-mistakes-required.yml with a thin caller of kunchenguid/no-mistakes/.github/actions/require-no-mistakes.

Constraints that were explicitly required, and that a reviewer reading only the diff would not know:

1. SURGICAL SCOPE. The only change is swapping the inline enforcement for the thin caller while preserving exemptions. Do not alter unrelated CI, do not touch other workflows.

2. PIN. The action is pinned to the immutable commit SHA 32d396ac0f29135daf7fcb9964aba9d5f4e796d6, never @main, and deliberately a SHA rather than a moving tag for supply-chain safety, because main is editable by the very pull request the gate is judging. Verified facts: that commit is contained in NO release tag, the latest published no-mistakes release is v1.57.1, and 1.58.0 is unreleased - so the trailing comment says 'post-v1.57.1, untagged' and must NOT claim the action ships in any released version.

3. JOB NAME UNCHANGED. The job name must stay exactly 'PR must be raised via no-mistakes' so any branch ruleset keeps matching the same required check.

4. EXEMPTIONS PRESERVED EXACTLY. A dropped exemption that starts blocking release-please or bots is a regression. The exemptions were deliberately KEPT in the job-level 'if:' rather than moved to the action's exempt-authors input. That is considered, not an oversight: an in-job exemption is evaluated inside a run, and a GITHUB_TOKEN pull request's run is created in action_required and never starts, so only a job-level condition reliably exempts those authors, and it also preserves the exact verdict shape (a skipped job rather than a passing one).

5. EVERYTHING ELSE PRESERVED BYTE-FOR-BYTE, verified by diffing every line above the steps: block against the previous file: the workflow name, run-name template, branches filter, any paths-ignore filter, permissions contents: read, the concurrency group expression and cancel-in-progress, and the read-only fork boundary (pull_request, never pull_request_target, no checkout, no secrets).

6. LAST-WINS IS INTENDED. The shared action's verifier treats duplicate step records as last-wins and does not inspect skip-shaped sibling fields. Some inline gates elsewhere in the fleet were stricter. The repository owner ruled explicitly that the stricter behavior is over-strict, is NOT a standard to preserve, and that relaxing to last-wins on migration is the intended outcome. Do not raise this as a regression and do not propose hardening the shared action.

7. TRIGGER. synchronize is dropped from on.pull_request.types so the trigger set matches the no-mistakes repository's own post-#773 configuration: types [opened, edited, reopened]. Binding plus synchronize pins a stale FAILURE check run to a head the pipeline is about to fix, GitHub keeps that failure next to the later edited SUCCESS, and gh pr checks collapses same-named check runs by startedAt alone, so the CI monitor can park the run red forever. This was verified safe for this repository specifically: its ruleset carries an empty required_status_checks list and it has no legacy branch protection, so no head SHA needs a run of its own - the same precondition stated in no-mistakes' own workflow comment.

## What Changed

- Replace the inline PR attestation verifier with the shared `require-no-mistakes` action pinned to an immutable commit while preserving job-level bot exemptions.
- Remove the `synchronize` trigger to avoid stale failure runs while retaining opened, edited, and reopened checks.
- Update contributor documentation to describe the required check and its signature and pipeline-attestation validation.

## Risk Assessment

✅ Low: The change is narrowly scoped, matches the authoritative migration constraints, and the pinned shared action preserves the required enforcement behavior.

## Testing

Targeted validation confirmed the sole changed workflow is accepted by GitHub Actions tooling, preserves its required check and job-level exemptions, drops only the synchronize trigger, securely calls the immutable shared-action pin, accepts compliant and intended last-wins attestations, and rejects stale or unsigned PR bodies; the worktree remained clean.

<details>
<summary>Evidence: Workflow semantics and pinned shared-action behavior transcript</summary>

Source: [Workflow semantics and pinned shared-action behavior transcript](https://github.com/kunchenguid/gnhf/blob/fa468a0660a7805f3ca1eb6b73cf0e47a1d88a32/.no-mistakes/evidence/fm/nm-shared-action-migration-r1/no-mistakes-migration-transcript.txt)

```text
=== Workflow consumer validation ===
actionlint: valid GitHub Actions workflow
trigger: pull_request opened, edited, reopened on main
security boundary: contents=read, no checkout, no secrets, no pull_request_target
required check: PR must be raised via no-mistakes
job exemption expression preserved: github.event.pull_request.user.login != 'github-actions[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'release-please[bot]'
shared action: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6
preserved semantics: workflow identity, branch/path filters, permissions, concurrency, runner, and job condition

=== Shared action behavior at pinned SHA ===
[compliant] exit=0
Found no-mistakes signature in PR #42 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.
exempt=false compliant=true 
[last-wins] exit=0
Found no-mistakes signature in PR #42 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.
exempt=false compliant=true 
[stale] exit=1
::error::Pipeline attestation head_sha does not match the current PR head.
Found no-mistakes signature in PR #42 body.
exempt=false compliant=false exempt=false 
[unsigned] exit=1
::error::This PR was not raised through no-mistakes.
exempt=false compliant=false exempt=false 
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee54c145828f2718587768eae446e746441a0874","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `actionlint .github/workflows/no-mistakes-required.yml`
- `Parsed the base and target workflow YAML into normalized models and verified preserved workflow identity, filters, permissions, concurrency, runner, job name, and exact job-level exemption condition.`
- <code>Verified the target uses one thin caller step pinned to `kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6`, without checkout, secrets, inputs, or inline execution.</code>
- `Executed the pinned shared verifier against realistic pull-request event payloads for compliant, duplicate last-wins, stale-head, and unsigned cases.`
- <code>`git diff --name-only 4e68f98308497e61a0eeaa531e542d4420813e8b..30c2946e190cba7b8d2876a5cd45b1796708b0f3` and `git diff --check 4e68f98308497e61a0eeaa531e542d4420813e8b..30c2946e190cba7b8d2876a5cd45b1796708b0f3`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
