### PR TITLE
fix(core): honor pending token abort before success

### DIFF
--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -533,6 +533,48 @@ describe("Orchestrator stop limits", () => {
     });
   });
 
+  it("does not commit when an agent resolves after triggering the token cap", async () => {
+    const agent: Agent = {
+      name: "opencode",
+      run: vi.fn(async (_prompt, _cwd, options) => {
+        options?.onUsage?.({
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 1,
+          cacheCreationTokens: 0,
+        });
+        return createSuccessResult("should not commit");
+      }),
+    };
+    const orchestrator = new Orchestrator(
+      config,
+      agent,
+      runInfo,
+      "ship it",
+      "/repo",
+      0,
+      { maxTokens: 15 },
+    );
+
+    const abort = vi.fn();
+    orchestrator.on("abort", abort);
+
+    await orchestrator.start();
+
+    expect(agent.run).toHaveBeenCalledTimes(1);
+    expect(mockAppendNotes).not.toHaveBeenCalled();
+    expect(mockCommitAll).not.toHaveBeenCalled();
+    expect(mockResetHard).toHaveBeenCalledWith("/repo");
+    expect(abort).toHaveBeenCalledWith("max tokens reached (16/15)");
+    expect(orchestrator.getState()).toMatchObject({
+      status: "aborted",
+      totalInputTokens: 10,
+      totalOutputTokens: 5,
+      totalCacheReadTokens: 1,
+      totalCacheCreationTokens: 0,
+    });
+  });
+
   it("counts cache read and cache creation tokens against the token budget", async () => {
     // #212: an opencode/claude-sonnet run billed ~41M tokens against a 1M cap
     // because cache_read and cache_write carried the traffic and neither was

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -534,18 +534,17 @@ describe("Orchestrator stop limits", () => {
   });
 
   it("does not commit when an agent resolves after triggering the token cap", async () => {
-    let abortSignalObserved = false;
     const agent: Agent = {
       name: "opencode",
-      run: vi.fn(async (_prompt, _cwd, options) => {
+      run: vi.fn((_prompt, _cwd, options) => {
         options?.onUsage?.({
           inputTokens: 10,
           outputTokens: 5,
           cacheReadTokens: 1,
           cacheCreationTokens: 0,
         });
-        abortSignalObserved = options?.signal?.aborted === true;
-        return createSuccessResult("should not commit");
+        expect(options?.signal?.aborted).toBe(true);
+        return Promise.resolve(createSuccessResult("should not commit"));
       }),
     };
     const orchestrator = new Orchestrator(
@@ -564,7 +563,6 @@ describe("Orchestrator stop limits", () => {
     await orchestrator.start();
 
     expect(agent.run).toHaveBeenCalledTimes(1);
-    expect(abortSignalObserved).toBe(true);
     expect(mockAppendNotes).not.toHaveBeenCalled();
     expect(mockCommitAll).not.toHaveBeenCalled();
     expect(mockResetHard).toHaveBeenCalledWith("/repo");

--- a/src/core/orchestrator.test.ts
+++ b/src/core/orchestrator.test.ts
@@ -534,6 +534,7 @@ describe("Orchestrator stop limits", () => {
   });
 
   it("does not commit when an agent resolves after triggering the token cap", async () => {
+    let abortSignalObserved = false;
     const agent: Agent = {
       name: "opencode",
       run: vi.fn(async (_prompt, _cwd, options) => {
@@ -543,6 +544,7 @@ describe("Orchestrator stop limits", () => {
           cacheReadTokens: 1,
           cacheCreationTokens: 0,
         });
+        abortSignalObserved = options?.signal?.aborted === true;
         return createSuccessResult("should not commit");
       }),
     };
@@ -562,6 +564,7 @@ describe("Orchestrator stop limits", () => {
     await orchestrator.start();
 
     expect(agent.run).toHaveBeenCalledTimes(1);
+    expect(abortSignalObserved).toBe(true);
     expect(mockAppendNotes).not.toHaveBeenCalled();
     expect(mockCommitAll).not.toHaveBeenCalled();
     expect(mockResetHard).toHaveBeenCalledWith("/repo");

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -576,6 +576,18 @@ export class Orchestrator extends EventEmitter<OrchestratorEvents> {
       this.activeIterationTokensEstimated = false;
       if (result.usage.estimated) this.state.tokensEstimated = true;
 
+      if (this.pendingAbortReason) {
+        appendDebugLog("agent:run:aborted", {
+          iteration: this.state.currentIteration,
+          elapsedMs: Date.now() - agentStartedAt,
+          reason: this.pendingAbortReason,
+        });
+        if (this.pendingCommitFailure === null) {
+          resetHard(this.cwd);
+        }
+        return { type: "aborted", reason: this.pendingAbortReason };
+      }
+
       appendDebugLog("agent:run:end", {
         iteration: this.state.currentIteration,
         elapsedMs: Date.now() - agentStartedAt,


### PR DESCRIPTION
## Intent

Fix GNHF issue #216 and close it from the pull request. Once --max-tokens has set pendingAbortReason, that token abort must take precedence even if the agent resolves successfully instead of rejecting on the abort signal. The over-budget iteration must be rolled back with no commit and no iteration notes, while retaining the existing reject-on-abort behavior, cache accounting, pending commit-failure preservation, and all unrelated token-limit semantics. Add a behavioral orchestrator regression where a synchronous fake OpenCode agent reports input=10, output=5, cache-read=1 under maxTokens=15 and then returns success; require a 16/15 abort, no commit, no notes, resetHard, and the reported token totals. Keep the implementation limited to the orchestrator and its test, with no adapter, public API, documentation, changelog, release, or unrelated test-harness changes. Keep the public PR title and body focused strictly on the bug, deterministic reproduction, implementation, and tests; include the repository-required pipeline attestation without extra tooling or provenance commentary.

## What Changed

- Fixes #216 by making a pending `--max-tokens` abort take precedence when an agent returns success after exceeding the budget.
- Rolls back the over-budget iteration before it can create a commit or append iteration notes, while preserving pending commit-failure work.
- Adds an orchestrator regression test covering the deterministic 16/15 cache-inclusive token abort and reported totals.

## Risk Assessment

✅ Low: The change narrowly enforces the pending token-abort invariant before success recording, preserves rollback and pending commit-failure behavior, and adds the required behavioral regression without unrelated changes.

## Testing

Focused orchestrator regressions exercised synchronous-success precedence, reject-on-abort behavior, cache accounting, accumulated usage, and pending commit-failure preservation. A real-git probe demonstrated the 16/15 abort, retained token totals, tracked-file rollback, zero commits, unchanged notes, and zero recorded iterations. The initial probe setup omitted GNHF's run-directory exclusion; after correcting that fixture mismatch, it passed. No UI screenshot was applicable because this is a non-visual orchestrator race fix.

<details>
<summary>Evidence: Real-git pending token-abort behavior transcript</summary>

Source: [Real-git pending token-abort behavior transcript](https://github.com/fanrenaz/gnhf/blob/347cc7512bf3651b74650f2859a254eba64b700a/.no-mistakes/evidence/fix/pending-token-abort/pending-token-abort-behavior.txt)

```text
(node:28968) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.2 C:/Users/Ren Yifan/.no-mistakes/worktrees/c8bd7ed54fb5/01M18SXQ2XAYD93K37CDNXZJ0C

(node:1336) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
warning: in the working copy of 'tracked.txt', LF will be replaced by CRLF the next time Git touches it
stdout | manual-token-abort-evidence.test.ts > records real rollback evidence for synchronous success after token abort
BEHAVIOR_EVIDENCE {
  "agentOutcome": "resolved success after synchronous usage update",
  "abortReason": "max tokens reached (16/15)",
  "status": "aborted",
  "tokenTotals": {
    "input": 10,
    "output": 5,
    "cacheRead": 1,
    "cacheCreation": 0,
    "budgetTotal": 16,
    "maxTokens": 15
  },
  "commitCountAfterBase": 0,
  "trackedFileAfterRun": "before",
  "notesAfterRun": "# Iteration Notes\n\n",
  "recordedIterations": 0
}

 ✓ manual-token-abort-evidence.test.ts > records real rollback evidence for synchronous success after token abort 1398ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  15:46:53
   Duration  2.12s (transform 267ms, setup 0ms, import 345ms, tests 1.44s, environment 0ms)

```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dbdc1f573a308964682a63122b489e4528636b28","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 49982a9cbc56473177b99c98d0b6b880f47af6f3 dbdc1f573a308964682a63122b489e4528636b28 -- src/core/orchestrator.ts src/core/orchestrator.test.ts` for required scope.</code>
- <code>Ran `pnpm exec vitest run src/core/orchestrator.test.ts -t &#34;does not commit when an agent resolves after triggering the token cap&#34; --reporter=verbose`.</code>
- <code>Ran `pnpm exec vitest run src/core/orchestrator.test.ts -t &#34;aborts when reported token usage reaches the configured cap|does not commit when an agent resolves after triggering the token cap|counts cache read and cache creation tokens against the token budget|accumulates cache tokens across iterations rather than overwriting them|preserves pending commit failure changes when repair hits token limit&#34; --reporter=verbose`.</code>
- <code>Ran a temporary real-git Vitest probe with a synchronous fake OpenCode agent, captured the behavioral transcript, then removed the probe and generated `node_modules`.</code>
- `Verified the worktree is clean after testing and the evidence transcript remains in the dedicated evidence directory.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
