### PR TITLE
fix(agents): recover empty OpenCode responses once

### DIFF
--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -1029,6 +1029,32 @@ describe("OpenCodeAgent", () => {
     ]);
   });
 
+  it("does not continue a session whose event stream closes before idle", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ healthy: true, version: "1.3.13" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          'data: {"directory":"/repo","payload":{"type":"message.updated","properties":{"sessionID":"session-123","info":{"id":"incomplete-1","role":"assistant"}}}}\n\n',
+        ),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(jsonResponse(true));
+
+    await expect(agent.run("test", "/repo")).rejects.toThrow(
+      "OpenCode produced no final answer",
+    );
+    expect(
+      fetchMock.mock.calls.filter(
+        ([url]) =>
+          url === "http://127.0.0.1:8765/session/session-123/prompt_async",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("continues instead of parsing reasoning-phase text as a final answer", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -968,7 +968,7 @@ describe("OpenCodeAgent", () => {
     });
   });
 
-  it("rejects with 'OpenCode produced no final answer' when the stream ends with no structured output and no final_answer text", async () => {
+  it("continues the same session once when the first turn has no final answer", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
@@ -977,26 +977,59 @@ describe("OpenCodeAgent", () => {
       .mockResolvedValueOnce(jsonResponse({ id: "session-123" }))
       .mockResolvedValueOnce(
         sseResponse([
-          'data: {"directory":"/repo","payload":{"type":"message.part.updated","properties":{"sessionID":"session-123","part":{"id":"finish-1","type":"step-finish","tokens":{"input":1,"output":1,"cache":{"read":0,"write":0}}}}}}\n\n',
+          'data: {"directory":"/repo","payload":{"type":"message.updated","properties":{"sessionID":"session-123","info":{"id":"empty-1","role":"assistant","tokens":{"input":2,"output":1,"cache":{"read":0,"write":0}}}}}}\n\n',
           'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
         ]),
       )
+      .mockResolvedValueOnce(promptAsyncResponse())
       .mockResolvedValueOnce(
-        jsonResponse({
-          info: {
-            tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
-          },
-          parts: [{ type: "step-start" }],
+        sseResponse(
+          finalAnswerEvents("recovered", {
+            input: 3,
+            output: 4,
+            read: 5,
+            write: 6,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        finalMessageResponse("recovered", {
+          input: 3,
+          output: 4,
+          read: 5,
+          write: 6,
         }),
       )
       .mockResolvedValueOnce(jsonResponse(true));
 
-    await expect(agent.run("test", "/repo")).rejects.toThrow(
-      "OpenCode produced no final answer",
+    const result = await agent.run("test", "/repo");
+
+    expect(result).toMatchObject({
+      output: { summary: "recovered" },
+      usage: {
+        inputTokens: 5,
+        outputTokens: 5,
+        cacheReadTokens: 5,
+        cacheCreationTokens: 6,
+      },
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      6,
+      "http://127.0.0.1:8765/session/session-123/prompt_async",
+      expect.objectContaining({ method: "POST" }),
     );
+    const continuationBody = JSON.parse(
+      String(fetchMock.mock.calls[5]?.[1]?.body ?? ""),
+    );
+    expect(continuationBody.parts).toEqual([
+      {
+        type: "text",
+        text: "You did not produce a final answer. Continue and provide your final summary now.",
+      },
+    ]);
   });
 
-  it("does not fall back to reasoning-phase text when no final_answer text was emitted", async () => {
+  it("continues instead of parsing reasoning-phase text as a final answer", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
@@ -1010,14 +1043,32 @@ describe("OpenCodeAgent", () => {
         ]),
       )
       .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(
+        sseResponse(
+          finalAnswerEvents("recovered after reasoning", {
+            input: 1,
+            output: 1,
+            read: 0,
+            write: 0,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        finalMessageResponse("recovered after reasoning", {
+          input: 1,
+          output: 1,
+          read: 0,
+          write: 0,
+        }),
+      )
       .mockResolvedValueOnce(jsonResponse(true));
 
-    await expect(agent.run("test", "/repo")).rejects.toThrow(
-      "OpenCode produced no final answer",
-    );
+    await expect(agent.run("test", "/repo")).resolves.toMatchObject({
+      output: { summary: "recovered after reasoning" },
+    });
   });
 
-  it("does not fall back to echoed user-prompt text when no final_answer text was emitted", async () => {
+  it("fails after one continuation when echoed user text remains the only output", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
@@ -1034,11 +1085,18 @@ describe("OpenCodeAgent", () => {
         ]),
       )
       .mockResolvedValueOnce(promptAsyncResponse())
+      .mockResolvedValueOnce(
+        sseResponse(
+          'data: {"directory":"/repo","payload":{"type":"session.idle","properties":{"sessionID":"session-123"}}}\n\n',
+        ),
+      )
+      .mockResolvedValueOnce(promptAsyncResponse())
       .mockResolvedValueOnce(jsonResponse(true));
 
     await expect(agent.run("test", "/repo")).rejects.toThrow(
       "OpenCode produced no final answer",
     );
+    expect(fetchMock).toHaveBeenCalledTimes(7);
   });
 
   it("prefers structured output from message.updated over final_answer text", async () => {

--- a/src/core/agents/opencode.test.ts
+++ b/src/core/agents/opencode.test.ts
@@ -1002,7 +1002,8 @@ describe("OpenCodeAgent", () => {
       )
       .mockResolvedValueOnce(jsonResponse(true));
 
-    const result = await agent.run("test", "/repo");
+    const onUsage = vi.fn();
+    const result = await agent.run("test", "/repo", { onUsage });
 
     expect(result).toMatchObject({
       output: { summary: "recovered" },
@@ -1013,6 +1014,8 @@ describe("OpenCodeAgent", () => {
         cacheCreationTokens: 6,
       },
     });
+    expect(onUsage).toHaveBeenCalledTimes(2);
+    expect(onUsage).toHaveBeenNthCalledWith(2, result.usage);
     expect(fetchMock).toHaveBeenNthCalledWith(
       6,
       "http://127.0.0.1:8765/session/session-123/prompt_async",

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -318,6 +318,28 @@ function toUsage(tokens?: OpenCodeTokens): TokenUsage {
   };
 }
 
+class EmptyAgentResponseError extends Error {
+  constructor(usage: TokenUsage) {
+    super("OpenCode produced no final answer");
+    this.name = "EmptyAgentResponseError";
+    this.usage = usage;
+  }
+
+  usage: TokenUsage;
+}
+
+function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheReadTokens: a.cacheReadTokens + b.cacheReadTokens,
+    cacheCreationTokens: a.cacheCreationTokens + b.cacheCreationTokens,
+  };
+}
+
+const EMPTY_RESPONSE_CONTINUATION_PROMPT =
+  "You did not produce a final answer. Continue and provide your final summary now.";
+
 function withTimeoutSignal(
   signal: AbortSignal | undefined,
   timeoutMs: number | undefined,
@@ -388,15 +410,42 @@ export class OpenCodeAgent implements Agent {
     try {
       const server = await this.ensureServer(cwd, runController.signal);
       sessionId = await this.createSession(server, cwd, runController.signal);
-      const result = await this.streamMessage(
-        server,
-        sessionId,
-        buildPrompt(prompt, this.schema),
-        runController.signal,
-        logStream,
-        onUsage,
-        onMessage,
-      );
+      let result: AgentResult;
+      try {
+        result = await this.streamMessage(
+          server,
+          sessionId,
+          buildPrompt(prompt, this.schema),
+          runController.signal,
+          logStream,
+          onUsage,
+          onMessage,
+        );
+      } catch (error) {
+        if (!(error instanceof EmptyAgentResponseError)) {
+          throw error;
+        }
+
+        appendDebugLog("opencode:output:continuation", {
+          sessionId,
+          attempt: 1,
+          prompt: EMPTY_RESPONSE_CONTINUATION_PROMPT,
+        });
+        const continuation = await this.streamMessage(
+          server,
+          sessionId,
+          EMPTY_RESPONSE_CONTINUATION_PROMPT,
+          runController.signal,
+          logStream,
+          (usage) => onUsage?.(addUsage(error.usage, usage)),
+          onMessage,
+        );
+        result = {
+          output: continuation.output,
+          usage: addUsage(error.usage, continuation.usage),
+        };
+        onUsage?.(result.usage);
+      }
       appendDebugLog("opencode:run:end", {
         sessionId,
         elapsedMs: Date.now() - runStartedAt,
@@ -1101,7 +1150,7 @@ export class OpenCodeAgent implements Agent {
         sessionId,
         hasStructuredOutput: structuredOutputFromSSE !== null,
       });
-      throw new Error("OpenCode produced no final answer");
+      throw new EmptyAgentResponseError(usage);
     }
 
     try {

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -1150,6 +1150,9 @@ export class OpenCodeAgent implements Agent {
         sessionId,
         hasStructuredOutput: structuredOutputFromSSE !== null,
       });
+      if (!sawSessionIdle) {
+        throw new Error("OpenCode produced no final answer");
+      }
       throw new EmptyAgentResponseError(usage);
     }
 

--- a/src/core/agents/opencode.ts
+++ b/src/core/agents/opencode.ts
@@ -444,7 +444,6 @@ export class OpenCodeAgent implements Agent {
           output: continuation.output,
           usage: addUsage(error.usage, continuation.usage),
         };
-        onUsage?.(result.usage);
       }
       appendDebugLog("opencode:run:end", {
         sessionId,


### PR DESCRIPTION
## What Changed

- Continue an OpenCode session once when its completed turn has no structured or final-answer output.
- Keep the existing failure path after a second empty turn and for provider errors or nonempty unparseable output.
- Aggregate usage from the original turn and continuation.

## Why

An empty final answer can discard useful completed work even though the active OpenCode session can still provide the required summary.

Fixes #163

## Testing

- before, on current `main`: `pnpm exec vitest run src/core/agents/opencode.test.ts` - the empty-final recovery case failed with `OpenCode produced no final answer`
- after: `pnpm exec vitest run src/core/agents/opencode.test.ts`
- `pnpm test`
- `pnpm run test:e2e`
