### PR TITLE
docs: explain Antigravity integration through ACP

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ ACP bridge such as the third-party
 `acp:agy` alone would try to start `agy` as an ACP server; changing the command
 name does not convert its print-mode output into ACP.
 
+Before using this setup, review the bridge README's
+[Terms of Service risk](https://github.com/shubzkothekar/antigravity-acp#%EF%B8%8F-terms-of-service-risk)
+notice. The third-party bridge warns that using it with Antigravity OAuth may
+risk account suspension or termination.
+
 The following setup was tested with `antigravity-acp` 1.1.0 on macOS. Install
 [Bun](https://bun.com), install and sign in to `agy`, then verify `agy models`
 works. Install the bridge outside the repository gnhf will work on:
@@ -401,8 +406,7 @@ Choose a model ID listed by `agy models`. gnhf's `--model` and native
 setting of this bridge, forwarded to `agy`.
 
 Here `antigravity` is a local registry name for the ACP bridge, while `agy` is
-the underlying CLI. You can use `agy` as the registry key instead and invoke
-`--agent acp:agy`, provided that key still points to the bridge.
+the underlying CLI.
 
 The bridge runs `agy` with automatic tool approval and reads its local
 conversation databases to stream responses. Review the bridge's documentation

--- a/README.md
+++ b/README.md
@@ -360,6 +360,55 @@ Set `GNHF_TELEMETRY=0` to turn it off.
 | OpenCode           | `--agent opencode`                | Install `opencode` and configure at least one usable model provider first.                                                                                                          | `gnhf` starts a local `opencode serve --hostname 127.0.0.1 --port <port> --print-logs` process automatically, creates a per-run session, and applies a blanket allow rule so tool calls do not block on prompts.                                                                                                                                                                           |
 | ACP target         | `--agent acp:<target-or-command>` | Install and authenticate the target supported by the bundled [`acpx`](https://github.com/openclaw/acpx) registry, such as `acp:gemini`, or pass a quoted custom ACP server command. | `gnhf` runs the target through ACP with a persistent per-run session under `.gnhf/runs/<runId>/acp-sessions`; token usage and `--max-tokens` use ACP `used` deltas when available, with prompt-length plus tool-call estimates as a fallback, and `agentPathOverride` and `agentArgsOverride` do not apply.                                                                                |
 
+### Antigravity through ACP
+
+Antigravity's CLI executable is `agy`. To use it with gnhf, run a separate
+ACP bridge such as the third-party
+[`antigravity-acp`](https://github.com/shubzkothekar/antigravity-acp) server.
+`acp:agy` alone would try to start `agy` as an ACP server; changing the command
+name does not convert its print-mode output into ACP.
+
+The following setup was tested with `antigravity-acp` 1.1.0 on macOS. Install
+[Bun](https://bun.com), install and sign in to `agy`, then verify `agy models`
+works. Install the bridge outside the repository gnhf will work on:
+
+```sh
+git clone --branch v1.1.0 --depth 1 https://github.com/shubzkothekar/antigravity-acp.git
+cd antigravity-acp
+bun install --frozen-lockfile --ignore-scripts
+```
+
+Merge this entry into `acpRegistryOverrides` in `~/.gnhf/config.yml`, replacing
+the example with the absolute path to the bridge checkout:
+
+```yaml
+acpRegistryOverrides:
+  antigravity: 'bun "/absolute/path/to/antigravity-acp/index.ts"'
+```
+
+From the repository you want gnhf to work on, run:
+
+```sh
+AGY_BIN="$(command -v agy)" \
+AGY_EXTRA_ARGS="--model gemini-3.8-flash-medium --effort medium" \
+gnhf --agent acp:antigravity --max-iterations 1 "Your task"
+```
+
+These environment-variable examples use a POSIX shell. `AGY_BIN` makes the
+bridge use your existing CLI installation instead of downloading another copy.
+Choose a model ID listed by `agy models`. gnhf's `--model` and native
+`agentArgsOverride` settings do not apply to ACP targets; `AGY_EXTRA_ARGS` is a
+setting of this bridge, forwarded to `agy`.
+
+Here `antigravity` is a local registry name for the ACP bridge, while `agy` is
+the underlying CLI. You can use `agy` as the registry key instead and invoke
+`--agent acp:agy`, provided that key still points to the bridge.
+
+The bridge runs `agy` with automatic tool approval and reads its local
+conversation databases to stream responses. Review the bridge's documentation
+before use. gnhf token totals can be estimates when the bridge does not provide
+ACP usage updates.
+
 ## Development
 
 If you want to contribute changes back to this repo, see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the required workflow, dev commands, and repo conventions.


### PR DESCRIPTION
Antigravity users can mistake the product name (`antigravity`) or CLI executable (`agy`) for an ACP server. This documents a working external ACP bridge configuration using `antigravity-acp` 1.1.0, including a named registry override, model/effort forwarding, prerequisites, and the bridge's approval and usage-reporting behavior.

The integration uses gnhf's existing ACP path and adds no native adapter or dependency. It follows the extension direction discussed in #188.

Validation:
- Live smoke test on macOS with unmodified gnhf 0.1.49, antigravity-acp 1.1.0, and `AGY_EXTRA_ARGS="--model gemini-3.8-flash-medium --effort medium"`: one successful iteration, `GNHF_ACP_AGY_OK`, stop condition met, no file changes or commits.
- Bridge installation with `bun install --frozen-lockfile --ignore-scripts` succeeded.
- Lint, format check, typecheck, build, and full test suite passed (812 passed, 3 skipped).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1c5fd40f87d66ec904e9aa06d3d8a5283861e181","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":2}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 2 scenarios were driven live against the product); User follows the documented pinned bridge setup and runs gnhf through `acp:antigravity`, producing a successful ACP iteration: The target changes only README text and therefore exposes no new runtime product surface. Repeating the external smoke test live in this test phase would additionally require the third-party antigravity-acp checkout and an authenticated Antigravity `agy` account. Provide those credentials and bridge installation inside an authorized isolated environment to re-drive it.; User tries `acp:agy` without an ACP bridge and gnhf does not treat the print-mode CLI as a working ACP server: This is unchanged runtime behavior outside the README-only patch. A fresh live attempt would require an installed authenticated `agy` CLI and would not validate any modified executable code.
- Live validation: ⚠️ no-surface - 0 of 2 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| User follows the documented pinned bridge setup and runs gnhf through `acp:antigravity`, producing a successful ACP iteration | ⏸️ untested | no | The target changes only README text and therefore exposes no new runtime product surface. Repeating the external smoke test live in this test phase would additionally require the third-party antigravi… |
| User tries `acp:agy` without an ACP bridge and gnhf does not treat the print-mode CLI as a working ACP server | ⏸️ untested | no | This is unchanged runtime behavior outside the README-only patch. A fresh live attempt would require an installed authenticated `agy` CLI and would not validate any modified executable code. |

- <code>`git diff --stat 0227fe415d38e6df0fad4828c7999ba2a3b065de..1c5fd40f87d66ec904e9aa06d3d8a5283861e181` and `git diff --unified=80 ... -- README.md`</code>
- <code>Targeted Node check of README&#39;s public documentation contract: README-only scope, pinned antigravity-acp 1.1.0 install, single `antigravity` registry entry, exact `acp:antigravity` invocation, naming explanation, and pre-setup risk notice</code>
- <code>Reviewed and preserved the prior `acp:antigravity` registry-override CLI transcript and adversarial direct `acp:agy` transcript</code>
- <code>Reviewed and preserved the caller-provided real antigravity-acp 1.1.0 to authenticated `agy` smoke-test transcript</code>
- <code>`git status --short` after evidence collection</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
